### PR TITLE
Create additional settingKey to define pattern matching state providers

### DIFF
--- a/scalapact-core/src/main/scala/com/itv/scalapactcore/verifier/Verifier.scala
+++ b/scalapact-core/src/main/scala/com/itv/scalapactcore/verifier/Verifier.scala
@@ -71,7 +71,7 @@ object Verifier {
         pact = pact,
         results = pact.interactions.map { interaction =>
 
-          val maybeProviderState = interaction.providerState.flatMap(p => pactVerifySettings.providerStates.find(j => j.key == p))
+          val maybeProviderState = interaction.providerState.map(p => ProviderState(p, PartialFunction(pactVerifySettings.providerStates)))
 
           val matchResult = (doRequest(arguments)(maybeProviderState) andThen attemptMatch(arguments.giveStrictMode)(List(interaction)))(interaction.request)
 
@@ -220,4 +220,4 @@ class ProviderStateFailure(key: String) extends Exception()
 
 case class ProviderState(key: String, f: String => Boolean)
 case class VersionedConsumer(name: String, version: String)
-case class PactVerifySettings(providerStates: List[ProviderState], pactBrokerAddress: String, projectVersion: String, providerName: String, consumerNames: List[String], versionedConsumerNames: List[VersionedConsumer])
+case class PactVerifySettings(providerStates: (String => Boolean), pactBrokerAddress: String, projectVersion: String, providerName: String, consumerNames: List[String], versionedConsumerNames: List[VersionedConsumer])

--- a/scalapact-sbtplugin/src/main/scala/com/itv/scalapact/plugin/ScalaPactPlugin.scala
+++ b/scalapact-sbtplugin/src/main/scala/com/itv/scalapact/plugin/ScalaPactPlugin.scala
@@ -12,7 +12,7 @@ import scala.language.implicitConversions
 
 object ScalaPactPlugin extends Plugin {
 
-  val providerStateMatcher = SettingKey[(String => Boolean)]("provider-state-matcher", "A list of provider state setup functions")
+  val providerStateMatcher = SettingKey[(String => Boolean)]("provider-state-matcher", "Alternative partial function for provider state setup")
   val providerStates = SettingKey[Seq[(String, String => Boolean)]]("provider-states", "A list of provider state setup functions")
   val pactBrokerAddress = SettingKey[String]("pactBrokerAddress", "The base url to publish / pull pact contract files to and from.")
   val providerName = SettingKey[String]("providerName", "The name of the service to verify")

--- a/scalapact-sbtplugin/src/main/scala/com/itv/scalapact/plugin/ScalaPactPlugin.scala
+++ b/scalapact-sbtplugin/src/main/scala/com/itv/scalapact/plugin/ScalaPactPlugin.scala
@@ -4,6 +4,7 @@ import com.itv.scalapact.plugin.publish.ScalaPactPublishCommand
 import com.itv.scalapact.plugin.stubber.ScalaPactStubberCommand
 import com.itv.scalapact.plugin.tester.ScalaPactTestCommand
 import com.itv.scalapact.plugin.verifier.ScalaPactVerifyCommand
+import com.itv.scalapactcore.common.Arguments
 import sbt.Keys._
 import sbt._
 
@@ -11,6 +12,7 @@ import scala.language.implicitConversions
 
 object ScalaPactPlugin extends Plugin {
 
+  val providerStateMatcher = SettingKey[(String => Boolean)]("provider-state-matcher", "A list of provider state setup functions")
   val providerStates = SettingKey[Seq[(String, String => Boolean)]]("provider-states", "A list of provider state setup functions")
   val pactBrokerAddress = SettingKey[String]("pactBrokerAddress", "The base url to publish / pull pact contract files to and from.")
   val providerName = SettingKey[String]("providerName", "The name of the service to verify")

--- a/scalapact-scalatest/pact.sbt
+++ b/scalapact-scalatest/pact.sbt
@@ -1,9 +1,20 @@
 import com.itv.scalapact.plugin.ScalaPactPlugin._
 import com.itv.scalapactcore.common._
 
+
+providerStates := Seq(
+  ("Resource with ID 1234 exists", (key: String) => {
+    println("Injecting key 1234 into the database...")
+    // Do some work to ensure the system under test is
+    // in an appropriate state before verification
+
+    true
+  })
+)
+
 val Resource = """Resource:([a-z]+)\{([^\{\}]+)\}""".r
 
-providerStates := {
+providerStateMatcher := {
   case key: String if key.startsWith("Resource with ID 1234 exists") =>
     println("Injecting key 1234 into the database...")
     // Do some work to ensure the system under test is
@@ -14,3 +25,9 @@ providerStates := {
     true
 
 }
+
+pactBrokerAddress := "http://localhost"
+providerName := "Their Provider Service"
+consumerNames := Seq("My Consumer")
+pactContractVersion := "1.0.0"
+allowSnapshotPublish := false

--- a/scalapact-scalatest/pact.sbt
+++ b/scalapact-scalatest/pact.sbt
@@ -1,16 +1,16 @@
 import com.itv.scalapact.plugin.ScalaPactPlugin._
+import com.itv.scalapactcore.common._
 
-providerStates := Seq(
-  ("Resource with ID 1234 exists", (key: String) => {
+val Resource = """Resource:([a-z]+)\{([^\{\}]+)\}""".r
+
+providerStates := {
+  case key: String if key.startsWith("Resource with ID 1234 exists") =>
     println("Injecting key 1234 into the database...")
     // Do some work to ensure the system under test is
     // in an appropriate state before verification
-    true
-  })
-)
 
-pactBrokerAddress := "http://localhost"
-providerName := "Their Provider Service"
-consumerNames := Seq("My Consumer")
-pactContractVersion := "1.0.0"
-allowSnapshotPublish := false
+    true
+  case Resource("user", id: String) => // Sample 'Resource:User:id:1234'
+    true
+
+}

--- a/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactVerify.scala
+++ b/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactVerify.scala
@@ -40,11 +40,8 @@ object ScalaPactVerify {
 
       private def doVerification(protocol: String, host: String, port: Int, strict: Boolean): Unit = {
 
-        val providerStatesList =
-          for {
-            g  <- given
-            ps <- setupProviderState
-          } yield List(ProviderState(g, ps))
+        val providerStateFunc = given.flatMap( g => setupProviderState).getOrElse({ _ : String => true})
+
 
         val (verifySettings, arguments) = sourceType match {
           case pactAsJsonString(json) =>
@@ -58,7 +55,7 @@ object ScalaPactVerify {
 
             (
               PactVerifySettings(
-                providerStates = providerStatesList.getOrElse(Nil),
+                providerStates = providerStateFunc,
                 pactBrokerAddress = "",
                 projectVersion = "",
                 providerName = "",
@@ -77,7 +74,7 @@ object ScalaPactVerify {
           case loadFromLocal(path) =>
             (
               PactVerifySettings(
-                providerStates = providerStatesList.getOrElse(Nil),
+                providerStates = providerStateFunc,
                 pactBrokerAddress = "",
                 projectVersion = "",
                 providerName = "",
@@ -96,7 +93,7 @@ object ScalaPactVerify {
           case pactBroker(url, providerName, consumerNames) =>
             (
               PactVerifySettings(
-                providerStates = providerStatesList.getOrElse(Nil),
+                providerStates = providerStateFunc,
                 pactBrokerAddress = url,
                 projectVersion = "",
                 providerName = providerName,
@@ -115,7 +112,7 @@ object ScalaPactVerify {
           case pactBrokerWithVersion(url, version, providerName, consumerNames) =>
             (
               PactVerifySettings(
-                providerStates = providerStatesList.getOrElse(Nil),
+                providerStates = providerStateFunc,
                 pactBrokerAddress = url,
                 projectVersion = "",
                 providerName = providerName,


### PR DESCRIPTION
@davesmith00000 

Resolving the two SettingKey's together got a bit hairy. 

So this approaches rips out the internals and replaces with (String => Boolean), and then maps existing providerStates key into that type. Hope you don't think it's too invasive. 

Going to want tests around the states to make sure default cases are handled well, and that the keys are still allowed individually.