### PR TITLE
Exclude logback.xml and log4j.properties from published jar.

### DIFF
--- a/scalapact-scalatest/build.sbt
+++ b/scalapact-scalatest/build.sbt
@@ -7,3 +7,7 @@ libraryDependencies ++= Seq(
   "com.github.tomakehurst" % "wiremock" % "1.56" % "test",
   "fr.hmil" %% "roshttp" % "2.0.1" % "test"
 )
+
+mappings in (Compile, packageBin) ~= {
+  _.filterNot { case (_, fileName) => fileName == "logback.xml" || fileName == "log4j.properties" }
+}


### PR DESCRIPTION
This should address: https://github.com/ITV/scala-pact/issues/82

There may be a better way of doing this, to future-proof against more files being added to the resources directory, but I'm not sure how to get it working. For example, this lists out the contents of the resources directory.

    show compile:unmanagedResources

Only the scalapact-scalatest folder has these resources.