### PR TITLE
Flaky test fixing

### DIFF
--- a/scalapact-core/src/main/scala/com/itv/scalapactcore/stubber/InteractionManager.scala
+++ b/scalapact-core/src/main/scala/com/itv/scalapactcore/stubber/InteractionManager.scala
@@ -4,10 +4,7 @@ import com.itv.scalapactcore.common.ColourOuput._
 import com.itv.scalapactcore.common.{Arguments, ConfigAndPacts}
 import com.itv.scalapactcore.{Interaction, InteractionRequest}
 
-object InteractionManager extends InteractionManager
-
-//Use trait for testing or you'll have race conditions!
-trait InteractionManager {
+class InteractionManager {
 
   import com.itv.scalapactcore.common.matching.InteractionMatchers._
 

--- a/scalapact-core/src/main/scala/com/itv/scalapactcore/stubber/PactStubService.scala
+++ b/scalapact-core/src/main/scala/com/itv/scalapactcore/stubber/PactStubService.scala
@@ -1,69 +1,79 @@
 package com.itv.scalapactcore.stubber
 
+import java.util.concurrent.{ExecutorService, Executors}
+
 import com.itv.scalapactcore._
-import com.itv.scalapactcore.common.{Arguments, Http4sRequestResponseFactory}
 import com.itv.scalapactcore.common.ColourOuput._
+import com.itv.scalapactcore.common.{Arguments, Http4sRequestResponseFactory}
 import org.http4s.dsl._
 import org.http4s.server.Server
 import org.http4s.server.blaze.BlazeBuilder
 import org.http4s.util.CaseInsensitiveString
 import org.http4s.{HttpService, Request, Response, Status}
 
+import scala.concurrent.duration._
+
 object PactStubService {
 
-  lazy val startServer: Arguments => Unit = config => {
+  private val nThreads: Int = 50
+  private val executorService: ExecutorService = Executors.newFixedThreadPool(nThreads)
+
+  def startServer: Arguments => Unit = config => {
     println(("Starting ScalaPact Stubber on: http://" + config.giveHost + ":" + config.givePort).white.bold)
     println(("Strict matching mode: " + config.giveStrictMode).white.bold)
 
-    BlazeBuilder.bindHttp(config.givePort, config.giveHost)
-      .mountService(PactStubService.service(config.giveStrictMode), "/")
-      .run
-      .awaitShutdown()
+    runServer(new InteractionManager)(nThreads)(config).awaitShutdown()
   }
 
-  lazy val runServer: Arguments => Server = config => {
-    BlazeBuilder.bindHttp(config.givePort, config.giveHost)
-      .mountService(PactStubService.service(config.giveStrictMode), "/")
+  def runServer: InteractionManager => Int => Arguments => Server = interactionManager => connectionPoolSize => config => {
+    BlazeBuilder
+      .bindHttp(config.givePort, config.giveHost)
+      .withServiceExecutor(executorService)
+      .withIdleTimeout(60.seconds)
+      .withConnectorPoolSize(connectionPoolSize)
+      .mountService(PactStubService.service(interactionManager)(config.giveStrictMode), "/")
       .run
   }
 
-  lazy val stopServer: Server => Unit = server => {
+  def stopServer: Server => Unit = server => {
     server.shutdown
   }
 
   private val isAdminCall: Request => Boolean = request =>
-    request.pathInfo.startsWith("/interactions") &&
       request.headers.get(CaseInsensitiveString("X-Pact-Admin")).exists(h => h.value == "true")
 
-  private val service: Boolean => HttpService = strictMatching =>
+  private val service: InteractionManager => Boolean => HttpService = interactionManager => strictMatching =>
     HttpService.lift { req =>
-      matchRequestWithResponse(strictMatching)(req)
+      matchRequestWithResponse(interactionManager, strictMatching)(req)
     }
 
-  private def matchRequestWithResponse(strictMatching: Boolean)(req: Request): scalaz.concurrent.Task[Response] = {
+  private def matchRequestWithResponse(interactionManager: InteractionManager, strictMatching: Boolean)(req: Request): scalaz.concurrent.Task[Response] = {
     if(isAdminCall(req)) {
 
       req.method.name.toUpperCase match {
-        case m if m == "GET" =>
-          val output = ScalaPactWriter.pactToJsonString(Pact(PactActor(""), PactActor(""), InteractionManager.getInteractions))
+        case m if m == "GET" && req.pathInfo.startsWith("/stub/status") =>
+          Ok()
+
+        case m if m == "GET" && req.pathInfo.startsWith("/interactions") =>
+          val output = ScalaPactWriter.pactToJsonString(Pact(PactActor(""), PactActor(""), interactionManager.getInteractions))
           Ok(output)
 
-        case m if m == "POST" || m == "PUT" =>
+        case m if m == "POST" || m == "PUT" && req.pathInfo.startsWith("/interactions") =>
           ScalaPactReader.jsonStringToPact(req.bodyAsText.runLog.map(body => Option(body.foldLeft("")(_ + _))).unsafePerformSync.getOrElse("")) match {
             case Right(r) =>
-              InteractionManager.addInteractions(r.interactions)
+              interactionManager.addInteractions(r.interactions)
 
-              val output = ScalaPactWriter.pactToJsonString(Pact(PactActor(""), PactActor(""), InteractionManager.getInteractions))
+              val output = ScalaPactWriter.pactToJsonString(Pact(PactActor(""), PactActor(""), interactionManager.getInteractions))
               Ok(output)
 
             case Left(l) =>
               InternalServerError(l)
           }
 
-        case m if m == "DELETE" =>
-          InteractionManager.clearInteractions()
+        case m if m == "DELETE" && req.pathInfo.startsWith("/interactions") =>
+          interactionManager.clearInteractions()
 
-          val output = ScalaPactWriter.pactToJsonString(Pact(PactActor(""), PactActor(""), InteractionManager.getInteractions))
+          val output = ScalaPactWriter.pactToJsonString(Pact(PactActor(""), PactActor(""), interactionManager.getInteractions))
           Ok(output)
       }
 
@@ -72,7 +82,7 @@ object PactStubService {
 
       import com.itv.scalapactcore.common.HeaderImplicitConversions._
 
-      InteractionManager.findMatchingInteraction(
+      interactionManager.findMatchingInteraction(
         InteractionRequest(
           method = Option(req.method.name.toUpperCase),
           headers = Option(req.headers),

--- a/scalapact-core/src/main/scala/com/itv/scalapactcore/stubber/PactStubService.scala
+++ b/scalapact-core/src/main/scala/com/itv/scalapactcore/stubber/PactStubService.scala
@@ -18,11 +18,11 @@ object PactStubService {
   private val nThreads: Int = 50
   private val executorService: ExecutorService = Executors.newFixedThreadPool(nThreads)
 
-  def startServer: Arguments => Unit = config => {
+  def startServer: InteractionManager => Arguments => Unit = interactionManager => config => {
     println(("Starting ScalaPact Stubber on: http://" + config.giveHost + ":" + config.givePort).white.bold)
     println(("Strict matching mode: " + config.giveStrictMode).white.bold)
 
-    runServer(new InteractionManager)(nThreads)(config).awaitShutdown()
+    runServer(interactionManager)(nThreads)(config).awaitShutdown()
   }
 
   def runServer: InteractionManager => Int => Arguments => Server = interactionManager => connectionPoolSize => config => {

--- a/scalapact-core/src/main/scala/com/itv/scalapactcore/verifier/Verifier.scala
+++ b/scalapact-core/src/main/scala/com/itv/scalapactcore/verifier/Verifier.scala
@@ -117,25 +117,6 @@ object Verifier {
   private lazy val doRequest: Arguments => Option[ProviderState] => InteractionRequest => Either[String, InteractionResponse] = arguments => maybeProviderState => interactionRequest => {
     val baseUrl = s"${arguments.giveProtocol}://" + arguments.giveHost + ":" + arguments.givePort
 
-    // Started wart removing...
-//    val providerStateRun = maybeProviderState.map { ps =>
-//      val key = ps.key
-//
-//      println(s"Attempting to run provider state: $key".yellow.bold)
-//
-//      val success = ps.f(key)
-//
-//      if(success) {
-//        println(s"Provider state ran successfully".yellow.bold)
-//        Right(success)
-//      } else {
-//        println(s"Provider state run failed".red.bold)
-//        println("--------------------".yellow.bold)
-//        println(s"Error executing unknown provider state function with key: $key".red)
-//        Left(s"Error executing unknown provider state function with key: $key")
-//      }
-//    }
-
     try {
 
       if(maybeProviderState.isDefined) {
@@ -153,12 +134,13 @@ object Verifier {
         if(!success) throw new ProviderStateFailure(key)
       }
     } catch {
-      case _: Throwable =>
+      case t: Throwable =>
         if(maybeProviderState.isDefined) {
           println(s"Error executing unknown provider state function with key: ${maybeProviderState.map(_.key).getOrElse("<missing key>")}".red)
         } else {
           println("Error executing unknown provider state function!".red)
         }
+        throw t
     }
 
     try {

--- a/scalapact-sbtplugin/src/main/scala/com/itv/scalapact/plugin/stubber/ScalaPactStubberCommand.scala
+++ b/scalapact-sbtplugin/src/main/scala/com/itv/scalapact/plugin/stubber/ScalaPactStubberCommand.scala
@@ -23,7 +23,7 @@ object ScalaPactStubberCommand {
 
     val interactionManager: InteractionManager = new InteractionManager
 
-    (parseArguments andThen loadPactFiles("target/pacts") andThen interactionManager.addToInteractionManager andThen startServer)(args)
+    (parseArguments andThen loadPactFiles("target/pacts") andThen interactionManager.addToInteractionManager andThen startServer(interactionManager))(args)
 
     pactTestedState
   }

--- a/scalapact-sbtplugin/src/main/scala/com/itv/scalapact/plugin/stubber/ScalaPactStubberCommand.scala
+++ b/scalapact-sbtplugin/src/main/scala/com/itv/scalapact/plugin/stubber/ScalaPactStubberCommand.scala
@@ -5,7 +5,7 @@ import sbt._
 import com.itv.scalapactcore.common.CommandArguments._
 import com.itv.scalapactcore.common.LocalPactFileLoader._
 import com.itv.scalapactcore.stubber.PactStubService._
-import com.itv.scalapactcore.stubber.InteractionManager._
+import com.itv.scalapactcore.stubber.InteractionManager
 import com.itv.scalapactcore.common.ColourOuput._
 
 object ScalaPactStubberCommand {
@@ -21,7 +21,9 @@ object ScalaPactStubberCommand {
 
     val pactTestedState = Command.process("pact-test", state)
 
-    (parseArguments andThen loadPactFiles("target/pacts") andThen addToInteractionManager andThen startServer)(args)
+    val interactionManager: InteractionManager = new InteractionManager
+
+    (parseArguments andThen loadPactFiles("target/pacts") andThen interactionManager.addToInteractionManager andThen startServer)(args)
 
     pactTestedState
   }

--- a/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactMock.scala
+++ b/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactMock.scala
@@ -4,9 +4,10 @@ import java.io.IOException
 import java.net.ServerSocket
 
 import com.itv.scalapact.ScalaPactForger._
-import com.itv.scalapactcore.common.{Arguments, ConfigAndPacts}
-import com.itv.scalapactcore.stubber.InteractionManager._
+import com.itv.scalapactcore.common.{Arguments, ConfigAndPacts, ScalaPactHttp}
+import com.itv.scalapactcore.stubber.InteractionManager
 import com.itv.scalapactcore.stubber.PactStubService._
+import org.http4s.server.Server
 
 object ScalaPactMock {
 
@@ -25,32 +26,34 @@ object ScalaPactMock {
     var port = -1
 
     try {
-      socket.setReuseAddress(true)
+      socket.setReuseAddress(false)
       port = socket.getLocalPort
 
       try {
         socket.close()
       } catch {
         // Ignore IOException on close()
-        case e: IOException =>
+        case _: IOException =>
       }
     } catch{
-      case e: IOException =>
+      case _: IOException =>
     } finally {
       if (socket != null) {
         try {
           socket.close()
         } catch {
-          case e: IOException =>
+          case _: IOException =>
         }
       }
     }
 
-    if(port == -1) throw new IllegalStateException("Could not find a free TCP/IP port to start embedded Jetty HTTP Server on")
+    if(port == -1) throw new IllegalStateException("Could not find a free TCP/IP port to start embedded HTTP Server on")
     else port
   }
 
   def runConsumerIntegrationTest[A](strict: Boolean)(pactDescription: ScalaPactDescriptionFinal)(test: ScalaPactMockConfig => A): A = {
+
+    val interactionManager: InteractionManager = new InteractionManager
 
     val mockConfig = ScalaPactMockConfig("http", "localhost", findFreePort())
 
@@ -65,19 +68,37 @@ object ScalaPactMock {
       pacts = List(ScalaPactContractWriter.producePactFromDescription(pactDescription))
     )
 
-    val server = (addToInteractionManager andThen runServer)(configAndPacts)
+    val connectionPoolSize: Int = 5
 
-    // This if naff, but sometimes isn't quite ready when we run the first test for some reason.
-    // TODO: Fix this properly
-    Thread.sleep(100)
+    val server = (interactionManager.addToInteractionManager andThen runServer(interactionManager)(connectionPoolSize))(configAndPacts)
 
-    println("> ScalaPact mock running at: " + mockConfig.baseUrl)
+    println("> ScalaPact stub running at: " + mockConfig.baseUrl)
 
-    val result = configuredTestRunner(pactDescription)(mockConfig)(test)
-
-    stopServer(server)
-    result
+    waitForServerThenTest(server, mockConfig, test, pactDescription)
   }
+
+  private def waitForServerThenTest[A](server: Server, mockConfig: ScalaPactMockConfig, test: ScalaPactMockConfig => A, pactDescription: ScalaPactDescriptionFinal): A = {
+    def rec(attemptsRemaining: Int, intervalMillis: Int): A = {
+      if(isStubReady(mockConfig)) {
+        val result = configuredTestRunner(pactDescription)(mockConfig)(test)
+
+        stopServer(server)
+
+        result
+      } else if(attemptsRemaining == 0) {
+        throw new Exception("Could not connect to stub are: " + mockConfig.baseUrl)
+      } else {
+        println(">  ...waiting for stub, attempts remaining: " + attemptsRemaining)
+        Thread.sleep(intervalMillis)
+        rec(attemptsRemaining - 1, intervalMillis)
+      }
+    }
+
+    rec(5, 100)
+  }
+
+  private def isStubReady(mockConfig: ScalaPactMockConfig): Boolean =
+    ScalaPactHttp.doRequest(ScalaPactHttp.GET, mockConfig.baseUrl, "/stub/status", Map("X-Pact-Admin" -> "true"), None).unsafePerformSync.is2xx
 
 }
 

--- a/scalapact-scalatest/src/test/scala/com/itv/scalapact/HeavySpec.scala
+++ b/scalapact-scalatest/src/test/scala/com/itv/scalapact/HeavySpec.scala
@@ -1,0 +1,45 @@
+package com.itv.scalapact
+
+import org.scalatest.{FunSpec, Matchers}
+
+import ScalaPactForger._
+
+class HeavySpec extends FunSpec with Matchers {
+
+  def makeEndPoints(name: String, count: Int): List[String] = (0 until count).toList.map(i => s"/$name/_$i")
+
+  def generatePactAndTestIt(endPoint: String): Unit = {
+    forgePact
+      .between("heavy-consumer").and("heavy-provider")
+      .addInteraction(interaction.description("load").uponReceiving(endPoint).willRespondWith(200))
+      .runConsumerTest { config =>
+
+        val response = SimpleClient.doGetRequest(config.baseUrl, endPoint, Map())
+
+        withClue("Failing response: " + response) {
+          response.status shouldEqual 200
+        }
+      }
+  }
+
+  describe("Running many pacts") {
+
+    it("should be able to cope with a pact test") {
+      makeEndPoints("single", 1).foreach(generatePactAndTestIt)
+    }
+
+    it("should be able to cope with another 10 pact tests") {
+      makeEndPoints("ten", 10).foreach(generatePactAndTestIt)
+    }
+
+    it("should be able to cope with another 20 pact tests") {
+      makeEndPoints("twenty", 20).foreach(generatePactAndTestIt)
+    }
+
+    it("should be able to cope with another 100 pact tests") {
+      makeEndPoints("one-hundred", 100).foreach(generatePactAndTestIt)
+    }
+
+  }
+
+}

--- a/scalapact-standalone-stubber/src/main/scala/com/itv/standalonestubber/PactStubber.scala
+++ b/scalapact-standalone-stubber/src/main/scala/com/itv/standalonestubber/PactStubber.scala
@@ -16,7 +16,7 @@ object PactStubber {
 
     val interactionManager: InteractionManager = new InteractionManager
 
-    (parseArguments andThen loadPactFiles("pacts") andThen interactionManager.addToInteractionManager andThen startServer)(args)
+    (parseArguments andThen loadPactFiles("pacts") andThen interactionManager.addToInteractionManager andThen startServer(interactionManager))(args)
 
   }
 

--- a/scalapact-standalone-stubber/src/main/scala/com/itv/standalonestubber/PactStubber.scala
+++ b/scalapact-standalone-stubber/src/main/scala/com/itv/standalonestubber/PactStubber.scala
@@ -3,7 +3,7 @@ package com.itv.standalonestubber
 import com.itv.scalapactcore.common.ColourOuput._
 import com.itv.scalapactcore.common.CommandArguments._
 import com.itv.scalapactcore.common.LocalPactFileLoader._
-import com.itv.scalapactcore.stubber.InteractionManager._
+import com.itv.scalapactcore.stubber.InteractionManager
 import com.itv.scalapactcore.stubber.PactStubService._
 
 object PactStubber {
@@ -14,7 +14,9 @@ object PactStubber {
     println("** ScalaPact: Running Stubber      **".white.bold)
     println("*************************************".white.bold)
 
-    (parseArguments andThen loadPactFiles("pacts") andThen addToInteractionManager andThen startServer)(args)
+    val interactionManager: InteractionManager = new InteractionManager
+
+    (parseArguments andThen loadPactFiles("pacts") andThen interactionManager.addToInteractionManager andThen startServer)(args)
 
   }
 


### PR DESCRIPTION
This branch:
- Vastly improves throughput of the stub services;
- Removes flaky test running (which was due to unintended shared state which crept in when wiremock was replaced by the pact stubber);
- Drastically increases pact test speed by removing a hacky Thread.sleep that's been praying on my mind;
- Allows for many more pacts to be forged per test suite.