### PR TITLE
Fix broken links in consumer example docs

### DIFF
--- a/scalapact-docs/src/main/paradox/examples/consumer.md
+++ b/scalapact-docs/src/main/paradox/examples/consumer.md
@@ -1,7 +1,7 @@
 # The Consumer
 The consumer project owns and generates the Pact contract file.
 
-The Pact contract file is the result of an [integration test](https://github.com/ITV/scala-pact/blob/example-projects/example/consumer/src/test/scala/com/example/consumer/ProviderClientSpec.scala) that tests a [real, albeit crude piece of client code](https://github.com/ITV/scala-pact/blob/example-projects/example/consumer/src/main/scala/com/example/consumer/ProviderClient.scala) against a mock.
+The Pact contract file is the result of an [integration test](https://github.com/ITV/scala-pact/blob/master/example/consumer/src/test/scala/com/example/consumer/ProviderClientSpec.scala) that tests a [real, albeit crude piece of client code](https://github.com/ITV/scala-pact/blob/master/example/consumer/src/main/scala/com/example/consumer/ProviderClient.scala) against a mock.
 
 To run the pact-tests, do the following (assuming you've checked out the project and are in the example directory):
 


### PR DESCRIPTION
The first two links on here 404: http://io.itv.com/scala-pact/examples/consumer.html

I can't see the example-projects branch, so I'm assuming you'll be happy with a link to the code on master :) I grepped the project for more usages of the string 'example-projects' in .md files too, but only found these two.