### PR TITLE
Http4s 0.18.0 m4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -239,6 +239,15 @@ lazy val circe08_2_10 = circe08(scala210).dependsOn(shared_2_10).settings(
 lazy val circe08_2_11 = circe08(scala211).dependsOn(shared_2_11)
 lazy val circe08_2_12 = circe08(scala212).dependsOn(shared_2_12)
 
+lazy val circe09 =
+  (project in file("scalapact-circe-0-9"))
+    .settings(commonSettings: _*)
+    .settings(publishSettings: _*)
+    .cross
+
+lazy val circe09_2_11 = circe09(scala211).dependsOn(shared_2_11)
+lazy val circe09_2_12 = circe09(scala212).dependsOn(shared_2_12)
+
 lazy val pactSpec =
   (project in file("pact-spec-tests"))
     .settings(commonSettings: _*)
@@ -332,6 +341,8 @@ lazy val scalaPactProject =
       circe08_2_10,
       circe08_2_11,
       circe08_2_12,
+      circe09_2_11,
+      circe09_2_12,
       pactSpec_2_10,
       pactSpec_2_11,
       pactSpec_2_12

--- a/build.sbt
+++ b/build.sbt
@@ -205,6 +205,16 @@ lazy val http4s0170 =
 lazy val http4s0170_2_11 = http4s0170(scala211).dependsOn(shared_2_11)
 lazy val http4s0170_2_12 = http4s0170(scala212).dependsOn(shared_2_12)
 
+
+lazy val http4s0180 =
+  (project in file("scalapact-http4s-0-18-0"))
+    .settings(commonSettings: _*)
+    .settings(publishSettings: _*)
+    .cross
+
+lazy val http4s0180_2_11 = http4s0180(scala211).dependsOn(shared_2_11)
+lazy val http4s0180_2_12 = http4s0180(scala212).dependsOn(shared_2_12)
+
 lazy val argonaut62 =
   (project in file("scalapact-argonaut-6-2"))
     .settings(commonSettings: _*)
@@ -333,6 +343,8 @@ lazy val scalaPactProject =
       http4s0162_2_12,
       http4s0170_2_11,
       http4s0170_2_12,
+      http4s0180_2_11,
+      http4s0180_2_12,
       argonaut61_2_10,
       argonaut61_2_11,
       argonaut62_2_10,

--- a/example/consumer/build.sbt
+++ b/example/consumer/build.sbt
@@ -11,14 +11,15 @@ version := "0.0.1"
 
 enablePlugins(ScalaPactPlugin)
 
-libraryDependencies ++= Seq(
-  "com.itv"       %% "scalapact-argonaut-6-2"   % "2.2.1" % "test",
-  "com.itv"       %% "scalapact-http4s-0-15-0a" % "2.2.1" % "test",
-  "com.itv"       %% "scalapact-scalatest"      % "2.2.1" % "test",
-  "org.scalaj"    %% "scalaj-http"              % "2.3.0",
-  "org.slf4j"     %  "slf4j-simple"             % "1.6.4",
-  "org.json4s"    %% "json4s-native"            % "3.5.0",
-  "org.scalatest" %% "scalatest"                % "3.0.1"          % "test"
-)
+libraryDependencies ++=
+  Seq(
+    "com.itv"       %% "scalapact-argonaut-6-2"   % "2.2.2-SNAPSHOT" % "test",
+    "com.itv"       %% "scalapact-http4s-0-15-0a" % "2.2.2-SNAPSHOT" % "test",
+    "com.itv"       %% "scalapact-scalatest"      % "2.2.2-SNAPSHOT" % "test",
+    "org.scalaj"    %% "scalaj-http"              % "2.3.0",
+    "org.slf4j"     %  "slf4j-simple"             % "1.6.4",
+    "org.json4s"    %% "json4s-native"            % "3.5.0",
+    "org.scalatest" %% "scalatest"                % "3.0.1"          % "test"
+  )
 
 scalaPactEnv := ScalaPactEnv.default.withPort(8080)

--- a/example/consumer/project/plugins.sbt
+++ b/example/consumer/project/plugins.sbt
@@ -1,7 +1,7 @@
 
 libraryDependencies ++= Seq(
-  "com.itv" %% "scalapact-argonaut-6-2"   % "2.2.1",
-  "com.itv" %% "scalapact-http4s-0-15-0a" % "2.2.1"
+  "com.itv" %% "scalapact-argonaut-6-2"   % "2.2.2-SNAPSHOT",
+  "com.itv" %% "scalapact-http4s-0-15-0a" % "2.2.2-SNAPSHOT"
 )
 
-addSbtPlugin("com.itv" % "sbt-scalapact" % "2.2.1")
+addSbtPlugin("com.itv" % "sbt-scalapact" % "2.2.2-SNAPSHOT")

--- a/example/provider/project/plugins.sbt
+++ b/example/provider/project/plugins.sbt
@@ -1,7 +1,7 @@
 
 libraryDependencies ++= Seq(
-  "com.itv" %% "scalapact-argonaut-6-2"  % "2.2.1",
-  "com.itv" %% "scalapact-http4s-0-15-0a" % "2.2.1"
+  "com.itv" %% "scalapact-argonaut-6-2"  % "2.2.2-SNAPSHOT",
+  "com.itv" %% "scalapact-http4s-0-15-0a" % "2.2.2-SNAPSHOT"
 )
 
-addSbtPlugin("com.itv" % "sbt-scalapact" % "2.2.1")
+addSbtPlugin("com.itv" % "sbt-scalapact" % "2.2.2-SNAPSHOT")

--- a/example/provider_tests/build.sbt
+++ b/example/provider_tests/build.sbt
@@ -6,13 +6,14 @@ version := "0.0.1"
 
 scalaVersion := "2.11.8"
 
-libraryDependencies ++= Seq(
-  "org.http4s"     %% "http4s-blaze-server"      % "0.17.0",
-  "org.http4s"     %% "http4s-dsl"               % "0.17.0",
-  "org.http4s"     %% "http4s-argonaut"          % "0.17.0",
-  "org.slf4j"      %  "slf4j-simple"             % "1.6.4",
-  "org.scalatest"  %% "scalatest"                % "3.0.1"          % "test",
-  "com.itv"        %% "scalapact-circe-0-8"      % "2.2.1" % "test",
-  "com.itv"        %% "scalapact-http4s-0-17-0"  % "2.2.1" % "test",
-  "com.itv"        %% "scalapact-scalatest"      % "2.2.1" % "test"
-)
+libraryDependencies ++=
+  Seq(
+    "org.http4s" %% "http4s-blaze-server" % "0.17.0",
+    "org.http4s" %% "http4s-dsl" % "0.17.0",
+    "org.http4s" %% "http4s-argonaut" % "0.17.0",
+    "org.slf4j" % "slf4j-simple" % "1.6.4",
+    "org.scalatest" %% "scalatest" % "3.0.1" % "test",
+    "com.itv" %% "scalapact-circe-0-8" % "2.2.2-SNAPSHOT" % "test",
+    "com.itv" %% "scalapact-http4s-0-17-0" % "2.2.2-SNAPSHOT" % "test",
+    "com.itv" %% "scalapact-scalatest" % "2.2.2-SNAPSHOT" % "test"
+  )

--- a/scalapact-circe-0-9/build.sbt
+++ b/scalapact-circe-0-9/build.sbt
@@ -1,0 +1,9 @@
+name := "scalapact-circe-0-9"
+
+val circeVersion = "0.9.0-M1"
+
+libraryDependencies ++= Seq(
+  "io.circe" %% "circe-core",
+  "io.circe" %% "circe-generic",
+  "io.circe" %% "circe-parser"
+).map(_ % circeVersion)

--- a/scalapact-circe-0-9/src/main/scala/com/itv/scalapact/shared/pact/EitherWithToOption.scala
+++ b/scalapact-circe-0-9/src/main/scala/com/itv/scalapact/shared/pact/EitherWithToOption.scala
@@ -1,6 +1,7 @@
 package com.itv.scalapact.shared.pact
 
 object EitherWithToOption {
+
   implicit class WithToOption[A, B](either: Either[A, B]) {
     def toOption: Option[B] =
       either match {

--- a/scalapact-circe-0-9/src/main/scala/com/itv/scalapact/shared/pact/PactReader.scala
+++ b/scalapact-circe-0-9/src/main/scala/com/itv/scalapact/shared/pact/PactReader.scala
@@ -1,0 +1,97 @@
+package com.itv.scalapact.shared.pact
+
+import io.circe._
+import io.circe.parser._
+import io.circe.generic.auto._
+
+import com.itv.scalapact.shared._
+
+object PactReader extends IPactReader {
+
+  // Used by old Scala versions
+  import EitherWithToOption._
+
+  def jsonStringToPact(json: String): Either[String, Pact] = {
+    val brokenPact: Option[(PactActor, PactActor, List[(Option[Interaction], Option[String], Option[String])])] = for {
+      provider <- JsonBodySpecialCaseHelper.extractPactActor("provider")(json)
+      consumer <- JsonBodySpecialCaseHelper.extractPactActor("consumer")(json)
+      interactions <- JsonBodySpecialCaseHelper.extractInteractions(json)
+    } yield (provider, consumer, interactions)
+
+    brokenPact.map { bp =>
+
+      val interactions = bp._3.collect {
+        case (Some(i), r1, r2) =>
+          i.copy(
+            request = i.request.copy(body = r1),
+            response = i.response.copy(body = r2)
+          )
+      }
+
+      Pact(
+        provider = bp._1,
+        consumer = bp._2,
+        interactions = interactions
+          .map(i => i.copy(providerState = i.providerState.orElse(i.provider_state)))
+          .map(i => i.copy(provider_state = None))
+      )
+
+    } match {
+      case Some(pact) => Right(pact)
+      case None => Left(s"Could not read pact from json: $json")
+    }
+  }
+
+}
+
+object JsonBodySpecialCaseHelper {
+
+  // Used by old Scala versions
+  import EitherWithToOption._
+
+  val extractPactActor: String => String => Option[PactActor] = field => json =>
+    parse(json).toOption
+      .flatMap { j => j.hcursor.downField(field).focus }
+      .flatMap(p => p.as[PactActor].toOption)
+
+  val extractInteractions: String => Option[List[(Option[Interaction], Option[String], Option[String])]] = json => {
+
+    val interations =
+      parse(json).toOption
+        .flatMap { j => j.hcursor.downField("interactions").focus.flatMap(p => p.asArray.map(_.toList)) }
+
+    val makeOptionalBody: Json => Option[String] = j => j match {
+      case body: Json if body.isString =>
+        j.asString
+
+      case _ =>
+        Option(j.pretty(Printer.spaces2.copy(dropNullValues = true)))
+    }
+
+    interations.map { is =>
+      is.map { i =>
+        val minusRequestBody =
+          i.hcursor.downField("request").downField("body").delete.top match {
+            case ok @ Some(_) => ok
+            case None => Option(i)
+          }
+
+        val minusResponseBody = minusRequestBody.flatMap { ii =>
+          ii.hcursor.downField("response").downField("body").delete.top match {
+            case ok @ Some(_) => ok
+            case None => minusRequestBody // There wasn't a body, but there was still an interaction.
+          }
+        }
+
+        val requestBody = i.hcursor.downField("request").downField("body").focus
+          .flatMap { makeOptionalBody }
+
+        val responseBody = i.hcursor.downField("response").downField("body").focus
+          .flatMap { makeOptionalBody }
+
+        (minusResponseBody.flatMap(p => p.as[Interaction].toOption), requestBody, responseBody)
+      }
+    }
+  }
+
+}

--- a/scalapact-circe-0-9/src/main/scala/com/itv/scalapact/shared/pact/PactWriter.scala
+++ b/scalapact-circe-0-9/src/main/scala/com/itv/scalapact/shared/pact/PactWriter.scala
@@ -1,0 +1,73 @@
+package com.itv.scalapact.shared.pact
+
+import com.itv.scalapact.shared.{IPactWriter, Pact}
+import io.circe._
+import io.circe.parser._
+import io.circe.syntax._
+import io.circe.generic.auto._
+
+object PactWriter extends IPactWriter {
+
+  // Used by old Scala versions
+  import EitherWithToOption._
+
+  def pactToJsonString(pact: Pact): String = {
+
+    val interactions: Vector[Json] =
+      pact.interactions.toVector
+        .map { i =>
+
+          val maybeRequestBody = i.request.body.flatMap { rb =>
+            parse(rb).toOption.orElse(Option(Json.fromString(rb)))
+          }
+
+          val maybeResponseBody = i.response.body.flatMap { rb =>
+           parse(rb).toOption.orElse(Option(Json.fromString(rb)))
+          }
+
+          val bodilessInteraction = i.copy(
+            request = i.request.copy(body = None),
+            response = i.response.copy(body = None)
+          ).asJson
+
+          val withRequestBody = {
+            for {
+              requestBody <- maybeRequestBody
+              bodyField = bodilessInteraction.hcursor.downField("request").downField("body")
+              updated <- Option(bodyField.set(requestBody))
+            } yield updated.top
+          } match {
+            case ok @ Some(_) => ok.flatten
+            case None => Option(bodilessInteraction) // There wasn't a body, but there was still an interaction.
+          }
+
+          val withResponseBody = {
+            maybeResponseBody.map { responseBody =>
+              withRequestBody
+                .flatMap { j =>
+                  j.hcursor.downField("response").downField("body").set(responseBody).top
+                }
+            }
+          } match {
+            case ok @ Some(_) => ok.flatten
+            case None => withRequestBody // There wasn't a body, but there was still an interaction.
+          }
+
+          withResponseBody
+        }.collect { case Some(s) => s }
+
+    val json: Option[Json] =
+      pact.copy(interactions = Nil)
+        .asJson
+        .hcursor
+        .downField("interactions")
+        .withFocus(_.withArray(_ => interactions.asJson))
+        .top
+
+    // I don't believe you can ever see this exception.
+    json
+      .getOrElse(throw new Exception("Something went really wrong serialising the following pact into json: " + pact.renderAsString))
+      .pretty(Printer.spaces2.copy(dropNullValues = true))
+  }
+
+}

--- a/scalapact-circe-0-9/src/test/scala/com/itv/scalapact/shared/pact/PactFileExamples.scala
+++ b/scalapact-circe-0-9/src/test/scala/com/itv/scalapact/shared/pact/PactFileExamples.scala
@@ -1,0 +1,284 @@
+package com.itv.scalapact.shared.pact
+
+import com.itv.scalapact.shared._
+
+object PactFileExamples {
+
+  val verySimple = Pact(
+    consumer = PactActor("consumer"),
+    provider = PactActor("provider"),
+    interactions = List(
+      Interaction(
+        provider_state = None,
+        providerState = None,
+        description = "a simple request",
+        request = InteractionRequest(
+          method = Option("GET"),
+          path = Option("/"),
+          query = None,
+          headers = None,
+          body = None,
+          matchingRules = None
+        ),
+        response = InteractionResponse(
+          status = Option(200),
+          headers = None,
+          body = Option("""Hello"""),
+          None
+        )
+      )
+    )
+  )
+
+  val verySimpleAsString: String =
+    """{
+      |  "provider" : {
+      |    "name" : "provider"
+      |  },
+      |  "consumer" : {
+      |    "name" : "consumer"
+      |  },
+      |  "interactions" : [
+      |    {
+      |      "description" : "a simple request",
+      |      "request" : {
+      |        "method" : "GET",
+      |        "path" : "/"
+      |      },
+      |      "response" : {
+      |        "status" : 200,
+      |        "body" : "Hello"
+      |      }
+      |    }
+      |  ]
+      |}""".stripMargin
+
+  val simple = Pact(
+    consumer = PactActor("consumer"),
+    provider = PactActor("provider"),
+    interactions = List(
+      Interaction(
+        provider_state = None,
+        providerState = Option("a simple state"),
+        description = "a simple request",
+        request = InteractionRequest(
+          method = Option("GET"),
+          path = Option("/fetch-json"),
+          query = Option("fish=chips"),
+          headers = Option(Map("Content-Type" -> "text/plain")),
+          body = Option("""fish"""),
+          matchingRules = Option(
+            Map(
+              "$.headers.Accept" -> MatchingRule(`match` = Option("regex"), regex = Option("\\w+"), min = None),
+              "$.headers.Content-Length" -> MatchingRule(`match` = Option("type"), regex = None, min = None)
+            )
+          )
+        ),
+        response = InteractionResponse(
+          status = Option(200),
+          headers = Option(Map("Content-Type" -> "application/json")),
+          body = Option(
+            """{
+              |  "fish" : [
+              |    "cod",
+              |    "haddock",
+              |    "flying"
+              |  ]
+              |}""".stripMargin),
+          matchingRules = Option(
+            Map(
+              "$.headers.Accept" -> MatchingRule(`match` = Option("regex"), regex = Option("\\w+"), min = None),
+              "$.headers.Content-Length" -> MatchingRule(`match` = Option("type"), regex = None, min = None)
+            )
+          )
+        )
+      ),
+      Interaction(
+        provider_state = None,
+        providerState = Option("a simple state 2"),
+        description = "a simple request 2",
+        request = InteractionRequest(
+          method = Option("GET"),
+          path = Option("/fetch-json2"),
+          query = None,
+          headers = Option(Map("Content-Type" -> "text/plain")),
+          body = Option("""fish"""),
+          matchingRules = None
+        ),
+        response = InteractionResponse(
+          status = Option(200),
+          headers = Option(Map("Content-Type" -> "application/json")),
+          body = Option(
+            """{
+              |  "chips" : true,
+              |  "fish" : [
+              |    "cod",
+              |    "haddock"
+              |  ]
+              |}""".stripMargin),
+          matchingRules = None
+        )
+      )
+    )
+  )
+
+  val simpleAsString: String = """{
+                         |  "provider" : {
+                         |    "name" : "provider"
+                         |  },
+                         |  "consumer" : {
+                         |    "name" : "consumer"
+                         |  },
+                         |  "interactions" : [
+                         |    {
+                         |      "providerState" : "a simple state",
+                         |      "description" : "a simple request",
+                         |      "request" : {
+                         |        "method" : "GET",
+                         |        "path" : "/fetch-json",
+                         |        "query" : "fish=chips",
+                         |        "headers" : {
+                         |          "Content-Type" : "text/plain"
+                         |        },
+                         |        "body" : "fish",
+                         |        "matchingRules" : {
+                         |          "$.headers.Accept" : {
+                         |            "match" : "regex",
+                         |            "regex" : "\\w+"
+                         |          },
+                         |          "$.headers.Content-Length" : {
+                         |            "match" : "type"
+                         |          }
+                         |        }
+                         |      },
+                         |      "response" : {
+                         |        "status" : 200,
+                         |        "headers" : {
+                         |          "Content-Type" : "application/json"
+                         |        },
+                         |        "body" : {
+                         |          "fish" : [
+                         |            "cod",
+                         |            "haddock",
+                         |            "flying"
+                         |          ]
+                         |        },
+                         |        "matchingRules" : {
+                         |          "$.headers.Accept" : {
+                         |            "match" : "regex",
+                         |            "regex" : "\\w+"
+                         |          },
+                         |          "$.headers.Content-Length" : {
+                         |            "match" : "type"
+                         |          }
+                         |        }
+                         |      }
+                         |    },
+                         |    {
+                         |      "providerState" : "a simple state 2",
+                         |      "description" : "a simple request 2",
+                         |      "request" : {
+                         |        "method" : "GET",
+                         |        "path" : "/fetch-json2",
+                         |        "headers" : {
+                         |          "Content-Type" : "text/plain"
+                         |        },
+                         |        "body" : "fish"
+                         |      },
+                         |      "response" : {
+                         |        "status" : 200,
+                         |        "headers" : {
+                         |          "Content-Type" : "application/json"
+                         |        },
+                         |        "body" : {
+                         |          "chips" : true,
+                         |          "fish" : [
+                         |            "cod",
+                         |            "haddock"
+                         |          ]
+                         |        }
+                         |      }
+                         |    }
+                         |  ]
+                         |}""".stripMargin
+
+  val simpleOldProviderStateAsString: String = """{
+                                 |  "provider" : {
+                                 |    "name" : "provider"
+                                 |  },
+                                 |  "consumer" : {
+                                 |    "name" : "consumer"
+                                 |  },
+                                 |  "interactions" : [
+                                 |    {
+                                 |      "provider_state" : "a simple state",
+                                 |      "description" : "a simple request",
+                                 |      "request" : {
+                                 |        "method" : "GET",
+                                 |        "path" : "/fetch-json",
+                                 |        "body" : "fish",
+                                 |        "query" : "fish=chips",
+                                 |        "headers" : {
+                                 |          "Content-Type" : "text/plain"
+                                 |        },
+                                 |        "matchingRules" : {
+                                 |          "$.headers.Accept" : {
+                                 |            "match" : "regex",
+                                 |            "regex" : "\\w+"
+                                 |          },
+                                 |          "$.headers.Content-Length" : {
+                                 |            "match" : "type"
+                                 |          }
+                                 |        }
+                                 |      },
+                                 |      "response" : {
+                                 |        "status" : 200,
+                                 |        "headers" : {
+                                 |          "Content-Type" : "application/json"
+                                 |        },
+                                 |        "body" : {
+                                 |          "fish" : [
+                                 |            "cod",
+                                 |            "haddock",
+                                 |            "flying"
+                                 |          ]
+                                 |        },
+                                 |        "matchingRules" : {
+                                 |          "$.headers.Accept" : {
+                                 |            "match" : "regex",
+                                 |            "regex" : "\\w+"
+                                 |          },
+                                 |          "$.headers.Content-Length" : {
+                                 |            "match" : "type"
+                                 |          }
+                                 |        }
+                                 |      }
+                                 |    },
+                                 |    {
+                                 |      "provider_state" : "a simple state 2",
+                                 |      "description" : "a simple request 2",
+                                 |      "request" : {
+                                 |        "method" : "GET",
+                                 |        "path" : "/fetch-json2",
+                                 |        "body" : "fish",
+                                 |        "headers" : {
+                                 |          "Content-Type" : "text/plain"
+                                 |        }
+                                 |      },
+                                 |      "response" : {
+                                 |        "status" : 200,
+                                 |        "headers" : {
+                                 |          "Content-Type" : "application/json"
+                                 |        },
+                                 |        "body" : {
+                                 |          "chips" : true,
+                                 |          "fish" : [
+                                 |            "cod",
+                                 |            "haddock"
+                                 |          ]
+                                 |        }
+                                 |      }
+                                 |    }
+                                 |  ]
+                                 |}""".stripMargin
+}

--- a/scalapact-circe-0-9/src/test/scala/com/itv/scalapact/shared/pact/RubyJsonHelperSpec.scala
+++ b/scalapact-circe-0-9/src/test/scala/com/itv/scalapact/shared/pact/RubyJsonHelperSpec.scala
@@ -1,0 +1,103 @@
+package com.itv.scalapact.shared.pact
+
+import com.itv.scalapact.shared._
+import org.scalatest.{FunSpec, Matchers}
+
+class RubyJsonHelperSpec extends FunSpec with Matchers {
+
+  describe("Handling ruby json") {
+
+    it("should be able to extract the provider") {
+
+      JsonBodySpecialCaseHelper.extractPactActor("provider")(PactFileExamples.simpleAsString) shouldEqual Some(PactActor("provider"))
+
+    }
+
+    it("should be able to extract the consumer") {
+
+      JsonBodySpecialCaseHelper.extractPactActor("consumer")(PactFileExamples.simpleAsString) shouldEqual Some(PactActor("consumer"))
+
+    }
+
+    it("should be able to extract a list of interactions paired with their bodies") {
+
+      val interaction1 = Interaction(
+        provider_state = None,
+        providerState = Option("a simple state"),
+        description = "a simple request",
+        request = InteractionRequest(
+          method = Option("GET"),
+          path = Option("/fetch-json"),
+          query = Option("fish=chips"),
+          headers = Option(Map("Content-Type" -> "text/plain")),
+          body = None,
+          matchingRules = Option(
+            Map(
+              "$.headers.Accept" -> MatchingRule(`match` = Option("regex"), regex = Option("\\w+"), min = None),
+              "$.headers.Content-Length" -> MatchingRule(`match` = Option("type"), regex = None, min = None)
+            )
+          )
+        ),
+        response = InteractionResponse(
+          status = Option(200),
+          headers = Option(Map("Content-Type" -> "application/json")),
+          body = None,
+          matchingRules = Option(
+            Map(
+              "$.headers.Accept" -> MatchingRule(`match` = Option("regex"), regex = Option("\\w+"), min = None),
+              "$.headers.Content-Length" -> MatchingRule(`match` = Option("type"), regex = None, min = None)
+            )
+          )
+        )
+      )
+      val interaction1RequestBody = Option("fish")
+      val interaction1ResponseBody = Option(
+        """{
+          |  "fish" : [
+          |    "cod",
+          |    "haddock",
+          |    "flying"
+          |  ]
+          |}""".stripMargin)
+
+      val interaction2 = Interaction(
+        provider_state = None,
+        providerState = Option("a simple state 2"),
+        description = "a simple request 2",
+        request = InteractionRequest(
+          method = Option("GET"),
+          path = Option("/fetch-json2"),
+          query = None,
+          headers = Option(Map("Content-Type" -> "text/plain")),
+          body = None,
+          matchingRules = None
+        ),
+        response = InteractionResponse(
+          status = Option(200),
+          headers = Option(Map("Content-Type" -> "application/json")),
+          body = None,
+          matchingRules = None
+        )
+      )
+      val interaction2RequestBody = Option("fish")
+      val interaction2ResponseBody = Option(
+        """{
+          |  "chips" : true,
+          |  "fish" : [
+          |    "cod",
+          |    "haddock"
+          |  ]
+          |}""".stripMargin)
+
+      val list = List(
+        (Some(interaction1), interaction1RequestBody, interaction1ResponseBody),
+        (Some(interaction2), interaction2RequestBody, interaction2ResponseBody)
+      )
+
+      JsonBodySpecialCaseHelper.extractInteractions(PactFileExamples.simpleAsString) shouldEqual Some(list)
+
+    }
+
+  }
+
+}

--- a/scalapact-circe-0-9/src/test/scala/com/itv/scalapact/shared/pact/ScalaPactReaderWriterSpec.scala
+++ b/scalapact-circe-0-9/src/test/scala/com/itv/scalapact/shared/pact/ScalaPactReaderWriterSpec.scala
@@ -1,0 +1,95 @@
+package com.itv.scalapact.shared.pact
+
+import io.circe.parser._
+import org.scalatest.{FunSpec, Matchers}
+
+class ScalaPactReaderWriterSpec extends FunSpec with Matchers {
+
+  //Used by earlier scala versions
+  import EitherWithToOption._
+
+  describe("Reading and writing a homogeneous Pact files") {
+
+    it("should be able to read Pact files") {
+      val pactEither = PactReader.jsonStringToPact(PactFileExamples.simpleAsString)
+
+      pactEither.right.get shouldEqual PactFileExamples.simple
+    }
+
+    it("should be able to read Pact files using the old provider state key") {
+      val pactEither = PactReader.jsonStringToPact(PactFileExamples.simpleOldProviderStateAsString)
+
+      pactEither.right.get shouldEqual PactFileExamples.simple
+    }
+
+    it("should be able to write Pact files") {
+
+      val written = PactWriter.pactToJsonString(PactFileExamples.simple)
+
+      val expected = PactFileExamples.simpleAsString
+
+      parse(written).toOption.get shouldEqual parse(expected).toOption.get
+    }
+
+    it("should be able to eat it's own dog food") {
+
+      val json = PactWriter.pactToJsonString(PactFileExamples.simple)
+
+      val pact = PactReader.jsonStringToPact(json).right.get
+
+      val `reJson'd` = parse(PactWriter.pactToJsonString(pact)).toOption.get
+
+      `reJson'd` shouldEqual parse(PactFileExamples.simpleAsString).toOption.get
+
+      pact shouldEqual PactFileExamples.simple
+
+    }
+
+    it("should be able to read ruby format json") {
+      val pactEither = PactReader.jsonStringToPact(PactFileExamples.simpleAsString)
+
+      pactEither.right.get shouldEqual PactFileExamples.simple
+    }
+
+    it("should be able to write a pact file in ruby format") {
+
+      val written = PactWriter.pactToJsonString(PactFileExamples.simple)
+
+      val expected = PactFileExamples.simpleAsString
+
+      written shouldEqual expected
+
+    }
+
+    it("should be able to eat it's own dog food with no body") {
+
+      val json = PactWriter.pactToJsonString(PactFileExamples.verySimple)
+
+      val pact = PactReader.jsonStringToPact(json).right.get
+
+      val `reJson'd` = parse(PactWriter.pactToJsonString(pact)).toOption.get
+
+      `reJson'd` shouldEqual parse(PactFileExamples.verySimpleAsString).toOption.get
+
+      pact shouldEqual PactFileExamples.verySimple
+
+    }
+
+    it("should be able to read ruby format json with no body") {
+      val pactEither = PactReader.jsonStringToPact(PactFileExamples.verySimpleAsString)
+
+      pactEither.right.get shouldEqual PactFileExamples.verySimple
+    }
+
+    it("should be able to write a pact file in ruby format with no body") {
+
+      val written = PactWriter.pactToJsonString(PactFileExamples.verySimple)
+
+      val expected = PactFileExamples.verySimpleAsString
+
+      parse(written).toOption.get shouldEqual parse(expected).toOption.get
+    }
+
+  }
+
+}

--- a/scalapact-http4s-0-18-0/build.sbt
+++ b/scalapact-http4s-0-18-0/build.sbt
@@ -1,0 +1,12 @@
+name := "scalapact-http4s-0-18-0"
+
+lazy val http4sVersion = "0.18.0-M4"
+
+libraryDependencies ++= Seq(
+  "org.http4s" %% "http4s-blaze-server" % http4sVersion,
+  "org.http4s" %% "http4s-blaze-client" % http4sVersion,
+  "org.http4s" %% "http4s-dsl"          % http4sVersion,
+//  "org.log4s"  %% "log4s"               % "1.3.3" force(),
+  "com.github.tomakehurst" % "wiremock" % "1.56" % "test"
+)
+

--- a/scalapact-http4s-0-18-0/src/main/scala/com/itv/scalapact/shared/http/Http4sClientHelper.scala
+++ b/scalapact-http4s-0-18-0/src/main/scala/com/itv/scalapact/shared/http/Http4sClientHelper.scala
@@ -1,0 +1,45 @@
+package com.itv.scalapact.shared.http
+
+import java.util.concurrent.Executors
+
+import cats.effect.IO
+import com.itv.scalapact.shared.{SimpleRequest, SimpleResponse}
+import org.http4s.client.Client
+import org.http4s.client.blaze.{BlazeClientConfig, PooledHttp1Client}
+import org.http4s.headers.{AgentProduct, `User-Agent`}
+import org.http4s._
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+
+object Http4sClientHelper {
+
+  import HeaderImplicitConversions._
+  import com.itv.scalapact.shared.RightBiasEither._
+
+  private[http] implicit val executionContext: ExecutionContext = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(2))
+
+  private def blazeClientConfig(clientTimeout: Duration): BlazeClientConfig = BlazeClientConfig.defaultConfig.copy(
+    requestTimeout = clientTimeout,
+    userAgent = Option(`User-Agent`(AgentProduct("scala-pact", Option(BuildInfo.version)))),
+    checkEndpointIdentification = false
+  )
+
+  private val extractResponse: Response[IO] => IO[SimpleResponse] = r =>
+    r.bodyAsText.runLog.map(_.mkString).map { b => SimpleResponse(r.status.code, r.headers, Some(b)) }
+
+  def defaultClient: Client[IO] =
+    buildPooledBlazeHttpClient(1, Duration(1, SECONDS))
+
+  def buildPooledBlazeHttpClient(maxTotalConnections: Int, clientTimeout: Duration): Client[IO] =
+    PooledHttp1Client[IO](maxTotalConnections = maxTotalConnections, config = blazeClientConfig(clientTimeout))
+
+  val doRequest: (SimpleRequest, Client[IO]) => IO[SimpleResponse] = (request, httpClient) =>
+    for {
+      request  <- Http4sRequestResponseFactory.buildRequest(request)
+      //FIXME: this doesn't type check!
+      response <- httpClient.fetch[SimpleResponse](request)(extractResponse)
+      _        <- httpClient.shutdown
+    } yield response
+
+}

--- a/scalapact-http4s-0-18-0/src/main/scala/com/itv/scalapact/shared/http/Http4sClientHelper.scala
+++ b/scalapact-http4s-0-18-0/src/main/scala/com/itv/scalapact/shared/http/Http4sClientHelper.scala
@@ -37,7 +37,6 @@ object Http4sClientHelper {
   val doRequest: (SimpleRequest, Client[IO]) => IO[SimpleResponse] = (request, httpClient) =>
     for {
       request  <- Http4sRequestResponseFactory.buildRequest(request)
-      //FIXME: this doesn't type check!
       response <- httpClient.fetch[SimpleResponse](request)(extractResponse)
       _        <- httpClient.shutdown
     } yield response

--- a/scalapact-http4s-0-18-0/src/main/scala/com/itv/scalapact/shared/http/Http4sRequestResponseFactory.scala
+++ b/scalapact-http4s-0-18-0/src/main/scala/com/itv/scalapact/shared/http/Http4sRequestResponseFactory.scala
@@ -1,0 +1,106 @@
+package com.itv.scalapact.shared.http
+
+import java.nio.charset.StandardCharsets
+
+import cats.effect.IO
+import com.itv.scalapact.shared.{HttpMethod, SimpleRequest}
+import com.itv.scalapact.shared.HttpMethod._
+import fs2.Chunk
+import org.http4s._
+import scodec.bits.ByteVector
+
+object Http4sRequestResponseFactory {
+
+  import HeaderImplicitConversions._
+  import com.itv.scalapact.shared.RightBiasEither._
+
+  implicit def toIO[A <: Throwable, B](a: Either[A, B]): IO[B] = a.fold(IO.raiseError, IO.pure)
+
+  private val stringToByteVector: String => Chunk[Byte] = str => {
+    Chunk.bytes(ByteVector(str.getBytes(StandardCharsets.UTF_8)).toArray)
+  }
+
+  def buildUri(baseUrl: String, endpoint: String): IO[Uri] =
+    Uri.fromString(baseUrl + endpoint).leftMap(l => new Exception(l.message))
+
+  def intToStatus(status: IntAndReason): ParseResult[Status] =
+    status match {
+      case IntAndReason(code, Some(reason)) =>
+        Status.fromIntAndReason(code, reason)
+
+      case IntAndReason(code, None) =>
+        Status.fromInt(code)
+    }
+
+  def httpMethodToMethod(httpMethod: HttpMethod): Method =
+    httpMethod match {
+      case GET =>
+        Method.GET
+
+      case POST =>
+        Method.POST
+
+      case PUT =>
+        Method.PUT
+
+      case DELETE =>
+        Method.DELETE
+
+      case OPTIONS =>
+        Method.OPTIONS
+    }
+
+  def buildRequest(request: SimpleRequest): IO[Request[IO]] =
+    buildUri(request.baseUrl, request.endPoint).flatMap { uri =>
+      val r = Request[IO](
+        method = httpMethodToMethod(request.method),
+        uri = uri,
+        httpVersion = HttpVersion.`HTTP/1.1`,
+        headers = request.headers,
+        body = EmptyBody,
+        attributes = AttributeMap.empty
+      )
+
+      request.body.map { b =>
+        implicit val enc: EntityEncoder[IO, String] =
+          EntityEncoder.simple[IO, String]()(stringToByteVector)
+
+        r.withBody(b)
+      }.getOrElse(IO(r))
+    }
+
+  def buildResponse(status: IntAndReason, headers: Map[String, String], body: Option[String]): IO[Response[IO]] =
+    intToStatus(status) match {
+      case Left(l) =>
+        l.toHttpResponse(HttpVersion.`HTTP/1.1`)
+
+      case Right(code) =>
+        val response = Response[IO](
+          status = code,
+          httpVersion = HttpVersion.`HTTP/1.1`,
+          headers = headers,
+          body = EmptyBody,
+          attributes = AttributeMap.empty
+        )
+
+        body.map { b =>
+          implicit val enc: EntityEncoder[IO, String] =
+            EntityEncoder.simple[IO, String]()(stringToByteVector)
+          response.withBody(b)
+        }.getOrElse(IO(response))
+    }
+
+}
+
+object HeaderImplicitConversions {
+  implicit def mapToHeaderList(headerMap: Map[String, String]): Headers =
+    Headers(headerMap.toList.map(t => Header(t._1, t._2)))
+
+  implicit def headerListToMap(headers: Headers): Map[String, String] =
+    headers.toList.map(h => Header.unapply(h)).collect { case Some(h) => (h._1.toString, h._2) }.toMap
+
+  implicit def headerListToMaybeMap(headers: Headers): Option[Map[String, String]] =
+    Option(headerListToMap(headers))
+}
+
+case class IntAndReason(code: Int, reason: Option[String])

--- a/scalapact-http4s-0-18-0/src/main/scala/com/itv/scalapact/shared/http/ScalaPactHttpClient.scala
+++ b/scalapact-http4s-0-18-0/src/main/scala/com/itv/scalapact/shared/http/ScalaPactHttpClient.scala
@@ -1,0 +1,45 @@
+package com.itv.scalapact.shared.http
+
+import cats.effect.IO
+import com.itv.scalapact.shared._
+import org.http4s.client.Client
+
+import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
+import scala.language.{implicitConversions, postfixOps}
+
+object ScalaPactHttpClient extends IScalaPactHttpClient {
+
+  private val maxTotalConnections: Int = 1
+
+  private implicit val executionContext: ExecutionContext = Http4sClientHelper.executionContext
+
+  def doRequest(simpleRequest: SimpleRequest): Future[SimpleResponse] =
+    doRequestIO(Http4sClientHelper.doRequest, simpleRequest).unsafeToFuture()
+
+  def doInteractionRequest(url: String, ir: InteractionRequest, clientTimeout: Duration): Future[InteractionResponse] =
+    doInteractionRequestIO(Http4sClientHelper.doRequest, url, ir, clientTimeout).unsafeToFuture()
+
+  def doRequestSync(simpleRequest: SimpleRequest): Either[Throwable, SimpleResponse] =
+    doRequestIO(Http4sClientHelper.doRequest, simpleRequest).attempt.unsafeRunSync()
+
+  def doInteractionRequestSync(url: String, ir: InteractionRequest, clientTimeout: Duration): Either[Throwable, InteractionResponse] =
+    doInteractionRequestIO(Http4sClientHelper.doRequest, url, ir, clientTimeout).attempt.unsafeRunSync()
+
+  def doRequestIO(performRequest: (SimpleRequest, Client[IO]) => IO[SimpleResponse], simpleRequest: SimpleRequest): IO[SimpleResponse] =
+    performRequest(simpleRequest, Http4sClientHelper.buildPooledBlazeHttpClient(maxTotalConnections, 2.seconds))
+
+  def doInteractionRequestIO(performRequest: (SimpleRequest, Client[IO]) => IO[SimpleResponse], url: String, ir: InteractionRequest, clientTimeout: Duration): IO[InteractionResponse] =
+    performRequest(
+      SimpleRequest( url, ir.path.getOrElse("") + ir.query.map(q => s"?$q").getOrElse(""), HttpMethod.maybeMethodToMethod(ir.method), ir.headers.getOrElse(Map.empty[String, String]), ir.body),
+      Http4sClientHelper.buildPooledBlazeHttpClient(maxTotalConnections, clientTimeout)
+    ).map { r =>
+      InteractionResponse(
+        status = Option(r.statusCode),
+        headers = if(r.headers.isEmpty) None else Option(r.headers.map(p => p._1 -> p._2.mkString)),
+        body = r.body,
+        matchingRules = None
+      )
+    }
+
+}

--- a/scalapact-http4s-0-18-0/src/test/scala/com/itv/scalapact/shared/http/Http4sClientHelperSpec.scala
+++ b/scalapact-http4s-0-18-0/src/test/scala/com/itv/scalapact/shared/http/Http4sClientHelperSpec.scala
@@ -1,0 +1,45 @@
+package com.itv.scalapact.shared.http
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration._
+import com.itv.scalapact.shared.{HttpMethod, SimpleRequest}
+import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
+
+class Http4sClientHelperSpec extends FunSpec with Matchers with BeforeAndAfterAll {
+
+  val wireMockServer = new WireMockServer(wireMockConfig().port(1234))
+
+  override def beforeAll(): Unit = {
+
+    wireMockServer.start()
+
+    WireMock.configureFor("localhost", 1234)
+
+    val response = aResponse().withStatus(200).withBody("Success").withHeader("foo", "bar")
+
+    wireMockServer.stubFor(
+      get(urlEqualTo("/test")).willReturn(response)
+    )
+
+  }
+
+  override def afterAll(): Unit = {
+    wireMockServer.stop()
+  }
+
+  describe("Making an HTTP request") {
+
+    it("should be able to make a simple request") {
+      val request = SimpleRequest("http://localhost:1234", "/test", HttpMethod.GET)
+      val response = Http4sClientHelper.doRequest(request, Http4sClientHelper.defaultClient).unsafeRunSync()
+
+      response.statusCode shouldEqual 200
+      response.body.get shouldEqual "Success"
+      response.headers.exists(_ == ("foo" -> "bar")) shouldEqual true
+    }
+
+  }
+
+}

--- a/scalapact-http4s-0-18-0/src/test/scala/com/itv/scalapact/shared/http/Http4sRequestResponseFactorySpec.scala
+++ b/scalapact-http4s-0-18-0/src/test/scala/com/itv/scalapact/shared/http/Http4sRequestResponseFactorySpec.scala
@@ -1,0 +1,50 @@
+package com.itv.scalapact.shared.http
+
+import com.itv.scalapact.shared.{HttpMethod, SimpleRequest}
+import org.scalatest.{FunSpec, Matchers}
+
+
+class Http4sRequestResponseFactorySpec extends FunSpec with Matchers {
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  describe("Creating Http4s requests and responses") {
+
+    it("should be able to manufacture a good request") {
+
+      val simpleRequest = SimpleRequest(
+        "http://localhost:8080",
+        "/foo",
+        HttpMethod.POST,
+        Map(
+          "Accept" -> "application/json",
+          "Content-Type" -> "test/plain"
+        ),
+        Some("Greetings!")
+      )
+
+      val request = Http4sRequestResponseFactory.buildRequest(simpleRequest).unsafeRunSync()
+
+      request.method.name shouldEqual "POST"
+      request.pathInfo.contains("foo") shouldEqual true
+      request.bodyAsText.runLog.unsafeRunSync().mkString shouldEqual "Greetings!"
+
+    }
+
+    it("should be able to manufacture a good response") {
+
+      val response = Http4sRequestResponseFactory.buildResponse(
+        IntAndReason(404, Some("Not Found")),
+        Map(
+          "Content-Type" -> "test/plain"
+        ),
+        Some("Missing")
+      ).unsafeRunSync()
+
+      response.status.code shouldEqual 404
+      response.bodyAsText.runLog.unsafeRunSync().mkString shouldEqual "Missing"
+
+    }
+
+  }
+
+}

--- a/scalapact-http4s-0-18-0/src/test/scala/com/itv/scalapact/shared/http/ScalaPactHttpClientSpec.scala
+++ b/scalapact-http4s-0-18-0/src/test/scala/com/itv/scalapact/shared/http/ScalaPactHttpClientSpec.scala
@@ -1,0 +1,39 @@
+package com.itv.scalapact.shared.http
+
+import com.itv.scalapact.shared._
+import org.http4s.client.Client
+import org.scalatest.{FunSpec, Matchers}
+import cats.effect.IO
+
+import scala.concurrent.duration._
+
+class ScalaPactHttpClientSpec extends FunSpec with Matchers {
+
+  describe("Making an interaction request") {
+
+    it("should be able to make and interaction request and get an interaction response") {
+
+      val requestDetails = InteractionRequest(
+        method = Some("GET"),
+        headers = None,
+        query = None,
+        path = Some("/foo"),
+        body = None,
+        matchingRules = None
+      )
+
+      val responseDetails = InteractionResponse(
+        status = Some(200),
+        headers = None,
+        body = None,
+        matchingRules = None
+      )
+
+      val fakeCaller: (SimpleRequest, Client[IO]) => IO[SimpleResponse] = (_, _) => IO.pure(SimpleResponse(200))
+
+      val result = ScalaPactHttpClient.doInteractionRequestIO(fakeCaller, "", requestDetails, 1.second).unsafeRunSync()
+
+      result shouldEqual responseDetails
+    }
+  }
+}

--- a/scripts/localpublish-libs.sh
+++ b/scripts/localpublish-libs.sh
@@ -78,6 +78,14 @@ echo ">>> Http4s 0.17.0 (2.12)"
 crossPublishLocal "http4s0170_2_12"
 
 echo ""
+echo ">>> Http4s 0.18.0 (2.11)"
+crossPublishLocal "http4s0180_2_11"
+
+echo ""
+echo ">>> Http4s 0.18.0 (2.12)"
+crossPublishLocal "http4s0180_2_12"
+
+echo ""
 echo ">>> Argonaut 6.1 (2.10)"
 crossPublishLocal "argonaut61_2_10"
 
@@ -115,3 +123,11 @@ crossPublishLocal "circe08_2_11"
 echo ""
 echo ">>> Circe 0.8.0 (2.12)"
 crossPublishLocal "circe08_2_12"
+
+echo ""
+echo ">>> Circe 0.9.0 (2.11)"
+crossPublishLocal "circe09_2_11"
+
+echo ""
+echo ">>> Circe 0.9.0 (2.12)"
+crossPublishLocal "circe09_2_12"

--- a/scripts/release-stage1-libs.sh
+++ b/scripts/release-stage1-libs.sh
@@ -78,6 +78,14 @@ echo ">>> Http4s 0.17.0 (2.12)"
 crossPublishReal "http4s0170_2_12"
 
 echo ""
+echo ">>> Http4s 0.18.0 (2.11)"
+crossPublishReal "http4s0180_2_11"
+
+echo ""
+echo ">>> Http4s 0.18.0 (2.12)"
+crossPublishReal "http4s0180_2_12"
+
+echo ""
 echo ">>> Argonaut 6.1 (2.10)"
 crossPublishReal "argonaut61_2_10"
 
@@ -115,3 +123,11 @@ crossPublishReal "circe08_2_11"
 echo ""
 echo ">>> Circe 0.8.0 (2.12)"
 crossPublishReal "circe08_2_12"
+
+echo ""
+echo ">>> Circe 0.9.0 (2.11)"
+crossPublishReal "circe09_2_11"
+
+echo ""
+echo ">>> Circe 0.9.0 (2.12)"
+crossPublishReal "circe09_2_12"


### PR DESCRIPTION
Create a new module using http4s 0.18.0 m4 and circe 0.9.0-M1. We depend on these libraries in [one of our project](https://github.com/ITV/fulfilmentplanning-orchestrator) and adding support for them will allow us to still use scala pacts. The module for circe-0.9.0-M1 is needed because fs2 (used by http4s 0.18.0) depends on cats 1.0.0. This way we avoid issues with library eviction!  

we have set 2.2.2-SNAPSHOT version and we run bash scripts/local-build-test.sh successfully.