### PR TITLE
Fix: ScalaPactContractWriter creates directories 'target' and 'pacts'…

### DIFF
--- a/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactContractWriter.scala
+++ b/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactContractWriter.scala
@@ -19,7 +19,7 @@ object ScalaPactContractWriter {
     val dirFile = new File(dirPath)
 
     if (!dirFile.exists()) {
-      dirFile.mkdir()
+      dirFile.mkdirs()
     }
 
     val string = simplifyName(pactDescription.consumer + pactDescription.provider + pactDescription.interactions.map(_.description).mkString + System.currentTimeMillis())


### PR DESCRIPTION
… if they don't exist
I use gradle and IntelliJ. The first time I used your project to create a pact I got a "java.io.IOException: No such file or directory" from the ScalaPactContractWriter.
I am not familiar with sbt, but I assume that sbt uses a "target" directory for its builds, not "build", like gradle. So there was no "target" directory in my project directory.
https://docs.oracle.com/javase/7/docs/api/java/io/File.html#mkdirs() should create all missing directories...