### PR TITLE
Fix data race due to reuse of the implicit `IPactStubber`.

### DIFF
--- a/scalapact-http4s-0-16a/src/main/scala/com/itv/scalapact/http/http.scala
+++ b/scalapact-http4s-0-16a/src/main/scala/com/itv/scalapact/http/http.scala
@@ -6,7 +6,9 @@ import scalaz.concurrent.Task
 
 package object http {
 
-  implicit val serverInstance: IPactStubber =
+  // Note that we create a new stubber anytime this implicit is needed (i.e. this is a `def`).
+  // We need this because implementations of `IPactStubber` might want to have their own state about the server running.
+  implicit def serverInstance: IPactStubber =
     new PactServer
 
   implicit val scalaPactHttpClient: IScalaPactHttpClient[Task] =

--- a/scalapact-http4s-0-16a/src/main/scala/com/itv/scalapact/http4s16a/package.scala
+++ b/scalapact-http4s-0-16a/src/main/scala/com/itv/scalapact/http4s16a/package.scala
@@ -6,7 +6,9 @@ import scalaz.concurrent.Task
 
 package object http4s16a {
 
-  implicit val serverInstance: IPactStubber =
+  // Note that we create a new stubber anytime this implicit is needed (i.e. this is a `def`).
+  // We need this because implementations of `IPactStubber` might want to have their own state about the server running.
+  implicit def serverInstance: IPactStubber =
     new PactServer
 
   implicit val scalaPactHttpClient: IScalaPactHttpClient[Task] =

--- a/scalapact-http4s-0-17/src/main/scala/com/itv/scalapact/http/http.scala
+++ b/scalapact-http4s-0-17/src/main/scala/com/itv/scalapact/http/http.scala
@@ -6,7 +6,9 @@ import fs2.Task
 
 package object http {
 
-  implicit val serverInstance: IPactStubber =
+  // Note that we create a new stubber anytime this implicit is needed (i.e. this is a `def`).
+  // We need this because implementations of `IPactStubber` might want to have their own state about the server running.
+  implicit def serverInstance: IPactStubber =
     new PactServer
 
   implicit val scalaPactHttpClient: IScalaPactHttpClient[Task] =

--- a/scalapact-http4s-0-17/src/main/scala/com/itv/scalapact/http4s17/package.scala
+++ b/scalapact-http4s-0-17/src/main/scala/com/itv/scalapact/http4s17/package.scala
@@ -6,7 +6,9 @@ import fs2.Task
 
 package object http4s17 {
 
-  implicit val serverInstance: IPactStubber =
+  // Note that we create a new stubber anytime this implicit is needed (i.e. this is a `def`).
+  // We need this because implementations of `IPactStubber` might want to have their own state about the server running.
+  implicit def serverInstance: IPactStubber =
     new PactServer
 
   implicit val scalaPactHttpClient: IScalaPactHttpClient[Task] =

--- a/scalapact-http4s-0-18/src/main/scala/com/itv/scalapact/http/http.scala
+++ b/scalapact-http4s-0-18/src/main/scala/com/itv/scalapact/http/http.scala
@@ -6,7 +6,9 @@ import com.itv.scalapact.shared.typeclasses.{IPactStubber, IScalaPactHttpClient}
 
 package object http {
 
-  implicit val serverInstance: IPactStubber =
+  // Note that we create a new stubber anytime this implicit is needed (i.e. this is a `def`).
+  // We need this because implementations of `IPactStubber` might want to have their own state about the server running.
+  implicit def serverInstance: IPactStubber =
     new PactServer
 
   implicit val scalaPactHttpClient: IScalaPactHttpClient[IO] =

--- a/scalapact-http4s-0-18/src/main/scala/com/itv/scalapact/http4s18/package.scala
+++ b/scalapact-http4s-0-18/src/main/scala/com/itv/scalapact/http4s18/package.scala
@@ -6,7 +6,9 @@ import com.itv.scalapact.shared.typeclasses.{IPactStubber, IScalaPactHttpClient}
 
 package object http4s18 {
 
-  implicit val serverInstance: IPactStubber =
+  // Note that we create a new stubber anytime this implicit is needed (i.e. this is a `def`).
+  // We need this because implementations of `IPactStubber` might want to have their own state about the server running.
+  implicit def serverInstance: IPactStubber =
     new PactServer
 
   implicit val scalaPactHttpClient: IScalaPactHttpClient[IO] =


### PR DESCRIPTION
The implementations of `IPactStubber` are not thread-safe and therefore the server
instance would be shared among all test threads.