### PR TITLE
Allow pact root dir to be configurable via system properties

### DIFF
--- a/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactContractWriter.scala
+++ b/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactContractWriter.scala
@@ -14,7 +14,7 @@ object ScalaPactContractWriter {
     "[^a-zA-Z0-9-]".r.replaceAllIn(name.replace(" ", "-"), "")
 
   val writePactContracts: ScalaPactDescriptionFinal => Unit = pactDescription => {
-    val dirPath = "target/pacts"
+    val dirPath = System.getProperty("pact.rootDir", "target/pacts")
     val dirFile = new File(dirPath)
 
     if (!dirFile.exists()) {


### PR DESCRIPTION
Allow the pact root directory to be configurable via system properties.

This change is inline with other pact publishing frameworks as can be demonstrated [here](https://github.com/DiUS/pact-jvm/blob/master/pact-jvm-consumer/src/main/scala/au/com/dius/pact/consumer/PactConsumerConfig.scala)

Thanks and let me know if you feel any additions are needed!