### PR TITLE
Added support for specifying messages as described by PactV3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 val compilerOptions212 = scalacOptions ++= Seq(
-  "-deprecation", // Emit warning and location for usages of deprecated APIs.
+  /*"-deprecation", // Emit warning and location for usages of deprecated APIs.
   "-encoding",
   "utf-8", // Specify character encoding used by source files.
   "-explaintypes", // Explain type errors in more detail.
@@ -42,7 +42,7 @@ val compilerOptions212 = scalacOptions ++= Seq(
   "-Ywarn-unused:imports", // Warn if an import selector is not referenced.
   "-Ywarn-unused:params", // Warn if a value parameter is unused.
   "-Ywarn-unused:patvars", // Warn if a variable bound in a pattern is unused.
-  "-Ywarn-value-discard" // Warn when non-Unit expression results are unused.
+  "-Ywarn-value-discard" // Warn when non-Unit expression results are unused.*/
 
   //TODO: these two flags don't seem to play well with io.circe.generic.auto. Find a way to re-instate them
   //  "-Ywarn-unused:locals", // Warn if a local definition is unused.
@@ -69,7 +69,8 @@ lazy val commonSettings = Seq(
   libraryDependencies ++= Seq(
     "org.scalatest" %% "scalatest" % "3.0.5" % "test"
   ),
-  wartremoverWarnings in (Compile, compile) ++= Warts.allBut(
+  //FIXME: Once contracts and interfaces are stable , add this back
+/*  wartremoverWarnings in (Compile, compile) ++= Warts.allBut(
     Wart.Overloading,
     Wart.FinalCaseClass,
     Wart.ImplicitConversion,
@@ -82,7 +83,7 @@ lazy val commonSettings = Seq(
     Wart.LeakingSealed,
     Wart.Null,
     Wart.Var
-  ),
+  ),*/
   parallelExecution in Test := false,
 //  javaOptions in Test ++= Seq(
 //    "-XX:+UnlockCommercialFeatures", "-XX:+FlightRecorder"

--- a/build.sbt
+++ b/build.sbt
@@ -40,11 +40,13 @@ val compilerOptions212 = scalacOptions ++= Seq(
   "-Ywarn-numeric-widen", // Warn when numerics are widened.
   "-Ywarn-unused:implicits", // Warn if an implicit parameter is unused.
   "-Ywarn-unused:imports", // Warn if an import selector is not referenced.
-  "-Ywarn-unused:locals", // Warn if a local definition is unused.
   "-Ywarn-unused:params", // Warn if a value parameter is unused.
   "-Ywarn-unused:patvars", // Warn if a variable bound in a pattern is unused.
-  "-Ywarn-unused:privates", // Warn if a private member is unused.
   "-Ywarn-value-discard" // Warn when non-Unit expression results are unused.
+
+  //TODO: these two flags don't seem to play well with io.circe.generic.auto. Find a way to re-instate them
+  //  "-Ywarn-unused:locals", // Warn if a local definition is unused.
+  //  "-Ywarn-unused:privates", // Warn if a private member is unused.
 )
 
 addCommandAlias(

--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,7 @@ addCommandAlias(
 )
 
 lazy val commonSettings = Seq(
-  version := "2.3.2-SNAPSHOT",
+  version := "2.3.0-FP1",
   organization := "com.itv",
   scalaVersion := scala212,
   libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 val compilerOptions212 = scalacOptions ++= Seq(
-  /*"-deprecation", // Emit warning and location for usages of deprecated APIs.
+  "-deprecation", // Emit warning and location for usages of deprecated APIs.
   "-encoding",
   "utf-8", // Specify character encoding used by source files.
   "-explaintypes", // Explain type errors in more detail.
@@ -42,7 +42,7 @@ val compilerOptions212 = scalacOptions ++= Seq(
   "-Ywarn-unused:imports", // Warn if an import selector is not referenced.
   "-Ywarn-unused:params", // Warn if a value parameter is unused.
   "-Ywarn-unused:patvars", // Warn if a variable bound in a pattern is unused.
-  "-Ywarn-value-discard" // Warn when non-Unit expression results are unused.*/
+  "-Ywarn-value-discard" // Warn when non-Unit expression results are unused.
 
   //TODO: these two flags don't seem to play well with io.circe.generic.auto. Find a way to re-instate them
   //  "-Ywarn-unused:locals", // Warn if a local definition is unused.
@@ -70,7 +70,7 @@ lazy val commonSettings = Seq(
     "org.scalatest" %% "scalatest" % "3.0.5" % "test"
   ),
   //FIXME: Once contracts and interfaces are stable , add this back
-/*  wartremoverWarnings in (Compile, compile) ++= Warts.allBut(
+  wartremoverWarnings in (Compile, compile) ++= Warts.allBut(
     Wart.Overloading,
     Wart.FinalCaseClass,
     Wart.ImplicitConversion,
@@ -83,7 +83,7 @@ lazy val commonSettings = Seq(
     Wart.LeakingSealed,
     Wart.Null,
     Wart.Var
-  ),*/
+  ),
   parallelExecution in Test := false,
 //  javaOptions in Test ++= Seq(
 //    "-XX:+UnlockCommercialFeatures", "-XX:+FlightRecorder"

--- a/scalapact-argonaut-6-2/src/main/scala/com/itv/scalapact/argonaut62/JsonConversionFunctions.scala
+++ b/scalapact-argonaut-6-2/src/main/scala/com/itv/scalapact/argonaut62/JsonConversionFunctions.scala
@@ -28,9 +28,9 @@ object JsonConversionFunctions extends IJsonConversionFunctions {
         IrNode(label, IrNullNode).withPath(pathToParent)
 
       case j: Json if j.isNumber && j.toString().contains(".") =>
-        irNodeFrom(j.number.flatMap(_.toDouble).map(IrDecimalNode))
+        irNodeFrom(j.number.map(_.toBigDecimal).map(IrDecimalNode))
       case j: Json if j.isNumber =>
-        irNodeFrom(j.number.flatMap(_.toLong).map(IrIntegerNode))
+        irNodeFrom(j.number.flatMap(_.toBigInt).map(IrIntegerNode))
 
       case j: Json if j.isBool =>
         irNodeFrom(j.bool.map(IrBooleanNode))

--- a/scalapact-argonaut-6-2/src/main/scala/com/itv/scalapact/argonaut62/PactImplicits.scala
+++ b/scalapact-argonaut-6-2/src/main/scala/com/itv/scalapact/argonaut62/PactImplicits.scala
@@ -57,7 +57,6 @@ object PactImplicits {
     contents
       .as[String]
       .fold[MessageContentType]((_, _) => MessageContentType.ApplicationJson, _ => MessageContentType.ApplicationText)
-  //TODO it should be simple to support xml
 
   implicit lazy val MessageContentTypeCodecJson: CodecJson[MessageContentType] = CodecJson[MessageContentType](
     x => EncodeJson.StringEncodeJson(x.renderString),

--- a/scalapact-argonaut-6-2/src/main/scala/com/itv/scalapact/argonaut62/PactImplicits.scala
+++ b/scalapact-argonaut-6-2/src/main/scala/com/itv/scalapact/argonaut62/PactImplicits.scala
@@ -20,7 +20,7 @@ object PactImplicits {
   )
 
   private def contents(message: Message): Json = message.contentType match {
-    case ApplicationJson => message.contents.parse.right.get
+    case ApplicationJson => message.contents.value.parse.right.get
     case _               => message.contents.asJson
   }
 

--- a/scalapact-argonaut-6-2/src/main/scala/com/itv/scalapact/argonaut62/PactImplicits.scala
+++ b/scalapact-argonaut-6-2/src/main/scala/com/itv/scalapact/argonaut62/PactImplicits.scala
@@ -39,7 +39,8 @@ object PactImplicits {
         providerState <- (c --\ "providerState").as[Option[String]]
         contents      <- (c --\ "contents").as[Json]
         metadata      <- (c --\ "metaData").as[Map[String, String]]
-      } yield Message(description, providerState, contents.nospaces, metadata, contentType(contents))
+      } yield
+        Message(description, providerState, contents.nospaces, metadata, Map.empty, contentType(contents)) //FIXME: Matching rules should be obtained from the kjson
   )
 
   def contentType(contents: Json): MessageContentType =

--- a/scalapact-argonaut-6-2/src/main/scala/com/itv/scalapact/argonaut62/PactImplicits.scala
+++ b/scalapact-argonaut-6-2/src/main/scala/com/itv/scalapact/argonaut62/PactImplicits.scala
@@ -31,7 +31,11 @@ object PactImplicits {
         "description"   -> message.description.asJson,
         "providerState" -> message.providerState.asJson,
         "contents"      -> contents(message),
-        "metaData"      -> message.metaData.asJson
+        "metaData"      -> message.metaData.asJson,
+        "matchingRules" -> (message.matchingRules match {
+          case mr if mr.nonEmpty => message.matchingRules.asJson
+          case _                 => jNull
+        })
     ),
     c =>
       for {
@@ -39,8 +43,14 @@ object PactImplicits {
         providerState <- (c --\ "providerState").as[Option[String]]
         contents      <- (c --\ "contents").as[Json]
         metadata      <- (c --\ "metaData").as[Map[String, String]]
+        matchingRules <- (c --\ "matchingRules").as[Option[Map[String, MatchingRule]]]
       } yield
-        Message(description, providerState, contents.nospaces, metadata, Map.empty, contentType(contents)) //FIXME: Matching rules should be obtained from the kjson
+        Message(description,
+                providerState,
+                contents.nospaces,
+                metadata,
+                matchingRules.getOrElse(Map.empty),
+                contentType(contents))
   )
 
   def contentType(contents: Json): MessageContentType =

--- a/scalapact-argonaut-6-2/src/main/scala/com/itv/scalapact/argonaut62/PactImplicits.scala
+++ b/scalapact-argonaut-6-2/src/main/scala/com/itv/scalapact/argonaut62/PactImplicits.scala
@@ -17,16 +17,18 @@ object PactImplicits {
     "name"
   )
 
-  implicit lazy val MessageCodecJson: CodecJson[Message] = casecodec5(Message.apply, Message.unapply)(
-    "description",
-    "contentType",
-    "providerState",
-    "content",
-    "meta"
+  implicit lazy val MessageCodecJson: CodecJson[Message] = CodecJson(
+    message => ???, //FIXME Implement it
+    c =>
+      for {
+        description   <- (c --\ "description").as[String]
+        providerState <- (c --\ "providerState").as[Option[String]]
+        contents      <- (c --\ "contents").as[Json].map(_.nospaces)
+        metadata      <- (c --\ "metaData").as[Map[String, String]]
+      } yield Message(description, providerState, contents, metadata)
   )
-
-  implicit lazy val MessageContentTypeCodecJson: CodecJson[MessageContentType] = CodecJson[MessageContentType](x =>
-    EncodeJson.StringEncodeJson(x.renderString),
+  implicit lazy val MessageContentTypeCodecJson: CodecJson[MessageContentType] = CodecJson[MessageContentType](
+    x => EncodeJson.StringEncodeJson(x.renderString),
     _.as[String].map(MessageContentType.apply)
   )
 

--- a/scalapact-argonaut-6-2/src/main/scala/com/itv/scalapact/argonaut62/PactImplicits.scala
+++ b/scalapact-argonaut-6-2/src/main/scala/com/itv/scalapact/argonaut62/PactImplicits.scala
@@ -21,7 +21,7 @@ object PactImplicits {
   )
 
   private def contents(message: Message): Json = message.contentType match {
-    case ApplicationJson => message.contents.value.parse.right.get
+    case ApplicationJson => message.contents.value.parse.fold(_ => Json.jNull, identity)
     case _               => message.contents.asJson
   }
 
@@ -45,9 +45,8 @@ object PactImplicits {
   def contentType(contents: Json): MessageContentType =
     contents
       .as[String]
-      .map(_ => MessageContentType.ApplicationText) //TODO it should be simple to support xml
-      .toOption
-      .getOrElse(MessageContentType.ApplicationJson)
+      .fold[MessageContentType]((_, _) => MessageContentType.ApplicationJson, _ => MessageContentType.ApplicationText)
+  //TODO it should be simple to support xml
 
   implicit lazy val MessageContentTypeCodecJson: CodecJson[MessageContentType] = CodecJson[MessageContentType](
     x => EncodeJson.StringEncodeJson(x.renderString),

--- a/scalapact-argonaut-6-2/src/main/scala/com/itv/scalapact/argonaut62/PactImplicits.scala
+++ b/scalapact-argonaut-6-2/src/main/scala/com/itv/scalapact/argonaut62/PactImplicits.scala
@@ -33,10 +33,10 @@ object PactImplicits {
   implicit lazy val MessageCodecJson: CodecJson[Message] = CodecJson(
     message =>
       Json.obj(
-        "description"   -> message.description.asJson,
-        "providerState" -> message.providerState.asJson,
-        "contents"      -> contents(message),
-        "metaData"      -> message.metaData.asJson,
+        "description"    -> message.description.asJson,
+        "providerStates" -> message.providerStates.asJson,
+        "contents"       -> contents(message),
+        "metaData"       -> message.metaData.asJson,
         "matchingRules" -> (message.matchingRules match {
           case mr if mr.nonEmpty => message.matchingRules.asJson
           case _                 => jNull
@@ -44,14 +44,15 @@ object PactImplicits {
     ),
     c =>
       for {
-        description   <- (c --\ "description").as[String]
-        providerState <- (c --\ "providerState").as[Option[String]]
-        contents      <- (c --\ "contents").as[Json]
-        metadata      <- (c --\ "metaData").as[Map[String, String]]
-        matchingRules <- (c --\ "matchingRules").as[Option[Message.MatchingRules]]
+        description    <- (c --\ "description").as[String]
+        providerState  <- (c --\ "providerState").as[Option[String]].map(_.toList)
+        providerStates <- (c --\ "providerStates").as[Option[List[String]]].map(_.toList.flatten)
+        contents       <- (c --\ "contents").as[Json]
+        metadata       <- (c --\ "metaData").as[Map[String, String]]
+        matchingRules  <- (c --\ "matchingRules").as[Option[Message.MatchingRules]]
       } yield
         Message(description,
-                providerState,
+                providerState ++ providerStates,
                 contents.nospaces,
                 metadata,
                 matchingRules.getOrElse(Map.empty),

--- a/scalapact-argonaut-6-2/src/main/scala/com/itv/scalapact/argonaut62/PactImplicits.scala
+++ b/scalapact-argonaut-6-2/src/main/scala/com/itv/scalapact/argonaut62/PactImplicits.scala
@@ -3,16 +3,31 @@ package com.itv.scalapact.argonaut62
 import argonaut.Argonaut._
 import argonaut._
 import com.itv.scalapact.shared._
+import argonaut._, Argonaut._
 
 object PactImplicits {
-  implicit lazy val PactCodecJson: CodecJson[Pact] = casecodec3(Pact.apply, Pact.unapply)(
+  implicit lazy val PactCodecJson: CodecJson[Pact] = casecodec4(Pact.apply, Pact.unapply)(
     "provider",
     "consumer",
-    "interactions"
+    "interactions",
+    "messages"
   )
 
   implicit lazy val PactActorCodecJson: CodecJson[PactActor] = casecodec1(PactActor.apply, PactActor.unapply)(
     "name"
+  )
+
+  implicit lazy val MessageCodecJson: CodecJson[Message] = casecodec5(Message.apply, Message.unapply)(
+    "description",
+    "contentType",
+    "providerState",
+    "content",
+    "meta"
+  )
+
+  implicit lazy val MessageContentTypeCodecJson: CodecJson[MessageContentType] = CodecJson[MessageContentType](x =>
+    EncodeJson.StringEncodeJson(x.renderString),
+    _.as[String].map(MessageContentType.apply)
   )
 
   implicit lazy val InteractionCodecJson: CodecJson[Interaction] = casecodec5(Interaction.apply, Interaction.unapply)(

--- a/scalapact-argonaut-6-2/src/main/scala/com/itv/scalapact/argonaut62/PactImplicits.scala
+++ b/scalapact-argonaut-6-2/src/main/scala/com/itv/scalapact/argonaut62/PactImplicits.scala
@@ -25,6 +25,11 @@ object PactImplicits {
     case _               => message.contents.asJson
   }
 
+  implicit lazy val MessageMatchersCodecJson: CodecJson[Message.Matchers] =
+    casecodec1(Message.Matchers.apply, Message.Matchers.unapply)(
+      "matchers"
+    )
+
   implicit lazy val MessageCodecJson: CodecJson[Message] = CodecJson(
     message =>
       Json.obj(
@@ -43,7 +48,7 @@ object PactImplicits {
         providerState <- (c --\ "providerState").as[Option[String]]
         contents      <- (c --\ "contents").as[Json]
         metadata      <- (c --\ "metaData").as[Map[String, String]]
-        matchingRules <- (c --\ "matchingRules").as[Option[Map[String, MatchingRule]]]
+        matchingRules <- (c --\ "matchingRules").as[Option[Message.MatchingRules]]
       } yield
         Message(description,
                 providerState,

--- a/scalapact-argonaut-6-2/src/main/scala/com/itv/scalapact/argonaut62/PactReader.scala
+++ b/scalapact-argonaut-6-2/src/main/scala/com/itv/scalapact/argonaut62/PactReader.scala
@@ -58,7 +58,9 @@ object JsonBodySpecialCaseHelper {
     json
       .field("interactions")
       .fold[DecodeResult[JsonArray]](DecodeResult.ok(List.empty[Json]))(
-        _.array.fold[DecodeResult[JsonArray]](DecodeResult.fail("", CursorHistory.empty))(DecodeResult.ok)
+        _.array.fold[DecodeResult[JsonArray]](
+          DecodeResult.fail(s"`interactions` field is not an array: [$json]", CursorHistory.empty)
+        )(DecodeResult.ok)
       )
       .flatMap {
         _.map(parseInteractionTuple)
@@ -104,10 +106,8 @@ object JsonBodySpecialCaseHelper {
       .getOrElse(DecodeResult.ok(None))
   }
 
-  val extractMessages: Json => DecodeResult[List[Message]] = json =>
-    json
-      .field("messages")
-      .fold[DecodeResult[List[Message]]](DecodeResult.ok(List.empty[Message]))(_.as[List[Message]])
+  val extractMessages: Json => DecodeResult[List[Message]] = _.field("messages")
+    .fold[DecodeResult[List[Message]]](DecodeResult.ok(List.empty[Message]))(_.as[List[Message]])
 
   private val makeOptionalBody: Json => Option[String] = {
     case body: Json if body.isString =>

--- a/scalapact-argonaut-6-2/src/main/scala/com/itv/scalapact/argonaut62/PactReader.scala
+++ b/scalapact-argonaut-6-2/src/main/scala/com/itv/scalapact/argonaut62/PactReader.scala
@@ -54,7 +54,7 @@ object JsonBodySpecialCaseHelper {
 
     })
 
-  protected[this] val extractInteractionsTuple: JsonParser[List[InterationTuple]] = json =>
+  protected[argonaut62] val extractInteractionsTuple: JsonParser[List[InterationTuple]] = json =>
     json
       .field("interactions")
       .fold[DecodeResult[JsonArray]](DecodeResult.ok(List.empty[Json]))(

--- a/scalapact-argonaut-6-2/src/main/scala/com/itv/scalapact/argonaut62/PactReader.scala
+++ b/scalapact-argonaut-6-2/src/main/scala/com/itv/scalapact/argonaut62/PactReader.scala
@@ -39,7 +39,7 @@ object JsonBodySpecialCaseHelper {
       json
         .field(field)
         .fold[DecodeResult[PactActor]](DecodeResult.fail(s"field `$field` does not exist", CursorHistory.empty))(
-          _.as[PactActor] //.map(PactActor)
+          _.as[PactActor]
     )
 
   val extractInteractions: JsonParser[List[Interaction]] = json =>

--- a/scalapact-argonaut-6-2/src/main/scala/com/itv/scalapact/argonaut62/PactWriter.scala
+++ b/scalapact-argonaut-6-2/src/main/scala/com/itv/scalapact/argonaut62/PactWriter.scala
@@ -1,6 +1,6 @@
 package com.itv.scalapact.argonaut62
 
-import argonaut.Argonaut._
+import argonaut.Argonaut.{JsonArray, _}
 import argonaut._
 import com.itv.scalapact.shared.Pact
 import com.itv.scalapact.shared.typeclasses.IPactWriter
@@ -66,6 +66,9 @@ class PactWriter extends IPactWriter {
 
     // I don't believe you can ever see this exception.
     json
+      .map(obj => {
+        Json(obj.obj.get.-("messages").toMap.toList: _*) //FIXME Need to return messages when it is required
+      })
       .getOrElse(
         throw new Exception(
           "Something went really wrong serialising the following pact into json: " + pact.renderAsString

--- a/scalapact-argonaut-6-2/src/main/scala/com/itv/scalapact/json/package.scala
+++ b/scalapact-argonaut-6-2/src/main/scala/com/itv/scalapact/json/package.scala
@@ -4,7 +4,7 @@ import argonaut.{Json, Parse}
 import com.itv.scalapact.argonaut62.{PactReader, PactWriter}
 import com.itv.scalapact.shared.MessageContentType
 import com.itv.scalapact.shared.MessageContentType.ApplicationJson
-import com.itv.scalapact.shared.typeclasses.{IMessageFormat, IPactReader, IPactWriter, MessageFormatError}
+import com.itv.scalapact.shared.typeclasses._
 
 package object json {
   implicit val pactReaderInstance: IPactReader =
@@ -20,6 +20,9 @@ package object json {
 
     override def decode(s: String): Either[MessageFormatError, Json] =
       Parse.parse(s).fold(m => Left(MessageFormatError(m)), Right(_))
+  }
+  implicit val inferTypeInstance: IInferTypes[Json] = new IInferTypes[Json] {
+    override protected def inferFrom(t: Json): Map[String, String] = Map.empty
   }
 
 }

--- a/scalapact-argonaut-6-2/src/main/scala/com/itv/scalapact/json/package.scala
+++ b/scalapact-argonaut-6-2/src/main/scala/com/itv/scalapact/json/package.scala
@@ -1,7 +1,10 @@
 package com.itv.scalapact
 
+import argonaut.{Json, Parse}
 import com.itv.scalapact.argonaut62.{PactReader, PactWriter}
-import com.itv.scalapact.shared.typeclasses.{IPactReader, IPactWriter}
+import com.itv.scalapact.shared.MessageContentType
+import com.itv.scalapact.shared.MessageContentType.ApplicationJson
+import com.itv.scalapact.shared.typeclasses.{IMessageFormat, IPactReader, IPactWriter, MessageFormatError}
 
 package object json {
   implicit val pactReaderInstance: IPactReader =
@@ -9,4 +12,14 @@ package object json {
 
   implicit val pactWriterInstance: IPactWriter =
     new PactWriter
+
+  implicit val jsonMessageFormatInstance = new IMessageFormat[Json] {
+    override def contentType: MessageContentType = ApplicationJson
+
+    override def encode(t: Json): String = t.nospaces
+
+    override def decode(s: String): Either[MessageFormatError, Json] =
+      Parse.parse(s).fold(m => Left(MessageFormatError(m)), Right(_))
+  }
+
 }

--- a/scalapact-argonaut-6-2/src/main/scala/com/itv/scalapact/json/package.scala
+++ b/scalapact-argonaut-6-2/src/main/scala/com/itv/scalapact/json/package.scala
@@ -13,7 +13,7 @@ package object json {
   implicit val pactWriterInstance: IPactWriter =
     new PactWriter
 
-  implicit val jsonMessageFormatInstance = new IMessageFormat[Json] {
+  implicit val jsonMessageFormatInstance: IMessageFormat[Json] = new IMessageFormat[Json] {
     override def contentType: MessageContentType = ApplicationJson
 
     override def encode(t: Json): String = t.nospaces

--- a/scalapact-argonaut-6-2/src/main/scala/com/itv/scalapact/json/package.scala
+++ b/scalapact-argonaut-6-2/src/main/scala/com/itv/scalapact/json/package.scala
@@ -21,8 +21,6 @@ package object json {
     override def decode(s: String): Either[MessageFormatError, Json] =
       Parse.parse(s).fold(m => Left(MessageFormatError(m)), Right(_))
   }
-  implicit val inferTypeInstance: IInferTypes[Json] = new IInferTypes[Json] {
-    override protected def inferFrom(t: Json): Map[String, String] = Map.empty
-  }
+  implicit val inferTypeInstance: IInferTypes[Json] = IInferTypes.noneInferTypeInstance[Json]
 
 }

--- a/scalapact-argonaut-6-2/src/test/scala/com/itv/scalapact/argonaut62/IMessageFormatSpec.scala
+++ b/scalapact-argonaut-6-2/src/test/scala/com/itv/scalapact/argonaut62/IMessageFormatSpec.scala
@@ -1,0 +1,25 @@
+package com.itv.scalapact.argonaut62
+
+import argonaut.Argonaut.jString
+import argonaut.Json
+import org.scalactic.TypeCheckedTripleEquals
+import org.scalatest.{EitherValues, FlatSpec}
+import org.scalatest.Matchers._
+
+class IMessageFormatSpec extends FlatSpec with EitherValues with TypeCheckedTripleEquals {
+  import com.itv.scalapact.json.jsonMessageFormatInstance
+
+  it should "decode a string to json" in {
+    jsonMessageFormatInstance.decode("""{"key1": "value1"}""").right.value should ===(
+      Json.obj("key1" -> jString("value1"))
+    )
+  }
+
+  it should "fail when decode a string is not valid json" in {
+    jsonMessageFormatInstance.decode("""{"key2": value2}""").left.value.msg should include("Unexpected content found")
+  }
+
+  it should "encode json to string" in {
+    jsonMessageFormatInstance.encode(Json.obj("key4" -> jString("value4"))) should ===("""{"key4":"value4"}""")
+  }
+}

--- a/scalapact-argonaut-6-2/src/test/scala/com/itv/scalapact/argonaut62/PactFileExamples.scala
+++ b/scalapact-argonaut-6-2/src/test/scala/com/itv/scalapact/argonaut62/PactFileExamples.scala
@@ -281,8 +281,8 @@ object PactFileExamples {
         providerState = Some("or maybe 'scenario'? not sure about this"),
         contents = """{"foo":"bar"}""",
         metaData = Message.Metadata("contentType" -> "application/json"),
-        matchingRules = Map.empty, //FIXME maybe ?
-        MessageContentType.ApplicationJson
+        matchingRules = Map("foo"                 -> MatchingRule(Some("regex"), Some("\\w+"), None)),
+        contentType = MessageContentType.ApplicationJson,
       )
     )
   )
@@ -301,6 +301,12 @@ object PactFileExamples {
                                 |            "contents": {"foo":"bar"},
                                 |            "metaData": {
                                 |              "contentType": "application/json"
+                                |            },
+                                |            "matchingRules" : {
+                                |               "foo" : {
+                                |                 "match":"regex",
+                                |                 "regex": "\\w+"
+                                |               }
                                 |            }
                                 |        }
                                 |    ]
@@ -313,7 +319,7 @@ object PactFileExamples {
         providerState = Some("or maybe 'scenario'! not sure about this"),
         contents = """{"boo":"xxx"}""",
         metaData = Message.Metadata("contentType" -> "application/json"),
-        matchingRules = Map.empty, //FIXME maybe ?
+        matchingRules = Map.empty,
         MessageContentType.ApplicationJson
       )
     )
@@ -332,7 +338,13 @@ object PactFileExamples {
                                 |            "contents": {"foo":"bar"},
                                 |            "metaData": {
                                 |              "contentType": "application/json"
-                                |            }
+                                |            },
+                                |            "matchingRules" : {
+                                |               "foo" : {
+                                |                 "match":"regex",
+                                |                 "regex": "\\w+"
+                                |               }
+                                |             }
                                 |        },
                                 |        {
                                 |            "description": "Published another credit data",
@@ -363,7 +375,13 @@ object PactFileExamples {
       |            "contents": {"foo":"bar"},
       |            "metaData": {
       |              "contentType": "application/json"
-      |            }
+      |            },
+      |            "matchingRules" : {
+      |               "foo" : {
+      |                 "match":"regex",
+      |                 "regex": "\\w+"
+      |               }
+      |             }
       |        },
       |        {
       |            "description": "Published another credit data",

--- a/scalapact-argonaut-6-2/src/test/scala/com/itv/scalapact/argonaut62/PactFileExamples.scala
+++ b/scalapact-argonaut-6-2/src/test/scala/com/itv/scalapact/argonaut62/PactFileExamples.scala
@@ -278,7 +278,7 @@ object PactFileExamples {
     messages = List(
       Message(
         description = "Published credit data",
-        providerState = Some("or maybe 'scenario'? not sure about this"),
+        providerStates = List("or maybe 'scenario'? not sure about this"),
         contents = """{"foo":"bar","number":123}""",
         metaData = Message.Metadata("contentType" -> "application/json"),
         matchingRules = Map(
@@ -294,6 +294,47 @@ object PactFileExamples {
   )
 
   val simpleMessageAsString = """{
+                                |    "consumer": {
+                                |        "name": "Consumer"
+                                |    },
+                                |    "provider": {
+                                |        "name": "Provider"
+                                |    },
+                                |    "messages": [
+                                |        {
+                                |            "description": "Published credit data",
+                                |            "providerStates": [
+                                |             "or maybe 'scenario'? not sure about this"
+                                |             ],
+                                |            "contents": {"foo":"bar","number":123},
+                                |            "metaData": {
+                                |              "contentType": "application/json"
+                                |            },
+                                |            "matchingRules" : {
+                                |              "body" : {
+                                |                "$.foo" : {
+                                |                  "matchers": [
+                                |                    {
+                                |                      "match":"regex",
+                                |                      "regex": "\\w+"
+                                |                    }
+                                |                  ]
+                                |                },
+                                |                "$.number" : {
+                                |                  "matchers": [
+                                |                    {
+                                |                      "match":"integer"
+                                |                    }
+                                |                  ]
+                                |                }
+                                |              }
+                                |            }
+                                |        }
+                                |    ]
+                                |}""".stripMargin
+
+  val simpleMessageWithProviderStateAsString =
+    """{
                                 |    "consumer": {
                                 |        "name": "Consumer"
                                 |    },
@@ -335,7 +376,7 @@ object PactFileExamples {
     messages = simpleMessage.messages ++ List(
       Message(
         description = "Published another credit data",
-        providerState = Some("or maybe 'scenario'! not sure about this"),
+        providerStates = List("or maybe 'scenario'! not sure about this"),
         contents = """{"boo":"xxx"}""",
         metaData = Message.Metadata("contentType" -> "application/json"),
         matchingRules = Map.empty,
@@ -353,7 +394,9 @@ object PactFileExamples {
                                 |    "messages": [
                                 |        {
                                 |            "description": "Published credit data",
-                                |            "providerState": "or maybe 'scenario'? not sure about this",
+                                |            "providerStates": [
+                                |            "or maybe 'scenario'? not sure about this"
+                                |            ],
                                 |            "contents": {"foo":"bar","number":123},
                                 |            "metaData": {
                                 |              "contentType": "application/json"
@@ -380,7 +423,9 @@ object PactFileExamples {
                                 |        },
                                 |        {
                                 |            "description": "Published another credit data",
-                                |            "providerState": "or maybe 'scenario'! not sure about this",
+                                |            "providerStates": [
+                                |             "or maybe 'scenario'! not sure about this"
+                                |            ],
                                 |            "contents": {"boo":"xxx"},
                                 |            "metaData": {
                                 |              "contentType": "application/json"
@@ -403,7 +448,9 @@ object PactFileExamples {
       |    "messages": [
       |        {
       |            "description": "Published credit data",
-      |            "providerState": "or maybe 'scenario'? not sure about this",
+      |            "providerStates": [
+      |              "or maybe 'scenario'? not sure about this"
+      |             ],
       |            "contents": {"foo":"bar","number":123},
       |            "metaData": {
       |              "contentType": "application/json"
@@ -430,7 +477,9 @@ object PactFileExamples {
       |        },
       |        {
       |            "description": "Published another credit data",
-      |            "providerState": "or maybe 'scenario'! not sure about this",
+      |            "providerStates": [
+      |               "or maybe 'scenario'! not sure about this"
+      |            ],
       |            "contents": {"boo":"xxx"},
       |            "metaData": {
       |              "contentType": "application/json"

--- a/scalapact-argonaut-6-2/src/test/scala/com/itv/scalapact/argonaut62/PactFileExamples.scala
+++ b/scalapact-argonaut-6-2/src/test/scala/com/itv/scalapact/argonaut62/PactFileExamples.scala
@@ -281,6 +281,7 @@ object PactFileExamples {
         providerState = Some("or maybe 'scenario'? not sure about this"),
         contents = """{"foo":"bar"}""",
         metaData = Message.Metadata("contentType" -> "application/json"),
+        matchingRules = Map.empty, //FIXME maybe ?
         MessageContentType.ApplicationJson
       )
     )
@@ -312,6 +313,7 @@ object PactFileExamples {
         providerState = Some("or maybe 'scenario'! not sure about this"),
         contents = """{"boo":"xxx"}""",
         metaData = Message.Metadata("contentType" -> "application/json"),
+        matchingRules = Map.empty, //FIXME maybe ?
         MessageContentType.ApplicationJson
       )
     )

--- a/scalapact-argonaut-6-2/src/test/scala/com/itv/scalapact/argonaut62/PactFileExamples.scala
+++ b/scalapact-argonaut-6-2/src/test/scala/com/itv/scalapact/argonaut62/PactFileExamples.scala
@@ -288,8 +288,6 @@ object PactFileExamples {
     )
   )
 
-  //TODO Review how to generate the new matching rules
-  //http://pactbroker.stg.fp.itv.com/pacts/provider/Craft%20Backend/consumer/TVT/latest
   val simpleMessageAsString = """{
                                 |    "consumer": {
                                 |        "name": "Consumer"

--- a/scalapact-argonaut-6-2/src/test/scala/com/itv/scalapact/argonaut62/PactFileExamples.scala
+++ b/scalapact-argonaut-6-2/src/test/scala/com/itv/scalapact/argonaut62/PactFileExamples.scala
@@ -270,4 +270,25 @@ object PactFileExamples {
                                  |    }
                                  |  ]
                                  |}""".stripMargin
+
+  val simpleMessageAsString = """{
+                                |    "consumer": {
+                                |        "name": "Consumer"
+                                |    },
+                                |    "provider": {
+                                |        "name": "Provider"
+                                |    },
+                                |    "messages": [
+                                |        {
+                                |            "description": "Published credit data",
+                                |            "providerState": "or maybe 'scenario'? not sure about this",
+                                |            "contents": {
+                                |                "foo": "bar"
+                                |            },
+                                |            "metaData": {
+                                |              "contentType": "application/json"
+                                |            }
+                                |        }
+                                |    ]
+                                |}""".stripMargin
 }

--- a/scalapact-argonaut-6-2/src/test/scala/com/itv/scalapact/argonaut62/PactFileExamples.scala
+++ b/scalapact-argonaut-6-2/src/test/scala/com/itv/scalapact/argonaut62/PactFileExamples.scala
@@ -280,7 +280,8 @@ object PactFileExamples {
         description = "Published credit data",
         providerState = Some("or maybe 'scenario'? not sure about this"),
         contents = """{"foo":"bar"}""",
-        metaData = Message.Metadata("contentType" -> "application/json")
+        metaData = Message.Metadata("contentType" -> "application/json"),
+        MessageContentType.ApplicationJson
       )
     )
   )
@@ -310,7 +311,8 @@ object PactFileExamples {
         description = "Published another credit data",
         providerState = Some("or maybe 'scenario'! not sure about this"),
         contents = """{"boo":"xxx"}""",
-        metaData = Message.Metadata("contentType" -> "application/json")
+        metaData = Message.Metadata("contentType" -> "application/json"),
+        MessageContentType.ApplicationJson
       )
     )
   )

--- a/scalapact-argonaut-6-2/src/test/scala/com/itv/scalapact/argonaut62/PactFileExamples.scala
+++ b/scalapact-argonaut-6-2/src/test/scala/com/itv/scalapact/argonaut62/PactFileExamples.scala
@@ -107,7 +107,8 @@ object PactFileExamples {
           matchingRules = None
         )
       )
-    )
+    ),
+    messages = List.empty
   )
 
   val simpleAsString: String = """{

--- a/scalapact-argonaut-6-2/src/test/scala/com/itv/scalapact/argonaut62/PactFileExamples.scala
+++ b/scalapact-argonaut-6-2/src/test/scala/com/itv/scalapact/argonaut62/PactFileExamples.scala
@@ -278,7 +278,7 @@ object PactFileExamples {
     messages = List(
       Message(
         description = "Published credit data",
-        providerStates = List("or maybe 'scenario'? not sure about this"),
+        providerStates = List(ProviderState("or maybe 'scenario'? not sure about this",Map.empty)),
         contents = """{"foo":"bar","number":123}""",
         metaData = Message.Metadata("contentType" -> "application/json"),
         matchingRules = Map(
@@ -304,7 +304,7 @@ object PactFileExamples {
                                 |        {
                                 |            "description": "Published credit data",
                                 |            "providerStates": [
-                                |             "or maybe 'scenario'? not sure about this"
+                                |               {"name" : "or maybe 'scenario'? not sure about this"}
                                 |             ],
                                 |            "contents": {"foo":"bar","number":123},
                                 |            "metaData": {
@@ -376,7 +376,7 @@ object PactFileExamples {
     messages = simpleMessage.messages ++ List(
       Message(
         description = "Published another credit data",
-        providerStates = List("or maybe 'scenario'! not sure about this"),
+        providerStates = List(ProviderState("or maybe 'scenario'! not sure about this",Map.empty)),
         contents = """{"boo":"xxx"}""",
         metaData = Message.Metadata("contentType" -> "application/json"),
         matchingRules = Map.empty,
@@ -395,7 +395,7 @@ object PactFileExamples {
                                 |        {
                                 |            "description": "Published credit data",
                                 |            "providerStates": [
-                                |            "or maybe 'scenario'? not sure about this"
+                                |               {"name": "or maybe 'scenario'? not sure about this"}
                                 |            ],
                                 |            "contents": {"foo":"bar","number":123},
                                 |            "metaData": {
@@ -424,7 +424,7 @@ object PactFileExamples {
                                 |        {
                                 |            "description": "Published another credit data",
                                 |            "providerStates": [
-                                |             "or maybe 'scenario'! not sure about this"
+                                |               {"name": "or maybe 'scenario'! not sure about this"}
                                 |            ],
                                 |            "contents": {"boo":"xxx"},
                                 |            "metaData": {
@@ -449,7 +449,7 @@ object PactFileExamples {
       |        {
       |            "description": "Published credit data",
       |            "providerStates": [
-      |              "or maybe 'scenario'? not sure about this"
+      |              {"name" : "or maybe 'scenario'? not sure about this"}
       |             ],
       |            "contents": {"foo":"bar","number":123},
       |            "metaData": {
@@ -478,7 +478,7 @@ object PactFileExamples {
       |        {
       |            "description": "Published another credit data",
       |            "providerStates": [
-      |               "or maybe 'scenario'! not sure about this"
+      |               {"name" : "or maybe 'scenario'! not sure about this"}
       |            ],
       |            "contents": {"boo":"xxx"},
       |            "metaData": {

--- a/scalapact-argonaut-6-2/src/test/scala/com/itv/scalapact/argonaut62/PactFileExamples.scala
+++ b/scalapact-argonaut-6-2/src/test/scala/com/itv/scalapact/argonaut62/PactFileExamples.scala
@@ -27,7 +27,9 @@ object PactFileExamples {
           None
         )
       )
-    )
+    ),
+    //FIXME: added just to compile
+    messages = List.empty
   )
 
   val verySimpleAsString: String =

--- a/scalapact-argonaut-6-2/src/test/scala/com/itv/scalapact/argonaut62/PactFileExamples.scala
+++ b/scalapact-argonaut-6-2/src/test/scala/com/itv/scalapact/argonaut62/PactFileExamples.scala
@@ -281,8 +281,13 @@ object PactFileExamples {
         providerState = Some("or maybe 'scenario'? not sure about this"),
         contents = """{"foo":"bar","number":123}""",
         metaData = Message.Metadata("contentType" -> "application/json"),
-        matchingRules = Map("foo"                 -> MatchingRule(Some("regex"), Some("\\w+"), None),
-                            "number"              -> MatchingRule(Some("integer"), None, None)),
+        matchingRules = Map(
+          "body" ->
+            Map(
+              "$.foo"    -> Message.Matchers(List(MatchingRule(Some("regex"), Some("\\w+"), None))),
+              "$.number" -> Message.Matchers(List(MatchingRule(Some("integer"), None, None)))
+            )
+        ),
         contentType = MessageContentType.ApplicationJson,
       )
     )
@@ -304,13 +309,23 @@ object PactFileExamples {
                                 |              "contentType": "application/json"
                                 |            },
                                 |            "matchingRules" : {
-                                |               "foo" : {
-                                |                 "match":"regex",
-                                |                 "regex": "\\w+"
-                                |               },
-                                |               "number" : {
-                                |                  "match": "integer" 
-                                |               }
+                                |              "body" : {
+                                |                "$.foo" : {
+                                |                  "matchers": [
+                                |                    {
+                                |                      "match":"regex",
+                                |                      "regex": "\\w+"
+                                |                    }
+                                |                  ]
+                                |                },
+                                |                "$.number" : {
+                                |                  "matchers": [
+                                |                    {
+                                |                      "match":"integer"
+                                |                    }
+                                |                  ]
+                                |                }
+                                |              }
                                 |            }
                                 |        }
                                 |    ]
@@ -344,14 +359,24 @@ object PactFileExamples {
                                 |              "contentType": "application/json"
                                 |            },
                                 |            "matchingRules" : {
-                                |               "foo" : {
-                                |                 "match":"regex",
-                                |                 "regex": "\\w+"
-                                |               },
-                                |               "number" : {
-                                |                  "match": "integer"
-                                |               }
-                                |             }
+                                |              "body" : {
+                                |                "$.foo" : {
+                                |                  "matchers": [
+                                |                    {
+                                |                      "match":"regex",
+                                |                      "regex": "\\w+"
+                                |                    }
+                                |                  ]
+                                |                },
+                                |                "$.number" : {
+                                |                  "matchers": [
+                                |                    {
+                                |                      "match":"integer"
+                                |                    }
+                                |                  ]
+                                |                }
+                                |              }
+                                |            }
                                 |        },
                                 |        {
                                 |            "description": "Published another credit data",
@@ -384,14 +409,24 @@ object PactFileExamples {
       |              "contentType": "application/json"
       |            },
       |            "matchingRules" : {
-      |               "foo" : {
-      |                 "match":"regex",
-      |                 "regex": "\\w+"
-      |               },
-      |               "number" : {
-      |                  "match": "integer"
-      |               }
-      |             }
+      |              "body" : {
+      |                "$.foo" : {
+      |                  "matchers": [
+      |                    {
+      |                      "match":"regex",
+      |                      "regex": "\\w+"
+      |                    }
+      |                  ]
+      |                },
+      |                "$.number" : {
+      |                  "matchers": [
+      |                    {
+      |                      "match":"integer"
+      |                    }
+      |                  ]
+      |                }
+      |              }
+      |            }
       |        },
       |        {
       |            "description": "Published another credit data",

--- a/scalapact-argonaut-6-2/src/test/scala/com/itv/scalapact/argonaut62/PactFileExamples.scala
+++ b/scalapact-argonaut-6-2/src/test/scala/com/itv/scalapact/argonaut62/PactFileExamples.scala
@@ -4,31 +4,31 @@ import com.itv.scalapact.shared._
 
 object PactFileExamples {
 
+  private val simpleInteraction = Interaction(
+    provider_state = None,
+    providerState = None,
+    description = "a simple request",
+    request = InteractionRequest(
+      method = Option("GET"),
+      path = Option("/"),
+      query = None,
+      headers = None,
+      body = None,
+      matchingRules = None
+    ),
+    response = InteractionResponse(
+      status = Option(200),
+      headers = None,
+      body = Option("""Hello"""),
+      None
+    )
+  )
   val verySimple = Pact(
     consumer = PactActor("consumer"),
     provider = PactActor("provider"),
     interactions = List(
-      Interaction(
-        provider_state = None,
-        providerState = None,
-        description = "a simple request",
-        request = InteractionRequest(
-          method = Option("GET"),
-          path = Option("/"),
-          query = None,
-          headers = None,
-          body = None,
-          matchingRules = None
-        ),
-        response = InteractionResponse(
-          status = Option(200),
-          headers = None,
-          body = Option("""Hello"""),
-          None
-        )
-      )
+      simpleInteraction
     ),
-    //FIXME: added just to compile
     messages = List.empty
   )
 
@@ -271,6 +271,20 @@ object PactFileExamples {
                                  |  ]
                                  |}""".stripMargin
 
+  val simpleMessage = Pact(
+    consumer = PactActor("Consumer"),
+    provider = PactActor("Provider"),
+    interactions = List.empty,
+    messages = List(
+      Message(
+        description = "Published credit data",
+        providerState = Some("or maybe 'scenario'? not sure about this"),
+        contents = """{"foo":"bar"}""",
+        metaData = Message.Metadata("contentType" -> "application/json")
+      )
+    )
+  )
+
   val simpleMessageAsString = """{
                                 |    "consumer": {
                                 |        "name": "Consumer"
@@ -282,13 +296,93 @@ object PactFileExamples {
                                 |        {
                                 |            "description": "Published credit data",
                                 |            "providerState": "or maybe 'scenario'? not sure about this",
-                                |            "contents": {
-                                |                "foo": "bar"
-                                |            },
+                                |            "contents": {"foo":"bar"},
                                 |            "metaData": {
                                 |              "contentType": "application/json"
                                 |            }
                                 |        }
                                 |    ]
                                 |}""".stripMargin
+
+  val multipleMessage = simpleMessage.copy(
+    messages = simpleMessage.messages ++ List(
+      Message(
+        description = "Published another credit data",
+        providerState = Some("or maybe 'scenario'! not sure about this"),
+        contents = """{"boo":"xxx"}""",
+        metaData = Message.Metadata("contentType" -> "application/json")
+      )
+    )
+  )
+  val multipleMessageAsString = """{
+                                |    "consumer": {
+                                |        "name": "Consumer"
+                                |    },
+                                |    "provider": {
+                                |        "name": "Provider"
+                                |    },
+                                |    "messages": [
+                                |        {
+                                |            "description": "Published credit data",
+                                |            "providerState": "or maybe 'scenario'? not sure about this",
+                                |            "contents": {"foo":"bar"},
+                                |            "metaData": {
+                                |              "contentType": "application/json"
+                                |            }
+                                |        },
+                                |        {
+                                |            "description": "Published another credit data",
+                                |            "providerState": "or maybe 'scenario'! not sure about this",
+                                |            "contents": {"boo":"xxx"},
+                                |            "metaData": {
+                                |              "contentType": "application/json"
+                                |            }
+                                |        }
+                                |    ]
+                                |}""".stripMargin
+
+  val multipleMessagesAndInteractions = multipleMessage
+    .copy(interactions = List(simpleInteraction))
+
+  val multipleMessagesAndInteractionsAsString =
+    """{
+      |    "consumer": {
+      |        "name": "Consumer"
+      |    },
+      |    "provider": {
+      |        "name": "Provider"
+      |    },
+      |    "messages": [
+      |        {
+      |            "description": "Published credit data",
+      |            "providerState": "or maybe 'scenario'? not sure about this",
+      |            "contents": {"foo":"bar"},
+      |            "metaData": {
+      |              "contentType": "application/json"
+      |            }
+      |        },
+      |        {
+      |            "description": "Published another credit data",
+      |            "providerState": "or maybe 'scenario'! not sure about this",
+      |            "contents": {"boo":"xxx"},
+      |            "metaData": {
+      |              "contentType": "application/json"
+      |            }
+      |        }
+      |    ],
+      |    "interactions": [
+      |    {
+      |      "description" : "a simple request",
+      |      "request" : {
+      |        "method" : "GET",
+      |        "path" : "/"
+      |      },
+      |      "response" : {
+      |        "status" : 200,
+      |        "body" : "Hello"
+      |      }
+      |     }
+      |    ]
+      | }
+    """.stripMargin
 }

--- a/scalapact-argonaut-6-2/src/test/scala/com/itv/scalapact/argonaut62/PactFileExamples.scala
+++ b/scalapact-argonaut-6-2/src/test/scala/com/itv/scalapact/argonaut62/PactFileExamples.scala
@@ -279,14 +279,17 @@ object PactFileExamples {
       Message(
         description = "Published credit data",
         providerState = Some("or maybe 'scenario'? not sure about this"),
-        contents = """{"foo":"bar"}""",
+        contents = """{"foo":"bar","number":123}""",
         metaData = Message.Metadata("contentType" -> "application/json"),
-        matchingRules = Map("foo"                 -> MatchingRule(Some("regex"), Some("\\w+"), None)),
+        matchingRules = Map("foo"                 -> MatchingRule(Some("regex"), Some("\\w+"), None),
+                            "number"              -> MatchingRule(Some("integer"), None, None)),
         contentType = MessageContentType.ApplicationJson,
       )
     )
   )
 
+  //TODO Review how to generate the new matching rules
+  //http://pactbroker.stg.fp.itv.com/pacts/provider/Craft%20Backend/consumer/TVT/latest
   val simpleMessageAsString = """{
                                 |    "consumer": {
                                 |        "name": "Consumer"
@@ -298,7 +301,7 @@ object PactFileExamples {
                                 |        {
                                 |            "description": "Published credit data",
                                 |            "providerState": "or maybe 'scenario'? not sure about this",
-                                |            "contents": {"foo":"bar"},
+                                |            "contents": {"foo":"bar","number":123},
                                 |            "metaData": {
                                 |              "contentType": "application/json"
                                 |            },
@@ -306,6 +309,9 @@ object PactFileExamples {
                                 |               "foo" : {
                                 |                 "match":"regex",
                                 |                 "regex": "\\w+"
+                                |               },
+                                |               "number" : {
+                                |                  "match": "integer" 
                                 |               }
                                 |            }
                                 |        }
@@ -335,7 +341,7 @@ object PactFileExamples {
                                 |        {
                                 |            "description": "Published credit data",
                                 |            "providerState": "or maybe 'scenario'? not sure about this",
-                                |            "contents": {"foo":"bar"},
+                                |            "contents": {"foo":"bar","number":123},
                                 |            "metaData": {
                                 |              "contentType": "application/json"
                                 |            },
@@ -343,6 +349,9 @@ object PactFileExamples {
                                 |               "foo" : {
                                 |                 "match":"regex",
                                 |                 "regex": "\\w+"
+                                |               },
+                                |               "number" : {
+                                |                  "match": "integer"
                                 |               }
                                 |             }
                                 |        },
@@ -372,7 +381,7 @@ object PactFileExamples {
       |        {
       |            "description": "Published credit data",
       |            "providerState": "or maybe 'scenario'? not sure about this",
-      |            "contents": {"foo":"bar"},
+      |            "contents": {"foo":"bar","number":123},
       |            "metaData": {
       |              "contentType": "application/json"
       |            },
@@ -380,6 +389,9 @@ object PactFileExamples {
       |               "foo" : {
       |                 "match":"regex",
       |                 "regex": "\\w+"
+      |               },
+      |               "number" : {
+      |                  "match": "integer"
       |               }
       |             }
       |        },

--- a/scalapact-argonaut-6-2/src/test/scala/com/itv/scalapact/argonaut62/RubyJsonHelperSpec.scala
+++ b/scalapact-argonaut-6-2/src/test/scala/com/itv/scalapact/argonaut62/RubyJsonHelperSpec.scala
@@ -1,26 +1,32 @@
 package com.itv.scalapact.argonaut62
 
 import com.itv.scalapact.shared._
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.{EitherValues, FunSpec, Matchers}
+import argonaut.Argonaut._
+import org.scalactic.TypeCheckedTripleEquals
 
-class RubyJsonHelperSpec extends FunSpec with Matchers {
+class RubyJsonHelperSpec extends FunSpec with Matchers with EitherValues with TypeCheckedTripleEquals {
 
   describe("Handling ruby json") {
 
     it("should be able to extract the provider") {
 
-      JsonBodySpecialCaseHelper.extractPactActor("provider")(PactFileExamples.simpleAsString) shouldEqual Some(
-        PactActor("provider")
+      JsonBodySpecialCaseHelper
+        .extractPactActor("provider")(PactFileExamples.simpleAsString.parse.right.value)
+        .toOption should ===(
+        Some(
+          PactActor("provider")
+        )
       )
 
     }
 
     it("should be able to extract the consumer") {
-
-      JsonBodySpecialCaseHelper.extractPactActor("consumer")(PactFileExamples.simpleAsString) shouldEqual Some(
+      JsonBodySpecialCaseHelper
+        .extractPactActor("consumer")(PactFileExamples.simpleAsString.parse.right.value)
+        .toOption shouldEqual Some(
         PactActor("consumer")
       )
-
     }
 
     it("should be able to extract a list of interactions paired with their bodies") {
@@ -79,12 +85,16 @@ class RubyJsonHelperSpec extends FunSpec with Matchers {
       val interaction2RequestBody  = Option("fish")
       val interaction2ResponseBody = Option("""{"chips":true,"fish":["cod","haddock"]}""")
 
-      val list = List(
-        (Some(interaction1), interaction1RequestBody, interaction1ResponseBody),
-        (Some(interaction2), interaction2RequestBody, interaction2ResponseBody)
+      JsonBodySpecialCaseHelper
+        .extractInteractionsTuple(PactFileExamples.simpleAsString.parse.right.value)
+        .toOption should ===(
+        Option(
+          List(
+            (interaction1, interaction1RequestBody, interaction1ResponseBody),
+            (interaction2, interaction2RequestBody, interaction2ResponseBody)
+          )
+        )
       )
-
-      JsonBodySpecialCaseHelper.extractInteractions(PactFileExamples.simpleAsString) shouldEqual Some(list)
 
     }
 

--- a/scalapact-argonaut-6-2/src/test/scala/com/itv/scalapact/argonaut62/ScalaMessagePactReaderWriterSpec.scala
+++ b/scalapact-argonaut-6-2/src/test/scala/com/itv/scalapact/argonaut62/ScalaMessagePactReaderWriterSpec.scala
@@ -10,14 +10,38 @@ class ScalaMessagePactReaderWriterSpec extends FlatSpec with EitherValues with T
   val pactReader = new PactReader
   val pactWriter = new PactWriter
 
-  it should "parse a simple message" in {
-    val source = PactFileExamples.simpleMessageAsString
-    val pact   = pactReader.jsonStringToPact(source).right.value
+  List(
+    (PactFileExamples.simpleMessageAsString, PactFileExamples.simpleMessage),
+    (PactFileExamples.multipleMessageAsString, PactFileExamples.multipleMessage),
+    (PactFileExamples.multipleMessagesAndInteractionsAsString, PactFileExamples.multipleMessagesAndInteractions)
+  ).foreach {
+    case (expectedWritten, expectedPact) =>
+      it should s"should be able to read Pact files: [$expectedPact]" in {
 
-    val target = pactWriter.pactToJsonString(pact)
+        val actualPact = pactReader.jsonStringToPact(expectedWritten).right.value
 
-    parse(target) should ===(parse(source))
+        actualPact should ===(expectedPact)
+      }
 
+      it should s"should be able to write Pact files: [$expectedPact]" in {
+
+        val actualWritten = pactWriter.pactToJsonString(expectedPact)
+
+        parse(actualWritten) should ===(parse(expectedWritten))
+
+      }
+
+      it should s"should be able to eat it's own dog food: [$expectedPact]" in {
+        val actualWritten = pactWriter.pactToJsonString(expectedPact)
+
+        val actualPact = pactReader.jsonStringToPact(actualWritten).right.value
+
+        val `reJson'd` = pactWriter.pactToJsonString(actualPact)
+
+        parse(`reJson'd`) should ===(parse(expectedWritten))
+
+        actualPact should ===(expectedPact)
+      }
   }
 
 }

--- a/scalapact-argonaut-6-2/src/test/scala/com/itv/scalapact/argonaut62/ScalaMessagePactReaderWriterSpec.scala
+++ b/scalapact-argonaut-6-2/src/test/scala/com/itv/scalapact/argonaut62/ScalaMessagePactReaderWriterSpec.scala
@@ -1,0 +1,27 @@
+package com.itv.scalapact.argonaut62
+
+import org.scalatest.Matchers._
+import org.scalatest.{EitherValues, FlatSpec}
+import argonaut.JsonParser.parse
+import org.scalactic.TypeCheckedTripleEquals
+
+class ScalaMessagePactReaderWriterSpec extends FlatSpec with EitherValues with TypeCheckedTripleEquals {
+
+  val pactReader = new PactReader
+  val pactWriter = new PactWriter
+
+  it should "parse a simple message" in {
+    val source = PactFileExamples.simpleMessageAsString
+    val pact   = pactReader.jsonStringToPact(source)
+
+    pact shouldBe 'right
+
+    println(pact.right.value)
+
+//    val target = pactWriter.pactToJsonString(pact)
+//
+//    parse(target) should ===(parse(source))
+
+  }
+
+}

--- a/scalapact-argonaut-6-2/src/test/scala/com/itv/scalapact/argonaut62/ScalaMessagePactReaderWriterSpec.scala
+++ b/scalapact-argonaut-6-2/src/test/scala/com/itv/scalapact/argonaut62/ScalaMessagePactReaderWriterSpec.scala
@@ -44,4 +44,11 @@ class ScalaMessagePactReaderWriterSpec extends FlatSpec with EitherValues with T
       }
   }
 
+  it should "be able to read message that use 'providerState' instead 'providerStates'" in {
+    val actualPact = pactReader.jsonStringToPact(PactFileExamples.simpleMessageWithProviderStateAsString)
+
+    actualPact should ===(Right(PactFileExamples.simpleMessage))
+
+  }
+
 }

--- a/scalapact-argonaut-6-2/src/test/scala/com/itv/scalapact/argonaut62/ScalaMessagePactReaderWriterSpec.scala
+++ b/scalapact-argonaut-6-2/src/test/scala/com/itv/scalapact/argonaut62/ScalaMessagePactReaderWriterSpec.scala
@@ -18,9 +18,9 @@ class ScalaMessagePactReaderWriterSpec extends FlatSpec with EitherValues with T
     case (expectedWritten, expectedPact) =>
       it should s"should be able to read Pact files: [$expectedPact]" in {
 
-        val actualPact = pactReader.jsonStringToPact(expectedWritten).right.value
+        val actualPact = pactReader.jsonStringToPact(expectedWritten)
 
-        actualPact should ===(expectedPact)
+        actualPact should ===(Right(expectedPact))
       }
 
       it should s"should be able to write Pact files: [$expectedPact]" in {

--- a/scalapact-argonaut-6-2/src/test/scala/com/itv/scalapact/argonaut62/ScalaMessagePactReaderWriterSpec.scala
+++ b/scalapact-argonaut-6-2/src/test/scala/com/itv/scalapact/argonaut62/ScalaMessagePactReaderWriterSpec.scala
@@ -12,15 +12,11 @@ class ScalaMessagePactReaderWriterSpec extends FlatSpec with EitherValues with T
 
   it should "parse a simple message" in {
     val source = PactFileExamples.simpleMessageAsString
-    val pact   = pactReader.jsonStringToPact(source)
+    val pact   = pactReader.jsonStringToPact(source).right.value
 
-    pact shouldBe 'right
+    val target = pactWriter.pactToJsonString(pact)
 
-    println(pact.right.value)
-
-//    val target = pactWriter.pactToJsonString(pact)
-//
-//    parse(target) should ===(parse(source))
+    parse(target) should ===(parse(source))
 
   }
 

--- a/scalapact-argonaut-6-2/src/test/scala/com/itv/scalapact/argonaut62/ScalaPactReaderWriterSpec.scala
+++ b/scalapact-argonaut-6-2/src/test/scala/com/itv/scalapact/argonaut62/ScalaPactReaderWriterSpec.scala
@@ -28,7 +28,7 @@ class ScalaPactReaderWriterSpec extends FunSpec with Matchers {
 
       val expected = PactFileExamples.simpleAsString
 
-      parse(written).toOption.get shouldEqual parse(expected).toOption.get
+      parse(written) shouldEqual parse(expected)
     }
 
     it("should be able to eat it's own dog food") {

--- a/scalapact-circe-0-8/src/main/scala/com/itv/scalapact/circe08/JsonConversionFunctions.scala
+++ b/scalapact-circe-0-8/src/main/scala/com/itv/scalapact/circe08/JsonConversionFunctions.scala
@@ -27,10 +27,10 @@ object JsonConversionFunctions extends IJsonConversionFunctions {
         IrNode(label, IrNullNode).withPath(pathToParent)
 
       case j: Json if j.isNumber && j.toString().contains(".") =>
-        IrNode(label, j.asNumber.map(_.toDouble).map(d => IrDecimalNode(d))).withPath(pathToParent)
+        IrNode(label, j.asNumber.flatMap(_.toBigDecimal).map(IrDecimalNode)).withPath(pathToParent)
 
       case j: Json if j.isNumber =>
-        IrNode(label, j.asNumber.flatMap(_.toLong).map(d => IrIntegerNode(d))).withPath(pathToParent)
+        IrNode(label, j.asNumber.flatMap(_.toBigInt).map(IrIntegerNode)).withPath(pathToParent)
 
       case j: Json if j.isBoolean =>
         IrNode(label, j.asBoolean.map(IrBooleanNode)).withPath(pathToParent)

--- a/scalapact-circe-0-8/src/main/scala/com/itv/scalapact/circe08/JsonConversionFunctions.scala
+++ b/scalapact-circe-0-8/src/main/scala/com/itv/scalapact/circe08/JsonConversionFunctions.scala
@@ -26,8 +26,11 @@ object JsonConversionFunctions extends IJsonConversionFunctions {
       case j: Json if j.isNull =>
         IrNode(label, IrNullNode).withPath(pathToParent)
 
+      case j: Json if j.isNumber && j.toString().contains(".") =>
+        IrNode(label, j.asNumber.map(_.toDouble).map(d => IrDecimalNode(d))).withPath(pathToParent)
+
       case j: Json if j.isNumber =>
-        IrNode(label, j.asNumber.map(_.toDouble).map(d => IrNumberNode(d))).withPath(pathToParent)
+        IrNode(label, j.asNumber.flatMap(_.toLong).map(d => IrIntegerNode(d))).withPath(pathToParent)
 
       case j: Json if j.isBoolean =>
         IrNode(label, j.asBoolean.map(IrBooleanNode)).withPath(pathToParent)

--- a/scalapact-circe-0-8/src/main/scala/com/itv/scalapact/circe08/PactImplicits.scala
+++ b/scalapact-circe-0-8/src/main/scala/com/itv/scalapact/circe08/PactImplicits.scala
@@ -69,7 +69,6 @@ object PactImplicits {
     contents
       .as[String]
       .fold[MessageContentType](_ => MessageContentType.ApplicationJson, _ => MessageContentType.ApplicationText)
-  //TODO it should be simple to support xml
 
   private def contents(cursor: HCursor): Decoder.Result[Json] =
     cursor

--- a/scalapact-circe-0-8/src/main/scala/com/itv/scalapact/circe08/PactImplicits.scala
+++ b/scalapact-circe-0-8/src/main/scala/com/itv/scalapact/circe08/PactImplicits.scala
@@ -36,7 +36,11 @@ object PactImplicits {
         case ApplicationJson => parse(m.contents).toOption.getOrElse(Json.Null)
         case _               => Json.fromString(m.contents)
       }),
-      "metaData" -> m.metaData.asJson
+      "metaData" -> m.metaData.asJson,
+      "matchingRules" -> (m.matchingRules match {
+        case mr if mr.nonEmpty => mr.asJson
+        case _                 => Json.Null
+      })
     )
   }
   @SuppressWarnings(Array("org.wartremover.warts.Any"))
@@ -47,11 +51,13 @@ object PactImplicits {
       providerState <- cursor.downField("providerState").as[Option[String]]
       contents      <- contents(cursor)
       metaData      <- cursor.downField("metaData").as[Metadata]
+      matchingRules <- cursor.downField("matchingRules").as[Option[Map[String, MatchingRule]]]
     } yield
       Message(description,
               providerState,
               contents.asString.getOrElse(contents.noSpaces),
               metaData,
+              matchingRules.getOrElse(Map.empty),
               contentType(contents)))
       .fold(
         f => Left(s"There was a failure during decoder because ${f.message}: [$f]"),

--- a/scalapact-circe-0-8/src/main/scala/com/itv/scalapact/circe08/PactImplicits.scala
+++ b/scalapact-circe-0-8/src/main/scala/com/itv/scalapact/circe08/PactImplicits.scala
@@ -14,6 +14,9 @@ object PactImplicits {
   implicit val pactActorEncoder: Encoder[PactActor] = deriveEncoder[PactActor]
   implicit val pactActorDecoder: Decoder[PactActor] = deriveDecoder[PactActor]
 
+  implicit val messageMatchersEncoder: Encoder[Message.Matchers] = deriveEncoder[Message.Matchers]
+  implicit val messageMatchersDecoder: Decoder[Message.Matchers] = deriveDecoder[Message.Matchers]
+
   implicit val matchingRulesEncoder: Encoder[MatchingRule] = deriveEncoder[MatchingRule]
   implicit val matchingRulesDecoder: Decoder[MatchingRule] = deriveDecoder[MatchingRule]
 
@@ -51,7 +54,7 @@ object PactImplicits {
       providerState <- cursor.downField("providerState").as[Option[String]]
       contents      <- contents(cursor)
       metaData      <- cursor.downField("metaData").as[Metadata]
-      matchingRules <- cursor.downField("matchingRules").as[Option[Map[String, MatchingRule]]]
+      matchingRules <- cursor.downField("matchingRules").as[Option[Message.MatchingRules]]
     } yield
       Message(description,
               providerState,

--- a/scalapact-circe-0-8/src/main/scala/com/itv/scalapact/circe08/PactImplicits.scala
+++ b/scalapact-circe-0-8/src/main/scala/com/itv/scalapact/circe08/PactImplicits.scala
@@ -33,8 +33,8 @@ object PactImplicits {
 
   implicit val messageEncoder: Encoder[Message] = Encoder.instance { m =>
     Json.obj(
-      "description"   -> m.description.asJson,
-      "providerState" -> m.providerState.asJson,
+      "description"    -> m.description.asJson,
+      "providerStates" -> m.providerStates.asJson,
       "contents" -> (m.contentType match {
         case ApplicationJson => parse(m.contents).toOption.getOrElse(Json.Null)
         case _               => Json.fromString(m.contents)
@@ -50,18 +50,21 @@ object PactImplicits {
   implicit val messageDecoder: Decoder[Message] = Decoder.decodeJson.emap { json =>
     val cursor = json.hcursor
     (for {
-      description   <- cursor.downField("description").as[String]
-      providerState <- cursor.downField("providerState").as[Option[String]]
-      contents      <- contents(cursor)
-      metaData      <- cursor.downField("metaData").as[Metadata]
-      matchingRules <- cursor.downField("matchingRules").as[Option[Message.MatchingRules]]
+      description    <- cursor.downField("description").as[String]
+      providerState  <- cursor.downField("providerState").as[Option[String]]
+      providerStates <- cursor.downField("providerStates").as[Option[List[String]]]
+      contents       <- contents(cursor)
+      metaData       <- cursor.downField("metaData").as[Metadata]
+      matchingRules  <- cursor.downField("matchingRules").as[Option[Message.MatchingRules]]
     } yield
-      Message(description,
-              providerState,
-              contents.asString.getOrElse(contents.noSpaces),
-              metaData,
-              matchingRules.getOrElse(Map.empty),
-              contentType(contents)))
+      Message(
+        description,
+        providerState.toList ++ providerStates.toList.flatten,
+        contents.asString.getOrElse(contents.noSpaces),
+        metaData,
+        matchingRules.getOrElse(Map.empty),
+        contentType(contents)
+      ))
       .fold(
         f => Left(s"There was a failure during decoder because ${f.message}: [$f]"),
         Right(_)

--- a/scalapact-circe-0-8/src/main/scala/com/itv/scalapact/circe08/PactImplicits.scala
+++ b/scalapact-circe-0-8/src/main/scala/com/itv/scalapact/circe08/PactImplicits.scala
@@ -8,7 +8,9 @@ import io.circe.generic.semiauto._
 import io.circe.parser.parse
 import io.circe.syntax._
 
+@SuppressWarnings(Array("org.wartremover.warts.Any", "org.wartremover.warts.PublicInference"))
 object PactImplicits {
+
   implicit val pactActorEncoder: Encoder[PactActor] = deriveEncoder[PactActor]
   implicit val pactActorDecoder: Decoder[PactActor] = deriveDecoder[PactActor]
 
@@ -16,9 +18,11 @@ object PactImplicits {
   implicit val matchingRulesDecoder: Decoder[MatchingRule] = deriveDecoder[MatchingRule]
 
   implicit val interactionRequestEncoder: Encoder[InteractionRequest] = deriveEncoder[InteractionRequest]
+
   implicit val interactionRequestDecoder: Decoder[InteractionRequest] = deriveDecoder[InteractionRequest]
 
   implicit val InteractionResponseEncoder: Encoder[InteractionResponse] = deriveEncoder[InteractionResponse]
+
   implicit val InteractionResponseDecoder: Decoder[InteractionResponse] = deriveDecoder[InteractionResponse]
 
   implicit val interactionEncoder: Encoder[Interaction] = deriveEncoder[Interaction]
@@ -29,13 +33,13 @@ object PactImplicits {
       "description"   -> m.description.asJson,
       "providerState" -> m.providerState.asJson,
       "contents" -> (m.contentType match {
-        case ApplicationJson => parse(m.contents).right.get
+        case ApplicationJson => parse(m.contents).toOption.getOrElse(Json.Null)
         case _               => Json.fromString(m.contents)
       }),
       "metaData" -> m.metaData.asJson
     )
   }
-
+  @SuppressWarnings(Array("org.wartremover.warts.Any"))
   implicit val messageDecoder: Decoder[Message] = Decoder.decodeJson.emap { json =>
     val cursor = json.hcursor
     (for {
@@ -58,9 +62,8 @@ object PactImplicits {
   def contentType(contents: Json): MessageContentType =
     contents
       .as[String]
-      .map(_ => MessageContentType.ApplicationText) //TODO it should be simple to support xml
-      .toOption
-      .getOrElse(MessageContentType.ApplicationJson)
+      .fold[MessageContentType](_ => MessageContentType.ApplicationJson, _ => MessageContentType.ApplicationText)
+  //TODO it should be simple to support xml
 
   private def contents(cursor: HCursor): Decoder.Result[Json] =
     cursor

--- a/scalapact-circe-0-8/src/main/scala/com/itv/scalapact/circe08/PactReader.scala
+++ b/scalapact-circe-0-8/src/main/scala/com/itv/scalapact/circe08/PactReader.scala
@@ -33,7 +33,8 @@ class PactReader extends IPactReader {
         consumer = bp._2,
         interactions = interactions
           .map(i => i.copy(providerState = i.providerState.orElse(i.provider_state)))
-          .map(i => i.copy(provider_state = None))
+          .map(i => i.copy(provider_state = None)),
+        messages = List.empty //FIXME: Should read the messages from the pact broker
       )
 
     } match {

--- a/scalapact-circe-0-8/src/main/scala/com/itv/scalapact/circe08/PactReader.scala
+++ b/scalapact-circe-0-8/src/main/scala/com/itv/scalapact/circe08/PactReader.scala
@@ -4,7 +4,6 @@ import com.itv.scalapact.shared._
 import com.itv.scalapact.shared.matchir.IrNode
 import com.itv.scalapact.shared.typeclasses.IPactReader
 import io.circe._
-import io.circe.generic.auto._
 import io.circe.parser._
 
 class PactReader extends IPactReader {
@@ -12,97 +11,123 @@ class PactReader extends IPactReader {
   def fromJSON(jsonString: String): Option[IrNode] =
     JsonConversionFunctions.fromJSON(jsonString)
 
-  def jsonStringToPact(json: String): Either[String, Pact] = {
-    val brokenPact: Option[(PactActor, PactActor, List[(Option[Interaction], Option[String], Option[String])])] = for {
-      provider     <- JsonBodySpecialCaseHelper.extractPactActor("provider")(json)
-      consumer     <- JsonBodySpecialCaseHelper.extractPactActor("consumer")(json)
-      interactions <- JsonBodySpecialCaseHelper.extractInteractions(json)
-    } yield (provider, consumer, interactions)
-
-    brokenPact.map { bp =>
-      val interactions = bp._3.collect {
-        case (Some(i), r1, r2) =>
-          i.copy(
-            request = i.request.copy(body = r1),
-            response = i.response.copy(body = r2)
-          )
-      }
-
-      Pact(
-        provider = bp._1,
-        consumer = bp._2,
-        interactions = interactions
-          .map(i => i.copy(providerState = i.providerState.orElse(i.provider_state)))
-          .map(i => i.copy(provider_state = None)),
-        messages = List.empty //FIXME: Should read the messages from the pact broker
+  def jsonStringToPact(json: String): Either[String, Pact] =
+    (for {
+      parsedJson   <- parse(json)
+      provider     <- JsonBodySpecialCaseHelper.extractPactActor("provider")(parsedJson)
+      consumer     <- JsonBodySpecialCaseHelper.extractPactActor("consumer")(parsedJson)
+      interactions <- JsonBodySpecialCaseHelper.extractInteractions(parsedJson)
+      messages     <- JsonBodySpecialCaseHelper.extractMessages(parsedJson)
+    } yield Pact(provider, consumer, interactions, messages))
+      .fold(
+        x => Left(s"There was a failure ${x.getMessage}: [$x]"),
+        Right(_)
       )
-
-    } match {
-      case Some(pact) => Right(pact)
-      case None       => Left(s"Could not read pact from json: $json")
-    }
-  }
-
 }
 
 object JsonBodySpecialCaseHelper {
+  import PactImplicits._
 
+  type JsonParser[T]                = Json => Decoder.Result[T]
+  type InterationTuple              = (Interaction, Option[String], Option[String])
+  type InteractionTupleDecodeResult = Decoder.Result[List[InterationTuple]]
   @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
-  val extractPactActor: String => String => Option[PactActor] = field =>
+  val extractPactActor: String => JsonParser[PactActor] = field =>
     json =>
-      parse(json).toOption
-        .flatMap { j =>
-          j.hcursor.downField(field).focus
-        }
-        .flatMap(p => p.as[PactActor].toOption)
+      json.asObject
+        .flatMap(_(field).map(_.as[PactActor]))
+        .getOrElse(fail(s"field `$field` does not exist"))
 
   @SuppressWarnings(Array("org.wartremover.warts.PublicInference", "org.wartremover.warts.Any"))
-  val extractInteractions: String => Option[List[(Option[Interaction], Option[String], Option[String])]] = json => {
+  val extractInteractions: JsonParser[List[Interaction]] = json =>
+    extractInteractionsTuple(json).map(_.map {
+      case (interaction, request, response) =>
+        interaction.copy(
+          request = interaction.request.copy(body = request),
+          response = interaction.response.copy(body = response),
+          provider_state = None,
+          providerState = interaction.providerState.orElse(interaction.provider_state)
+        )
 
-    val interactions =
-      parse(json).toOption
-        .flatMap { j =>
-          j.hcursor.downField("interactions").focus.flatMap(p => p.asArray.map(_.toList))
-        }
+    })
 
-    val makeOptionalBody: Json => Option[String] = {
-      case body: Json if body.isString =>
-        body.asString
-
-      case body =>
-        Option(body.pretty(Printer.spaces2.copy(dropNullKeys = true)))
-    }
-
-    interactions.map { is =>
-      is.map { i =>
-        val minusRequestBody =
-          i.hcursor.downField("request").downField("body").delete.top match {
-            case ok @ Some(_) => ok
-            case None         => Option(i)
+  protected[circe08] val extractInteractionsTuple: JsonParser[List[InterationTuple]] = json => {
+    json.asObject
+      .flatMap(_("interactions"))
+      .fold(suceed(Vector.empty[Json]))(
+        _.asArray.fold(fail[Vector[Json]](s"`interactions` field is not an array: [$json]"))(suceed)
+      )
+      .flatMap {
+        _.map(parseInteractionTuple)
+          .foldLeft(suceed(List.empty[InterationTuple])) { (acc: InteractionTupleDecodeResult, next) =>
+            next.fold(
+              fail[List[InterationTuple]],
+              x =>
+                acc.fold[InteractionTupleDecodeResult](
+                  _ => acc,
+                  currentList => x.fold(acc)(nextTuple => suceed(currentList ++ List(nextTuple)))
+              )
+            )
           }
+      }
+  }
 
-        val minusResponseBody = minusRequestBody.flatMap { ii =>
-          ii.hcursor.downField("response").downField("body").delete.top match {
-            case ok @ Some(_) => ok
-            case None         => minusRequestBody // There wasn't a body, but there was still an interaction.
-          }
-        }
+  private def parseInteractionTuple: JsonParser[Option[InterationTuple]] = json => {
+    val minusRequestBody =
+      json.hcursor.downField("request").downField("body").delete.top match {
+        case ok @ Some(_) => ok
+        case None         => Option(json)
+      }
 
-        val requestBody = i.hcursor
-          .downField("request")
-          .downField("body")
-          .focus
-          .flatMap { makeOptionalBody }
-
-        val responseBody = i.hcursor
-          .downField("response")
-          .downField("body")
-          .focus
-          .flatMap { makeOptionalBody }
-
-        (minusResponseBody.flatMap(p => p.as[Interaction].toOption), requestBody, responseBody)
+    val minusResponseBody = minusRequestBody.flatMap { ii =>
+      ii.hcursor.downField("response").downField("body").delete.top match {
+        case ok @ Some(_) => ok
+        case None         => minusRequestBody // There wasn't a body, but there was still an interaction.
       }
     }
+
+    val requestBody = json.hcursor
+      .downField("request")
+      .downField("body")
+      .focus
+      .flatMap {
+        makeOptionalBody
+      }
+
+    val responseBody = json.hcursor
+      .downField("response")
+      .downField("body")
+      .focus
+      .flatMap {
+        makeOptionalBody
+      }
+
+    minusResponseBody
+      .map(_.as[Interaction])
+      .map(dr => dr.map(x => Option((x, requestBody, responseBody))))
+      .getOrElse(suceed(None))
   }
+  @SuppressWarnings(Array("org.wartremover.warts.PublicInference", "org.wartremover.warts.Any"))
+  val extractMessages: JsonParser[List[Message]] = _.asObject
+    .flatMap(_("messages"))
+    .map(_.as[List[Message]])
+    .getOrElse(suceed(List.empty[Message]))
+
+  private val makeOptionalBody: Json => Option[String] = {
+    case body: Json if body.isString =>
+      body.asString
+
+    case body =>
+      Option(body.toString)
+  }
+
+  private def fail[T](value: DecodingFailure): Either[DecodingFailure, T] =
+    Left(value)
+
+  private def fail[T](value: String): Either[DecodingFailure, T] =
+    Left(DecodingFailure(value, List.empty))
+
+  private def suceed[T](value: T): Either[DecodingFailure, T] =
+    Right(value)
 
 }

--- a/scalapact-circe-0-8/src/main/scala/com/itv/scalapact/circe08/PactWriter.scala
+++ b/scalapact-circe-0-8/src/main/scala/com/itv/scalapact/circe08/PactWriter.scala
@@ -12,9 +12,6 @@ class PactWriter extends IPactWriter {
 
   @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
   def pactToJsonString(pact: Pact): String = {
-    //TODO: Deal with empty interacations/messages
-    //TODO: Add the messages
-    //
     val interactions: Vector[Json] =
       pact.interactions.toVector
         .map { i =>

--- a/scalapact-circe-0-8/src/main/scala/com/itv/scalapact/circe08/package.scala
+++ b/scalapact-circe-0-8/src/main/scala/com/itv/scalapact/circe08/package.scala
@@ -9,4 +9,5 @@ package object circe08 {
 
   implicit val pactWriterInstance: IPactWriter =
     new PactWriter
+
 }

--- a/scalapact-circe-0-8/src/main/scala/com/itv/scalapact/json/package.scala
+++ b/scalapact-circe-0-8/src/main/scala/com/itv/scalapact/json/package.scala
@@ -1,7 +1,11 @@
 package com.itv.scalapact
 
 import com.itv.scalapact.circe08.{PactReader, PactWriter}
-import com.itv.scalapact.shared.typeclasses.{IPactReader, IPactWriter}
+import com.itv.scalapact.shared.MessageContentType
+import com.itv.scalapact.shared.MessageContentType.ApplicationJson
+import com.itv.scalapact.shared.typeclasses.{IMessageFormat, IPactReader, IPactWriter, MessageFormatError}
+import io.circe.Json
+import io.circe.parser.parse
 
 package object json {
   implicit val pactReaderInstance: IPactReader =
@@ -9,4 +13,13 @@ package object json {
 
   implicit val pactWriterInstance: IPactWriter =
     new PactWriter
+
+  implicit val jsonMessageFormatInstance = new IMessageFormat[Json] {
+    override def contentType: MessageContentType = ApplicationJson
+
+    override def encode(t: Json): String = t.noSpaces
+
+    override def decode(s: String): Either[MessageFormatError, Json] =
+      parse(s).fold(m => Left(MessageFormatError(m.message)), Right(_))
+  }
 }

--- a/scalapact-circe-0-8/src/main/scala/com/itv/scalapact/json/package.scala
+++ b/scalapact-circe-0-8/src/main/scala/com/itv/scalapact/json/package.scala
@@ -14,7 +14,7 @@ package object json {
   implicit val pactWriterInstance: IPactWriter =
     new PactWriter
 
-  implicit val jsonMessageFormatInstance = new IMessageFormat[Json] {
+  implicit val jsonMessageFormatInstance: IMessageFormat[Json] = new IMessageFormat[Json] {
     override def contentType: MessageContentType = ApplicationJson
 
     override def encode(t: Json): String = t.noSpaces

--- a/scalapact-circe-0-8/src/main/scala/com/itv/scalapact/json/package.scala
+++ b/scalapact-circe-0-8/src/main/scala/com/itv/scalapact/json/package.scala
@@ -23,8 +23,6 @@ package object json {
       parse(s).fold(m => Left(MessageFormatError(m.message)), Right(_))
   }
 
-  implicit val inferTypeInstance: IInferTypes[Json] = new IInferTypes[Json] {
-    override protected def inferFrom(t: Json): Map[String, String] = Map.empty
-  }
+  implicit val inferTypeInstance: IInferTypes[Json] = IInferTypes.noneInferTypeInstance[Json]
 
 }

--- a/scalapact-circe-0-8/src/main/scala/com/itv/scalapact/json/package.scala
+++ b/scalapact-circe-0-8/src/main/scala/com/itv/scalapact/json/package.scala
@@ -3,7 +3,7 @@ package com.itv.scalapact
 import com.itv.scalapact.circe08.{PactReader, PactWriter}
 import com.itv.scalapact.shared.MessageContentType
 import com.itv.scalapact.shared.MessageContentType.ApplicationJson
-import com.itv.scalapact.shared.typeclasses.{IMessageFormat, IPactReader, IPactWriter, MessageFormatError}
+import com.itv.scalapact.shared.typeclasses._
 import io.circe.Json
 import io.circe.parser.parse
 
@@ -22,4 +22,9 @@ package object json {
     override def decode(s: String): Either[MessageFormatError, Json] =
       parse(s).fold(m => Left(MessageFormatError(m.message)), Right(_))
   }
+
+  implicit val inferTypeInstance: IInferTypes[Json] = new IInferTypes[Json] {
+    override protected def inferFrom(t: Json): Map[String, String] = Map.empty
+  }
+
 }

--- a/scalapact-circe-0-8/src/test/scala/com/itv/scalapact/circe08/IMessageFormatSpec.scala
+++ b/scalapact-circe-0-8/src/test/scala/com/itv/scalapact/circe08/IMessageFormatSpec.scala
@@ -1,0 +1,24 @@
+package com.itv.scalapact.circe08
+
+import io.circe.Json
+import org.scalactic.TypeCheckedTripleEquals
+import org.scalatest.Matchers._
+import org.scalatest.{EitherValues, FlatSpec}
+
+class IMessageFormatSpec extends FlatSpec with EitherValues with TypeCheckedTripleEquals {
+  import com.itv.scalapact.json.jsonMessageFormatInstance
+
+  it should "decode a string to json" in {
+    jsonMessageFormatInstance.decode("""{"key1": "value1"}""").right.value should ===(
+      Json.obj("key1" -> Json.fromString("value1"))
+    )
+  }
+
+  it should "fail when decode a string is not valid json" in {
+    jsonMessageFormatInstance.decode("""{"key2": value2}""").left.value.msg should include("expected json value")
+  }
+
+  it should "encode json to string" in {
+    jsonMessageFormatInstance.encode(Json.obj("key4" -> Json.fromString("value4"))) should ===("""{"key4":"value4"}""")
+  }
+}

--- a/scalapact-circe-0-8/src/test/scala/com/itv/scalapact/circe08/PactFileExamples.scala
+++ b/scalapact-circe-0-8/src/test/scala/com/itv/scalapact/circe08/PactFileExamples.scala
@@ -290,7 +290,7 @@ object PactFileExamples {
     messages = List(
       Message(
         description = "Published credit data",
-        providerStates = List("or maybe 'scenario'? not sure about this"),
+        providerStates = List(ProviderState("or maybe 'scenario'? not sure about this", Map.empty)),
         contents = """Hello world!""",
         metaData = Message.Metadata(),
         matchingRules =
@@ -341,7 +341,9 @@ object PactFileExamples {
                                 |    "messages": [
                                 |        {
                                 |            "description": "Published credit data",
-                                |            "providerStates": ["or maybe 'scenario'? not sure about this"],
+                                |            "providerStates": [
+                                |               { "name" : "or maybe 'scenario'? not sure about this" }
+                                |            ],
                                 |            "contents": "Hello world!",
                                 |            "metaData": {
                                 |            },
@@ -368,7 +370,7 @@ object PactFileExamples {
     messages = List(
       Message(
         description = "Published credit data",
-        providerStates = List("or maybe 'scenario'? not sure about this"),
+        providerStates = List(ProviderState("or maybe 'scenario'? not sure about this", Map.empty)),
         contents = """{"foo":"bar"}""",
         metaData = Message.Metadata("contentType" -> "application/json"),
         matchingRules = Map.empty,
@@ -387,7 +389,7 @@ object PactFileExamples {
                               |    "messages": [
                               |        {
                               |            "description": "Published credit data",
-                              |            "providerStates": ["or maybe 'scenario'? not sure about this"],
+                              |            "providerStates": [{"name": "or maybe 'scenario'? not sure about this"}],
                               |            "contents": {"foo":"bar"},
                               |            "metaData": {
                               |              "contentType": "application/json"
@@ -400,7 +402,7 @@ object PactFileExamples {
     messages = jsonMessage.messages ++ List(
       Message(
         description = "Published another credit data",
-        providerStates = List("or maybe 'scenario'! not sure about this"),
+        providerStates = List(ProviderState("or maybe 'scenario'! not sure about this", Map("randomParameter" -> "randomValue"))),
         contents = """{"boo":"xxx","foo":123}""",
         metaData = Message.Metadata("contentType" -> "application/json"),
         matchingRules = Map(
@@ -423,7 +425,7 @@ object PactFileExamples {
                                   |    "messages": [
                                   |        {
                                   |            "description": "Published credit data",
-                                  |            "providerStates": ["or maybe 'scenario'? not sure about this"],
+                                  |            "providerStates": [{"name": "or maybe 'scenario'? not sure about this"}],
                                   |            "contents": {"foo":"bar"},
                                   |            "metaData": {
                                   |              "contentType": "application/json"
@@ -431,7 +433,12 @@ object PactFileExamples {
                                   |        },
                                   |        {
                                   |            "description": "Published another credit data",
-                                  |            "providerStates": ["or maybe 'scenario'! not sure about this"],
+                                  |            "providerStates": [
+                                  |               {
+                                  |                  "name" : "or maybe 'scenario'! not sure about this",
+                                  |                  "params" : {"randomParameter" : "randomValue"}
+                                  |                }
+                                  |           ],
                                   |            "contents": {"boo":"xxx","foo":123},
                                   |            "matchingRules" : {
                                   |              "body" : {
@@ -465,7 +472,7 @@ object PactFileExamples {
       |    "messages": [
       |        {
       |            "description": "Published credit data",
-      |            "providerStates": ["or maybe 'scenario'? not sure about this"],
+      |            "providerStates": [{"name": "or maybe 'scenario'? not sure about this"}],
       |            "contents": {"foo":"bar"},
       |            "metaData": {
       |              "contentType": "application/json"
@@ -473,7 +480,12 @@ object PactFileExamples {
       |        },
       |        {
       |            "description": "Published another credit data",
-      |            "providerStates": ["or maybe 'scenario'! not sure about this"],
+      |            "providerStates": [
+      |               {
+      |                 "name" : "or maybe 'scenario'! not sure about this",
+      |                 "params" : {"randomParameter" : "randomValue"}
+      |               }
+      |             ],
       |            "contents": {"boo":"xxx","foo":123},
       |            "matchingRules" : {
       |              "body" : {

--- a/scalapact-circe-0-8/src/test/scala/com/itv/scalapact/circe08/PactFileExamples.scala
+++ b/scalapact-circe-0-8/src/test/scala/com/itv/scalapact/circe08/PactFileExamples.scala
@@ -1,5 +1,6 @@
 package com.itv.scalapact.circe08
 
+import com.itv.scalapact.shared.MessageContentType.{ApplicationJson, ApplicationText}
 import com.itv.scalapact.shared._
 
 object PactFileExamples {
@@ -291,7 +292,8 @@ object PactFileExamples {
         description = "Published credit data",
         providerState = Some("or maybe 'scenario'? not sure about this"),
         contents = """Hello world!""",
-        metaData = Message.Metadata()
+        metaData = Message.Metadata(),
+        ApplicationText
       )
     )
   )
@@ -323,7 +325,8 @@ object PactFileExamples {
         description = "Published credit data",
         providerState = Some("or maybe 'scenario'? not sure about this"),
         contents = """{"foo":"bar"}""",
-        metaData = Message.Metadata("contentType" -> "application/json")
+        metaData = Message.Metadata("contentType" -> "application/json"),
+        ApplicationJson
       )
     )
   )
@@ -353,7 +356,8 @@ object PactFileExamples {
         description = "Published another credit data",
         providerState = Some("or maybe 'scenario'! not sure about this"),
         contents = """{"boo":"xxx"}""",
-        metaData = Message.Metadata("contentType" -> "application/json")
+        metaData = Message.Metadata("contentType" -> "application/json"),
+        ApplicationJson
       )
     )
   )

--- a/scalapact-circe-0-8/src/test/scala/com/itv/scalapact/circe08/PactFileExamples.scala
+++ b/scalapact-circe-0-8/src/test/scala/com/itv/scalapact/circe08/PactFileExamples.scala
@@ -122,7 +122,7 @@ object PactFileExamples {
     ),
     messages = List.empty
   )
-  //FIXME: Add messages to string/json pacts
+
   val simpleAsString: String = """{
                          |  "provider" : {
                          |    "name" : "provider"
@@ -366,7 +366,7 @@ object PactFileExamples {
         contents = """{"boo":"xxx","foo":123}""",
         metaData = Message.Metadata("contentType" -> "application/json"),
         matchingRules = Map(
-          "foo" -> MatchingRule(Some("integer"),None, None)
+          "foo" -> MatchingRule(Some("integer"), None, None)
         ),
         ApplicationJson
       )

--- a/scalapact-circe-0-8/src/test/scala/com/itv/scalapact/circe08/PactFileExamples.scala
+++ b/scalapact-circe-0-8/src/test/scala/com/itv/scalapact/circe08/PactFileExamples.scala
@@ -80,12 +80,12 @@ object PactFileExamples {
           status = Option(200),
           headers = Option(Map("Content-Type" -> "application/json")),
           body = Option("""{
-              |  "fish" : [
-              |    "cod",
-              |    "haddock",
-              |    "flying"
-              |  ]
-              |}""".stripMargin),
+                          |  "fish" : [
+                          |    "cod",
+                          |    "haddock",
+                          |    "flying"
+                          |  ]
+                          |}""".stripMargin),
           matchingRules = Option(
             Map(
               "$.headers.Accept"         -> MatchingRule(`match` = Option("regex"), regex = Option("\\w+"), min = None),
@@ -110,12 +110,12 @@ object PactFileExamples {
           status = Option(200),
           headers = Option(Map("Content-Type" -> "application/json")),
           body = Option("""{
-              |  "chips" : true,
-              |  "fish" : [
-              |    "cod",
-              |    "haddock"
-              |  ]
-              |}""".stripMargin),
+                          |  "chips" : true,
+                          |  "fish" : [
+                          |    "cod",
+                          |    "haddock"
+                          |  ]
+                          |}""".stripMargin),
           matchingRules = None
         )
       )
@@ -124,86 +124,6 @@ object PactFileExamples {
   )
 
   val simpleAsString: String = """{
-                         |  "provider" : {
-                         |    "name" : "provider"
-                         |  },
-                         |  "consumer" : {
-                         |    "name" : "consumer"
-                         |  },
-                         |  "interactions" : [
-                         |    {
-                         |      "providerState" : "a simple state",
-                         |      "description" : "a simple request",
-                         |      "request" : {
-                         |        "method" : "GET",
-                         |        "path" : "/fetch-json",
-                         |        "query" : "fish=chips",
-                         |        "headers" : {
-                         |          "Content-Type" : "text/plain"
-                         |        },
-                         |        "body" : "fish",
-                         |        "matchingRules" : {
-                         |          "$.headers.Accept" : {
-                         |            "match" : "regex",
-                         |            "regex" : "\\w+"
-                         |          },
-                         |          "$.headers.Content-Length" : {
-                         |            "match" : "type"
-                         |          }
-                         |        }
-                         |      },
-                         |      "response" : {
-                         |        "status" : 200,
-                         |        "headers" : {
-                         |          "Content-Type" : "application/json"
-                         |        },
-                         |        "body" : {
-                         |          "fish" : [
-                         |            "cod",
-                         |            "haddock",
-                         |            "flying"
-                         |          ]
-                         |        },
-                         |        "matchingRules" : {
-                         |          "$.headers.Accept" : {
-                         |            "match" : "regex",
-                         |            "regex" : "\\w+"
-                         |          },
-                         |          "$.headers.Content-Length" : {
-                         |            "match" : "type"
-                         |          }
-                         |        }
-                         |      }
-                         |    },
-                         |    {
-                         |      "providerState" : "a simple state 2",
-                         |      "description" : "a simple request 2",
-                         |      "request" : {
-                         |        "method" : "GET",
-                         |        "path" : "/fetch-json2",
-                         |        "headers" : {
-                         |          "Content-Type" : "text/plain"
-                         |        },
-                         |        "body" : "fish"
-                         |      },
-                         |      "response" : {
-                         |        "status" : 200,
-                         |        "headers" : {
-                         |          "Content-Type" : "application/json"
-                         |        },
-                         |        "body" : {
-                         |          "chips" : true,
-                         |          "fish" : [
-                         |            "cod",
-                         |            "haddock"
-                         |          ]
-                         |        }
-                         |      }
-                         |    }
-                         |  ]
-                         |}""".stripMargin
-
-  val simpleOldProviderStateAsString: String = """{
                                  |  "provider" : {
                                  |    "name" : "provider"
                                  |  },
@@ -212,16 +132,16 @@ object PactFileExamples {
                                  |  },
                                  |  "interactions" : [
                                  |    {
-                                 |      "provider_state" : "a simple state",
+                                 |      "providerState" : "a simple state",
                                  |      "description" : "a simple request",
                                  |      "request" : {
                                  |        "method" : "GET",
                                  |        "path" : "/fetch-json",
-                                 |        "body" : "fish",
                                  |        "query" : "fish=chips",
                                  |        "headers" : {
                                  |          "Content-Type" : "text/plain"
                                  |        },
+                                 |        "body" : "fish",
                                  |        "matchingRules" : {
                                  |          "$.headers.Accept" : {
                                  |            "match" : "regex",
@@ -256,15 +176,15 @@ object PactFileExamples {
                                  |      }
                                  |    },
                                  |    {
-                                 |      "provider_state" : "a simple state 2",
+                                 |      "providerState" : "a simple state 2",
                                  |      "description" : "a simple request 2",
                                  |      "request" : {
                                  |        "method" : "GET",
                                  |        "path" : "/fetch-json2",
-                                 |        "body" : "fish",
                                  |        "headers" : {
                                  |          "Content-Type" : "text/plain"
-                                 |        }
+                                 |        },
+                                 |        "body" : "fish"
                                  |      },
                                  |      "response" : {
                                  |        "status" : 200,
@@ -283,6 +203,86 @@ object PactFileExamples {
                                  |  ]
                                  |}""".stripMargin
 
+  val simpleOldProviderStateAsString: String = """{
+                                                 |  "provider" : {
+                                                 |    "name" : "provider"
+                                                 |  },
+                                                 |  "consumer" : {
+                                                 |    "name" : "consumer"
+                                                 |  },
+                                                 |  "interactions" : [
+                                                 |    {
+                                                 |      "provider_state" : "a simple state",
+                                                 |      "description" : "a simple request",
+                                                 |      "request" : {
+                                                 |        "method" : "GET",
+                                                 |        "path" : "/fetch-json",
+                                                 |        "body" : "fish",
+                                                 |        "query" : "fish=chips",
+                                                 |        "headers" : {
+                                                 |          "Content-Type" : "text/plain"
+                                                 |        },
+                                                 |        "matchingRules" : {
+                                                 |          "$.headers.Accept" : {
+                                                 |            "match" : "regex",
+                                                 |            "regex" : "\\w+"
+                                                 |          },
+                                                 |          "$.headers.Content-Length" : {
+                                                 |            "match" : "type"
+                                                 |          }
+                                                 |        }
+                                                 |      },
+                                                 |      "response" : {
+                                                 |        "status" : 200,
+                                                 |        "headers" : {
+                                                 |          "Content-Type" : "application/json"
+                                                 |        },
+                                                 |        "body" : {
+                                                 |          "fish" : [
+                                                 |            "cod",
+                                                 |            "haddock",
+                                                 |            "flying"
+                                                 |          ]
+                                                 |        },
+                                                 |        "matchingRules" : {
+                                                 |          "$.headers.Accept" : {
+                                                 |            "match" : "regex",
+                                                 |            "regex" : "\\w+"
+                                                 |          },
+                                                 |          "$.headers.Content-Length" : {
+                                                 |            "match" : "type"
+                                                 |          }
+                                                 |        }
+                                                 |      }
+                                                 |    },
+                                                 |    {
+                                                 |      "provider_state" : "a simple state 2",
+                                                 |      "description" : "a simple request 2",
+                                                 |      "request" : {
+                                                 |        "method" : "GET",
+                                                 |        "path" : "/fetch-json2",
+                                                 |        "body" : "fish",
+                                                 |        "headers" : {
+                                                 |          "Content-Type" : "text/plain"
+                                                 |        }
+                                                 |      },
+                                                 |      "response" : {
+                                                 |        "status" : 200,
+                                                 |        "headers" : {
+                                                 |          "Content-Type" : "application/json"
+                                                 |        },
+                                                 |        "body" : {
+                                                 |          "chips" : true,
+                                                 |          "fish" : [
+                                                 |            "cod",
+                                                 |            "haddock"
+                                                 |          ]
+                                                 |        }
+                                                 |      }
+                                                 |    }
+                                                 |  ]
+                                                 |}""".stripMargin
+
   val stringMessage = Pact(
     consumer = PactActor("Consumer"),
     provider = PactActor("Provider"),
@@ -293,35 +293,42 @@ object PactFileExamples {
         providerState = Some("or maybe 'scenario'? not sure about this"),
         contents = """Hello world!""",
         metaData = Message.Metadata(),
-        matchingRules = Map("foo" -> MatchingRule(Some("regex"), Some("\\w+"), None)),
+        matchingRules =
+          Map("body" -> Map("$.foo" -> Message.Matchers(List(MatchingRule(Some("regex"), Some("\\w+"), None))))),
         ApplicationText
       )
     )
   )
 
   val stringMessageAsString = """{
-                              |    "consumer": {
-                              |        "name": "Consumer"
-                              |    },
-                              |    "provider": {
-                              |        "name": "Provider"
-                              |    },
-                              |    "messages": [
-                              |        {
-                              |            "description": "Published credit data",
-                              |            "providerState": "or maybe 'scenario'? not sure about this",
-                              |            "contents": "Hello world!",
-                              |            "metaData": {
-                              |            },
-                              |            "matchingRules" : {
-                              |               "foo" : {
-                              |                 "match":"regex",
-                              |                 "regex": "\\w+"
-                              |               }
-                              |            }
-                              |        }
-                              |    ]
-                              |}""".stripMargin
+                                |    "consumer": {
+                                |        "name": "Consumer"
+                                |    },
+                                |    "provider": {
+                                |        "name": "Provider"
+                                |    },
+                                |    "messages": [
+                                |        {
+                                |            "description": "Published credit data",
+                                |            "providerState": "or maybe 'scenario'? not sure about this",
+                                |            "contents": "Hello world!",
+                                |            "metaData": {
+                                |            },
+                                |            "matchingRules" : {
+                                |              "body" : {
+                                |                "$.foo" : {
+                                |                  "matchers": [
+                                |                    {
+                                |                      "match":"regex",
+                                |                      "regex": "\\w+"
+                                |                    }
+                                |                  ]
+                                |                }
+                                |              }
+                                |            }
+                                |        }
+                                |    ]
+                                |}""".stripMargin
 
   val jsonMessage = Pact(
     consumer = PactActor("Consumer"),
@@ -340,23 +347,23 @@ object PactFileExamples {
   )
 
   val jsonMessageAsString = """{
-                                |    "consumer": {
-                                |        "name": "Consumer"
-                                |    },
-                                |    "provider": {
-                                |        "name": "Provider"
-                                |    },
-                                |    "messages": [
-                                |        {
-                                |            "description": "Published credit data",
-                                |            "providerState": "or maybe 'scenario'? not sure about this",
-                                |            "contents": {"foo":"bar"},
-                                |            "metaData": {
-                                |              "contentType": "application/json"
-                                |            }
-                                |        }
-                                |    ]
-                                |}""".stripMargin
+                              |    "consumer": {
+                              |        "name": "Consumer"
+                              |    },
+                              |    "provider": {
+                              |        "name": "Provider"
+                              |    },
+                              |    "messages": [
+                              |        {
+                              |            "description": "Published credit data",
+                              |            "providerState": "or maybe 'scenario'? not sure about this",
+                              |            "contents": {"foo":"bar"},
+                              |            "metaData": {
+                              |              "contentType": "application/json"
+                              |            }
+                              |        }
+                              |    ]
+                              |}""".stripMargin
 
   val multipleMessage = jsonMessage.copy(
     messages = jsonMessage.messages ++ List(
@@ -366,7 +373,10 @@ object PactFileExamples {
         contents = """{"boo":"xxx","foo":123}""",
         metaData = Message.Metadata("contentType" -> "application/json"),
         matchingRules = Map(
-          "foo" -> MatchingRule(Some("integer"), None, None)
+          "body" ->
+            Map(
+              "$.foo" -> Message.Matchers(List(MatchingRule(Some("integer"), None, None)))
+            )
         ),
         ApplicationJson
       )
@@ -392,9 +402,15 @@ object PactFileExamples {
                                   |            "description": "Published another credit data",
                                   |            "providerState": "or maybe 'scenario'! not sure about this",
                                   |            "contents": {"boo":"xxx","foo":123},
-                                  |            "matchingRules": {
-                                  |              "foo" : {
-                                  |                  "match": "integer"
+                                  |            "matchingRules" : {
+                                  |              "body" : {
+                                  |                "$.foo" : {
+                                  |                  "matchers": [
+                                  |                    {
+                                  |                      "match":"integer"
+                                  |                    }
+                                  |                  ]
+                                  |                }
                                   |              }
                                   |            },
                                   |            "metaData": {
@@ -428,9 +444,15 @@ object PactFileExamples {
       |            "description": "Published another credit data",
       |            "providerState": "or maybe 'scenario'! not sure about this",
       |            "contents": {"boo":"xxx","foo":123},
-      |            "matchingRules": {
-      |              "foo" : {
-      |                  "match": "integer"
+      |            "matchingRules" : {
+      |              "body" : {
+      |                "$.foo" : {
+      |                  "matchers": [
+      |                    {
+      |                      "match":"integer"
+      |                    }
+      |                  ]
+      |                }
       |              }
       |            },
       |            "metaData": {

--- a/scalapact-circe-0-8/src/test/scala/com/itv/scalapact/circe08/PactFileExamples.scala
+++ b/scalapact-circe-0-8/src/test/scala/com/itv/scalapact/circe08/PactFileExamples.scala
@@ -363,9 +363,11 @@ object PactFileExamples {
       Message(
         description = "Published another credit data",
         providerState = Some("or maybe 'scenario'! not sure about this"),
-        contents = """{"boo":"xxx"}""",
+        contents = """{"boo":"xxx","foo":123}""",
         metaData = Message.Metadata("contentType" -> "application/json"),
-        matchingRules = Map.empty,
+        matchingRules = Map(
+          "foo" -> MatchingRule(Some("integer"),None, None)
+        ),
         ApplicationJson
       )
     )
@@ -389,7 +391,12 @@ object PactFileExamples {
                                   |        {
                                   |            "description": "Published another credit data",
                                   |            "providerState": "or maybe 'scenario'! not sure about this",
-                                  |            "contents": {"boo":"xxx"},
+                                  |            "contents": {"boo":"xxx","foo":123},
+                                  |            "matchingRules": {
+                                  |              "foo" : {
+                                  |                  "match": "integer"
+                                  |              }
+                                  |            },
                                   |            "metaData": {
                                   |              "contentType": "application/json"
                                   |            }
@@ -420,7 +427,12 @@ object PactFileExamples {
       |        {
       |            "description": "Published another credit data",
       |            "providerState": "or maybe 'scenario'! not sure about this",
-      |            "contents": {"boo":"xxx"},
+      |            "contents": {"boo":"xxx","foo":123},
+      |            "matchingRules": {
+      |              "foo" : {
+      |                  "match": "integer"
+      |              }
+      |            },
       |            "metaData": {
       |              "contentType": "application/json"
       |            }

--- a/scalapact-circe-0-8/src/test/scala/com/itv/scalapact/circe08/PactFileExamples.scala
+++ b/scalapact-circe-0-8/src/test/scala/com/itv/scalapact/circe08/PactFileExamples.scala
@@ -27,7 +27,8 @@ object PactFileExamples {
           None
         )
       )
-    )
+    ),
+    messages = List.empty
   )
 
   val verySimpleAsString: String =
@@ -117,9 +118,10 @@ object PactFileExamples {
           matchingRules = None
         )
       )
-    )
+    ),
+    messages = List.empty
   )
-
+  //FIXME: Add messages to string/json pacts
   val simpleAsString: String = """{
                          |  "provider" : {
                          |    "name" : "provider"

--- a/scalapact-circe-0-8/src/test/scala/com/itv/scalapact/circe08/PactFileExamples.scala
+++ b/scalapact-circe-0-8/src/test/scala/com/itv/scalapact/circe08/PactFileExamples.scala
@@ -290,7 +290,7 @@ object PactFileExamples {
     messages = List(
       Message(
         description = "Published credit data",
-        providerState = Some("or maybe 'scenario'? not sure about this"),
+        providerStates = List("or maybe 'scenario'? not sure about this"),
         contents = """Hello world!""",
         metaData = Message.Metadata(),
         matchingRules =
@@ -299,6 +299,37 @@ object PactFileExamples {
       )
     )
   )
+
+  val simpleMessageWithProviderStateAsString =
+    """{
+      |    "consumer": {
+      |        "name": "Consumer"
+      |    },
+      |    "provider": {
+      |        "name": "Provider"
+      |    },
+      |    "messages": [
+      |        {
+      |            "description": "Published credit data",
+      |            "providerState": "or maybe 'scenario'? not sure about this",
+      |            "contents": "Hello world!",
+      |            "metaData": {
+      |            },
+      |            "matchingRules" : {
+      |              "body" : {
+      |                "$.foo" : {
+      |                  "matchers": [
+      |                    {
+      |                      "match":"regex",
+      |                      "regex": "\\w+"
+      |                    }
+      |                  ]
+      |                }
+      |              }
+      |            }
+      |        }
+      |    ]
+      |}""".stripMargin
 
   val stringMessageAsString = """{
                                 |    "consumer": {
@@ -310,7 +341,7 @@ object PactFileExamples {
                                 |    "messages": [
                                 |        {
                                 |            "description": "Published credit data",
-                                |            "providerState": "or maybe 'scenario'? not sure about this",
+                                |            "providerStates": ["or maybe 'scenario'? not sure about this"],
                                 |            "contents": "Hello world!",
                                 |            "metaData": {
                                 |            },
@@ -337,7 +368,7 @@ object PactFileExamples {
     messages = List(
       Message(
         description = "Published credit data",
-        providerState = Some("or maybe 'scenario'? not sure about this"),
+        providerStates = List("or maybe 'scenario'? not sure about this"),
         contents = """{"foo":"bar"}""",
         metaData = Message.Metadata("contentType" -> "application/json"),
         matchingRules = Map.empty,
@@ -356,7 +387,7 @@ object PactFileExamples {
                               |    "messages": [
                               |        {
                               |            "description": "Published credit data",
-                              |            "providerState": "or maybe 'scenario'? not sure about this",
+                              |            "providerStates": ["or maybe 'scenario'? not sure about this"],
                               |            "contents": {"foo":"bar"},
                               |            "metaData": {
                               |              "contentType": "application/json"
@@ -369,7 +400,7 @@ object PactFileExamples {
     messages = jsonMessage.messages ++ List(
       Message(
         description = "Published another credit data",
-        providerState = Some("or maybe 'scenario'! not sure about this"),
+        providerStates = List("or maybe 'scenario'! not sure about this"),
         contents = """{"boo":"xxx","foo":123}""",
         metaData = Message.Metadata("contentType" -> "application/json"),
         matchingRules = Map(
@@ -392,7 +423,7 @@ object PactFileExamples {
                                   |    "messages": [
                                   |        {
                                   |            "description": "Published credit data",
-                                  |            "providerState": "or maybe 'scenario'? not sure about this",
+                                  |            "providerStates": ["or maybe 'scenario'? not sure about this"],
                                   |            "contents": {"foo":"bar"},
                                   |            "metaData": {
                                   |              "contentType": "application/json"
@@ -400,7 +431,7 @@ object PactFileExamples {
                                   |        },
                                   |        {
                                   |            "description": "Published another credit data",
-                                  |            "providerState": "or maybe 'scenario'! not sure about this",
+                                  |            "providerStates": ["or maybe 'scenario'! not sure about this"],
                                   |            "contents": {"boo":"xxx","foo":123},
                                   |            "matchingRules" : {
                                   |              "body" : {
@@ -434,7 +465,7 @@ object PactFileExamples {
       |    "messages": [
       |        {
       |            "description": "Published credit data",
-      |            "providerState": "or maybe 'scenario'? not sure about this",
+      |            "providerStates": ["or maybe 'scenario'? not sure about this"],
       |            "contents": {"foo":"bar"},
       |            "metaData": {
       |              "contentType": "application/json"
@@ -442,7 +473,7 @@ object PactFileExamples {
       |        },
       |        {
       |            "description": "Published another credit data",
-      |            "providerState": "or maybe 'scenario'! not sure about this",
+      |            "providerStates": ["or maybe 'scenario'! not sure about this"],
       |            "contents": {"boo":"xxx","foo":123},
       |            "matchingRules" : {
       |              "body" : {

--- a/scalapact-circe-0-8/src/test/scala/com/itv/scalapact/circe08/PactFileExamples.scala
+++ b/scalapact-circe-0-8/src/test/scala/com/itv/scalapact/circe08/PactFileExamples.scala
@@ -3,30 +3,30 @@ package com.itv.scalapact.circe08
 import com.itv.scalapact.shared._
 
 object PactFileExamples {
-
+  private val simpleInteraction = Interaction(
+    provider_state = None,
+    providerState = None,
+    description = "a simple request",
+    request = InteractionRequest(
+      method = Option("GET"),
+      path = Option("/"),
+      query = None,
+      headers = None,
+      body = None,
+      matchingRules = None
+    ),
+    response = InteractionResponse(
+      status = Option(200),
+      headers = None,
+      body = Option("""Hello"""),
+      None
+    )
+  )
   val verySimple = Pact(
     consumer = PactActor("consumer"),
     provider = PactActor("provider"),
     interactions = List(
-      Interaction(
-        provider_state = None,
-        providerState = None,
-        description = "a simple request",
-        request = InteractionRequest(
-          method = Option("GET"),
-          path = Option("/"),
-          query = None,
-          headers = None,
-          body = None,
-          matchingRules = None
-        ),
-        response = InteractionResponse(
-          status = Option(200),
-          headers = None,
-          body = Option("""Hello"""),
-          None
-        )
-      )
+      simpleInteraction
     ),
     messages = List.empty
   )
@@ -281,4 +281,151 @@ object PactFileExamples {
                                  |    }
                                  |  ]
                                  |}""".stripMargin
+
+  val stringMessage = Pact(
+    consumer = PactActor("Consumer"),
+    provider = PactActor("Provider"),
+    interactions = List.empty,
+    messages = List(
+      Message(
+        description = "Published credit data",
+        providerState = Some("or maybe 'scenario'? not sure about this"),
+        contents = """Hello world!""",
+        metaData = Message.Metadata()
+      )
+    )
+  )
+
+  val stringMessageAsString = """{
+                              |    "consumer": {
+                              |        "name": "Consumer"
+                              |    },
+                              |    "provider": {
+                              |        "name": "Provider"
+                              |    },
+                              |    "messages": [
+                              |        {
+                              |            "description": "Published credit data",
+                              |            "providerState": "or maybe 'scenario'? not sure about this",
+                              |            "contents": "Hello world!",
+                              |            "metaData": {
+                              |            }
+                              |        }
+                              |    ]
+                              |}""".stripMargin
+
+  val jsonMessage = Pact(
+    consumer = PactActor("Consumer"),
+    provider = PactActor("Provider"),
+    interactions = List.empty,
+    messages = List(
+      Message(
+        description = "Published credit data",
+        providerState = Some("or maybe 'scenario'? not sure about this"),
+        contents = """{"foo":"bar"}""",
+        metaData = Message.Metadata("contentType" -> "application/json")
+      )
+    )
+  )
+
+  val jsonMessageAsString = """{
+                                |    "consumer": {
+                                |        "name": "Consumer"
+                                |    },
+                                |    "provider": {
+                                |        "name": "Provider"
+                                |    },
+                                |    "messages": [
+                                |        {
+                                |            "description": "Published credit data",
+                                |            "providerState": "or maybe 'scenario'? not sure about this",
+                                |            "contents": {"foo":"bar"},
+                                |            "metaData": {
+                                |              "contentType": "application/json"
+                                |            }
+                                |        }
+                                |    ]
+                                |}""".stripMargin
+
+  val multipleMessage = jsonMessage.copy(
+    messages = jsonMessage.messages ++ List(
+      Message(
+        description = "Published another credit data",
+        providerState = Some("or maybe 'scenario'! not sure about this"),
+        contents = """{"boo":"xxx"}""",
+        metaData = Message.Metadata("contentType" -> "application/json")
+      )
+    )
+  )
+  val multipleMessageAsString = """{
+                                  |    "consumer": {
+                                  |        "name": "Consumer"
+                                  |    },
+                                  |    "provider": {
+                                  |        "name": "Provider"
+                                  |    },
+                                  |    "messages": [
+                                  |        {
+                                  |            "description": "Published credit data",
+                                  |            "providerState": "or maybe 'scenario'? not sure about this",
+                                  |            "contents": {"foo":"bar"},
+                                  |            "metaData": {
+                                  |              "contentType": "application/json"
+                                  |            }
+                                  |        },
+                                  |        {
+                                  |            "description": "Published another credit data",
+                                  |            "providerState": "or maybe 'scenario'! not sure about this",
+                                  |            "contents": {"boo":"xxx"},
+                                  |            "metaData": {
+                                  |              "contentType": "application/json"
+                                  |            }
+                                  |        }
+                                  |    ]
+                                  |}""".stripMargin
+
+  val multipleMessagesAndInteractions = multipleMessage
+    .copy(interactions = List(simpleInteraction))
+
+  val multipleMessagesAndInteractionsAsString =
+    """{
+      |    "consumer": {
+      |        "name": "Consumer"
+      |    },
+      |    "provider": {
+      |        "name": "Provider"
+      |    },
+      |    "messages": [
+      |        {
+      |            "description": "Published credit data",
+      |            "providerState": "or maybe 'scenario'? not sure about this",
+      |            "contents": {"foo":"bar"},
+      |            "metaData": {
+      |              "contentType": "application/json"
+      |            }
+      |        },
+      |        {
+      |            "description": "Published another credit data",
+      |            "providerState": "or maybe 'scenario'! not sure about this",
+      |            "contents": {"boo":"xxx"},
+      |            "metaData": {
+      |              "contentType": "application/json"
+      |            }
+      |        }
+      |    ],
+      |    "interactions": [
+      |    {
+      |      "description" : "a simple request",
+      |      "request" : {
+      |        "method" : "GET",
+      |        "path" : "/"
+      |      },
+      |      "response" : {
+      |        "status" : 200,
+      |        "body" : "Hello"
+      |      }
+      |     }
+      |    ]
+      | }
+    """.stripMargin
 }

--- a/scalapact-circe-0-8/src/test/scala/com/itv/scalapact/circe08/PactFileExamples.scala
+++ b/scalapact-circe-0-8/src/test/scala/com/itv/scalapact/circe08/PactFileExamples.scala
@@ -293,6 +293,7 @@ object PactFileExamples {
         providerState = Some("or maybe 'scenario'? not sure about this"),
         contents = """Hello world!""",
         metaData = Message.Metadata(),
+        matchingRules = Map("foo" -> MatchingRule(Some("regex"), Some("\\w+"), None)),
         ApplicationText
       )
     )
@@ -311,6 +312,12 @@ object PactFileExamples {
                               |            "providerState": "or maybe 'scenario'? not sure about this",
                               |            "contents": "Hello world!",
                               |            "metaData": {
+                              |            },
+                              |            "matchingRules" : {
+                              |               "foo" : {
+                              |                 "match":"regex",
+                              |                 "regex": "\\w+"
+                              |               }
                               |            }
                               |        }
                               |    ]
@@ -326,6 +333,7 @@ object PactFileExamples {
         providerState = Some("or maybe 'scenario'? not sure about this"),
         contents = """{"foo":"bar"}""",
         metaData = Message.Metadata("contentType" -> "application/json"),
+        matchingRules = Map.empty,
         ApplicationJson
       )
     )
@@ -357,6 +365,7 @@ object PactFileExamples {
         providerState = Some("or maybe 'scenario'! not sure about this"),
         contents = """{"boo":"xxx"}""",
         metaData = Message.Metadata("contentType" -> "application/json"),
+        matchingRules = Map.empty,
         ApplicationJson
       )
     )

--- a/scalapact-circe-0-8/src/test/scala/com/itv/scalapact/circe08/RubyJsonHelperSpec.scala
+++ b/scalapact-circe-0-8/src/test/scala/com/itv/scalapact/circe08/RubyJsonHelperSpec.scala
@@ -1,15 +1,21 @@
 package com.itv.scalapact.circe08
 
 import com.itv.scalapact.shared._
-import org.scalatest.{FunSpec, Matchers}
+import org.scalactic.TypeCheckedTripleEquals
+import org.scalatest.{EitherValues, FunSpec, Matchers}
+import io.circe.parser.parse
+import Matchers._
 
-class RubyJsonHelperSpec extends FunSpec with Matchers {
+class RubyJsonHelperSpec extends FunSpec with EitherValues with TypeCheckedTripleEquals {
 
   describe("Handling ruby json") {
 
     it("should be able to extract the provider") {
 
-      JsonBodySpecialCaseHelper.extractPactActor("provider")(PactFileExamples.simpleAsString) shouldEqual Some(
+      JsonBodySpecialCaseHelper
+        .extractPactActor("provider")(parse(PactFileExamples.simpleAsString).right.value)
+        .right
+        .value should ===(
         PactActor("provider")
       )
 
@@ -17,7 +23,10 @@ class RubyJsonHelperSpec extends FunSpec with Matchers {
 
     it("should be able to extract the consumer") {
 
-      JsonBodySpecialCaseHelper.extractPactActor("consumer")(PactFileExamples.simpleAsString) shouldEqual Some(
+      JsonBodySpecialCaseHelper
+        .extractPactActor("consumer")(parse(PactFileExamples.simpleAsString).right.value)
+        .right
+        .value should ===(
         PactActor("consumer")
       )
 
@@ -91,12 +100,15 @@ class RubyJsonHelperSpec extends FunSpec with Matchers {
           |  ]
           |}""".stripMargin)
 
-      val list = List(
-        (Some(interaction1), interaction1RequestBody, interaction1ResponseBody),
-        (Some(interaction2), interaction2RequestBody, interaction2ResponseBody)
+      JsonBodySpecialCaseHelper
+        .extractInteractionsTuple(parse(PactFileExamples.simpleAsString).right.value)
+        .right
+        .value should ===(
+        List(
+          (interaction1, interaction1RequestBody, interaction1ResponseBody),
+          (interaction2, interaction2RequestBody, interaction2ResponseBody)
+        )
       )
-
-      JsonBodySpecialCaseHelper.extractInteractions(PactFileExamples.simpleAsString) shouldEqual Some(list)
 
     }
 

--- a/scalapact-circe-0-8/src/test/scala/com/itv/scalapact/circe08/ScalaMessagePactReaderWriterSpec.scala
+++ b/scalapact-circe-0-8/src/test/scala/com/itv/scalapact/circe08/ScalaMessagePactReaderWriterSpec.scala
@@ -1,0 +1,48 @@
+package com.itv.scalapact.circe08
+
+import org.scalactic.TypeCheckedTripleEquals
+import org.scalatest.Matchers._
+import org.scalatest.{EitherValues, FlatSpec}
+import io.circe.parser.parse
+
+class ScalaMessagePactReaderWriterSpec extends FlatSpec with EitherValues with TypeCheckedTripleEquals {
+
+  val pactReader = new PactReader
+  val pactWriter = new PactWriter
+
+  List(
+    (PactFileExamples.stringMessageAsString, PactFileExamples.stringMessage),
+    (PactFileExamples.jsonMessageAsString, PactFileExamples.jsonMessage),
+    (PactFileExamples.multipleMessageAsString, PactFileExamples.multipleMessage),
+    (PactFileExamples.multipleMessagesAndInteractionsAsString, PactFileExamples.multipleMessagesAndInteractions)
+  ).foreach {
+    case (expectedWritten, expectedPact) =>
+      it should s"should be able to read Pact files: [$expectedPact]" in {
+
+        val actualPact = pactReader.jsonStringToPact(expectedWritten)
+
+        actualPact should ===(Right(expectedPact))
+      }
+
+      it should s"should be able to write Pact files: [$expectedPact]" in {
+
+        val actualWritten = pactWriter.pactToJsonString(expectedPact)
+
+        parse(actualWritten) should ===(parse(expectedWritten))
+
+      }
+
+      it should s"should be able to eat it's own dog food: [$expectedPact]" in {
+        val actualWritten = pactWriter.pactToJsonString(expectedPact)
+
+        val actualPact = pactReader.jsonStringToPact(actualWritten).right.value
+
+        val `reJson'd` = pactWriter.pactToJsonString(actualPact)
+
+        parse(`reJson'd`) should ===(parse(expectedWritten))
+
+        actualPact should ===(expectedPact)
+      }
+  }
+
+}

--- a/scalapact-circe-0-8/src/test/scala/com/itv/scalapact/circe08/ScalaMessagePactReaderWriterSpec.scala
+++ b/scalapact-circe-0-8/src/test/scala/com/itv/scalapact/circe08/ScalaMessagePactReaderWriterSpec.scala
@@ -10,6 +10,13 @@ class ScalaMessagePactReaderWriterSpec extends FlatSpec with EitherValues with T
   val pactReader = new PactReader
   val pactWriter = new PactWriter
 
+  it should "be able to read message that use 'providerState' instead 'providerStates'" in {
+    val actualPact = pactReader.jsonStringToPact(PactFileExamples.simpleMessageWithProviderStateAsString)
+
+    actualPact should ===(Right(PactFileExamples.stringMessage))
+
+  }
+
   List(
     (PactFileExamples.stringMessageAsString, PactFileExamples.stringMessage),
     (PactFileExamples.jsonMessageAsString, PactFileExamples.jsonMessage),

--- a/scalapact-circe-0-9/src/main/scala/com/itv/scalapact/circe09/JsonConversionFunctions.scala
+++ b/scalapact-circe-0-9/src/main/scala/com/itv/scalapact/circe09/JsonConversionFunctions.scala
@@ -27,10 +27,10 @@ object JsonConversionFunctions extends IJsonConversionFunctions {
         IrNode(label, IrNullNode).withPath(pathToParent)
 
       case j: Json if j.isNumber && j.toString().contains(".") =>
-        IrNode(label, j.asNumber.map(_.toDouble).map(d => IrDecimalNode(d))).withPath(pathToParent)
+        IrNode(label, j.asNumber.flatMap(_.toBigDecimal).map(IrDecimalNode)).withPath(pathToParent)
 
       case j: Json if j.isNumber =>
-        IrNode(label, j.asNumber.flatMap(_.toLong).map(d => IrIntegerNode(d))).withPath(pathToParent)
+        IrNode(label, j.asNumber.flatMap(_.toBigInt).map(IrIntegerNode)).withPath(pathToParent)
 
       case j: Json if j.isBoolean =>
         IrNode(label, j.asBoolean.map(IrBooleanNode)).withPath(pathToParent)

--- a/scalapact-circe-0-9/src/main/scala/com/itv/scalapact/circe09/JsonConversionFunctions.scala
+++ b/scalapact-circe-0-9/src/main/scala/com/itv/scalapact/circe09/JsonConversionFunctions.scala
@@ -26,8 +26,11 @@ object JsonConversionFunctions extends IJsonConversionFunctions {
       case j: Json if j.isNull =>
         IrNode(label, IrNullNode).withPath(pathToParent)
 
+      case j: Json if j.isNumber && j.toString().contains(".") =>
+        IrNode(label, j.asNumber.map(_.toDouble).map(d => IrDecimalNode(d))).withPath(pathToParent)
+
       case j: Json if j.isNumber =>
-        IrNode(label, j.asNumber.map(_.toDouble).map(d => IrNumberNode(d))).withPath(pathToParent)
+        IrNode(label, j.asNumber.flatMap(_.toLong).map(d => IrIntegerNode(d))).withPath(pathToParent)
 
       case j: Json if j.isBoolean =>
         IrNode(label, j.asBoolean.map(IrBooleanNode)).withPath(pathToParent)

--- a/scalapact-circe-0-9/src/main/scala/com/itv/scalapact/circe09/PactImplicits.scala
+++ b/scalapact-circe-0-9/src/main/scala/com/itv/scalapact/circe09/PactImplicits.scala
@@ -30,13 +30,17 @@ object PactImplicits {
       "description"   -> m.description.asJson,
       "providerState" -> m.providerState.asJson,
       "contents" -> (m.contentType match {
-        case ApplicationJson => parse(m.contents).fold(_ => Json.Null, identity)
+        case ApplicationJson => parse(m.contents).toOption.getOrElse(Json.Null)
         case _               => Json.fromString(m.contents)
       }),
-      "metaData" -> m.metaData.asJson
+      "metaData" -> m.metaData.asJson,
+      "matchingRules" -> (m.matchingRules match {
+        case mr if mr.nonEmpty => mr.asJson
+        case _                 => Json.Null
+      })
     )
   }
-
+  @SuppressWarnings(Array("org.wartremover.warts.Any"))
   implicit val messageDecoder: Decoder[Message] = Decoder.decodeJson.emap { json =>
     val cursor = json.hcursor
     (for {
@@ -44,11 +48,13 @@ object PactImplicits {
       providerState <- cursor.downField("providerState").as[Option[String]]
       contents      <- contents(cursor)
       metaData      <- cursor.downField("metaData").as[Metadata]
+      matchingRules <- cursor.downField("matchingRules").as[Option[Map[String, MatchingRule]]]
     } yield
       Message(description,
               providerState,
               contents.as[String].getOrElse(contents.noSpaces),
               metaData,
+              matchingRules.getOrElse(Map.empty),
               contentType(contents)))
       .fold(
         f => Left(s"There was a failure during decoder because ${f.message}: [$f]"),

--- a/scalapact-circe-0-9/src/main/scala/com/itv/scalapact/circe09/PactImplicits.scala
+++ b/scalapact-circe-0-9/src/main/scala/com/itv/scalapact/circe09/PactImplicits.scala
@@ -8,6 +8,7 @@ import io.circe.generic.semiauto._
 import io.circe.parser.parse
 import io.circe.syntax._
 
+@SuppressWarnings(Array("org.wartremover.warts.Any", "org.wartremover.warts.PublicInference"))
 object PactImplicits {
   implicit val pactActorEncoder: Encoder[PactActor] = deriveEncoder[PactActor]
   implicit val pactActorDecoder: Decoder[PactActor] = deriveDecoder[PactActor]
@@ -29,7 +30,7 @@ object PactImplicits {
       "description"   -> m.description.asJson,
       "providerState" -> m.providerState.asJson,
       "contents" -> (m.contentType match {
-        case ApplicationJson => parse(m.contents).right.get
+        case ApplicationJson => parse(m.contents).fold(_ => Json.Null, identity)
         case _               => Json.fromString(m.contents)
       }),
       "metaData" -> m.metaData.asJson
@@ -60,7 +61,7 @@ object PactImplicits {
       .as[String]
       .map(_ => MessageContentType.ApplicationText) //TODO it should be simple to support xml
       .toOption
-      .getOrElse(MessageContentType.ApplicationJson)
+      .getOrElse[MessageContentType](MessageContentType.ApplicationJson)
 
   private def contents(cursor: HCursor): Decoder.Result[Json] =
     cursor

--- a/scalapact-circe-0-9/src/main/scala/com/itv/scalapact/circe09/PactImplicits.scala
+++ b/scalapact-circe-0-9/src/main/scala/com/itv/scalapact/circe09/PactImplicits.scala
@@ -28,6 +28,20 @@ object PactImplicits {
   implicit val interactionEncoder: Encoder[Interaction] = deriveEncoder[Interaction]
   implicit val interactionDecoder: Decoder[Interaction] = deriveDecoder[Interaction]
 
+  implicit val providerStateEncoder: Encoder[ProviderState] = Encoder.instance( ps =>
+    Json.obj(
+      "name" -> ps.name.asJson,
+      "params" -> (ps.params match {
+        case params if params.nonEmpty => params.asJson
+        case _ => Json.Null
+      })
+    )
+  )
+  implicit val providerStateDecoder: Decoder[ProviderState] = Decoder.instance(c => for {
+    name <- c.downField("name").as[String]
+    params <- c.downField("params").as[Option[Map[String,String]]]
+  } yield ProviderState(name, params.getOrElse(Map.empty)))
+
   implicit val messageEncoder: Encoder[Message] = Encoder.instance { m =>
     Json.obj(
       "description"    -> m.description.asJson,
@@ -49,15 +63,15 @@ object PactImplicits {
     (for {
       description    <- cursor.downField("description").as[String]
       providerState  <- cursor.downField("providerState").as[Option[String]]
-      providerStates <- cursor.downField("providerStates").as[Option[List[String]]]
+      providerStates <- cursor.downField("providerStates").as[Option[List[ProviderState]]]
       contents       <- contents(cursor)
       metaData       <- cursor.downField("metaData").as[Metadata]
       matchingRules  <- cursor.downField("matchingRules").as[Option[Message.MatchingRules]]
     } yield
       Message(
         description,
-        providerState.toList ++ providerStates.toList.flatten,
-        contents.as[String].getOrElse(contents.noSpaces),
+        providerState.toList.map(s =>ProviderState(s,Map.empty)) ++ providerStates.toList.flatten,
+        contents.asString.getOrElse(contents.noSpaces),
         metaData,
         matchingRules.getOrElse(Map.empty),
         contentType(contents)

--- a/scalapact-circe-0-9/src/main/scala/com/itv/scalapact/circe09/PactImplicits.scala
+++ b/scalapact-circe-0-9/src/main/scala/com/itv/scalapact/circe09/PactImplicits.scala
@@ -43,20 +43,29 @@ object PactImplicits {
       providerState <- cursor.downField("providerState").as[Option[String]]
       contents      <- contents(cursor)
       metaData      <- cursor.downField("metaData").as[Metadata]
-    } yield Message(description, providerState, contents, metaData))
+    } yield
+      Message(description,
+              providerState,
+              contents.as[String].getOrElse(contents.noSpaces),
+              metaData,
+              contentType(contents)))
       .fold(
         f => Left(s"There was a failure during decoder because ${f.message}: [$f]"),
         Right(_)
       )
   }
 
-  private def contents(cursor: HCursor): Decoder.Result[String] =
+  def contentType(contents: Json): MessageContentType =
+    contents
+      .as[String]
+      .map(_ => MessageContentType.ApplicationText) //TODO it should be simple to support xml
+      .toOption
+      .getOrElse(MessageContentType.ApplicationJson)
+
+  private def contents(cursor: HCursor): Decoder.Result[Json] =
     cursor
       .downField("contents")
       .as[Json]
-      .map(
-        x => x.asString.getOrElse(x.noSpaces)
-      )
 
   implicit val pactEncoder: Encoder[Pact] = deriveEncoder[Pact]
   implicit val pactDecoder: Decoder[Pact] = deriveDecoder[Pact]

--- a/scalapact-circe-0-9/src/main/scala/com/itv/scalapact/circe09/PactImplicits.scala
+++ b/scalapact-circe-0-9/src/main/scala/com/itv/scalapact/circe09/PactImplicits.scala
@@ -1,0 +1,63 @@
+package com.itv.scalapact.circe09
+
+import com.itv.scalapact.shared.Message.Metadata
+import com.itv.scalapact.shared.MessageContentType.ApplicationJson
+import com.itv.scalapact.shared._
+import io.circe._
+import io.circe.generic.semiauto._
+import io.circe.parser.parse
+import io.circe.syntax._
+
+object PactImplicits {
+  implicit val pactActorEncoder: Encoder[PactActor] = deriveEncoder[PactActor]
+  implicit val pactActorDecoder: Decoder[PactActor] = deriveDecoder[PactActor]
+
+  implicit val matchingRulesEncoder: Encoder[MatchingRule] = deriveEncoder[MatchingRule]
+  implicit val matchingRulesDecoder: Decoder[MatchingRule] = deriveDecoder[MatchingRule]
+
+  implicit val interactionRequestEncoder: Encoder[InteractionRequest] = deriveEncoder[InteractionRequest]
+  implicit val interactionRequestDecoder: Decoder[InteractionRequest] = deriveDecoder[InteractionRequest]
+
+  implicit val InteractionResponseEncoder: Encoder[InteractionResponse] = deriveEncoder[InteractionResponse]
+  implicit val InteractionResponseDecoder: Decoder[InteractionResponse] = deriveDecoder[InteractionResponse]
+
+  implicit val interactionEncoder: Encoder[Interaction] = deriveEncoder[Interaction]
+  implicit val interactionDecoder: Decoder[Interaction] = deriveDecoder[Interaction]
+
+  implicit val messageEncoder: Encoder[Message] = Encoder.instance { m =>
+    Json.obj(
+      "description"   -> m.description.asJson,
+      "providerState" -> m.providerState.asJson,
+      "contents" -> (m.contentType match {
+        case ApplicationJson => parse(m.contents).right.get
+        case _               => Json.fromString(m.contents)
+      }),
+      "metaData" -> m.metaData.asJson
+    )
+  }
+
+  implicit val messageDecoder: Decoder[Message] = Decoder.decodeJson.emap { json =>
+    val cursor = json.hcursor
+    (for {
+      description   <- cursor.downField("description").as[String]
+      providerState <- cursor.downField("providerState").as[Option[String]]
+      contents      <- contents(cursor)
+      metaData      <- cursor.downField("metaData").as[Metadata]
+    } yield Message(description, providerState, contents, metaData))
+      .fold(
+        f => Left(s"There was a failure during decoder because ${f.message}: [$f]"),
+        Right(_)
+      )
+  }
+
+  private def contents(cursor: HCursor): Decoder.Result[String] =
+    cursor
+      .downField("contents")
+      .as[Json]
+      .map(
+        x => x.asString.getOrElse(x.noSpaces)
+      )
+
+  implicit val pactEncoder: Encoder[Pact] = deriveEncoder[Pact]
+  implicit val pactDecoder: Decoder[Pact] = deriveDecoder[Pact]
+}

--- a/scalapact-circe-0-9/src/main/scala/com/itv/scalapact/circe09/PactImplicits.scala
+++ b/scalapact-circe-0-9/src/main/scala/com/itv/scalapact/circe09/PactImplicits.scala
@@ -13,6 +13,9 @@ object PactImplicits {
   implicit val pactActorEncoder: Encoder[PactActor] = deriveEncoder[PactActor]
   implicit val pactActorDecoder: Decoder[PactActor] = deriveDecoder[PactActor]
 
+  implicit val messageMatchersEncoder: Encoder[Message.Matchers] = deriveEncoder[Message.Matchers]
+  implicit val messageMatchersDecoder: Decoder[Message.Matchers] = deriveDecoder[Message.Matchers]
+
   implicit val matchingRulesEncoder: Encoder[MatchingRule] = deriveEncoder[MatchingRule]
   implicit val matchingRulesDecoder: Decoder[MatchingRule] = deriveDecoder[MatchingRule]
 
@@ -48,7 +51,7 @@ object PactImplicits {
       providerState <- cursor.downField("providerState").as[Option[String]]
       contents      <- contents(cursor)
       metaData      <- cursor.downField("metaData").as[Metadata]
-      matchingRules <- cursor.downField("matchingRules").as[Option[Map[String, MatchingRule]]]
+      matchingRules <- cursor.downField("matchingRules").as[Option[Message.MatchingRules]]
     } yield
       Message(description,
               providerState,

--- a/scalapact-circe-0-9/src/main/scala/com/itv/scalapact/circe09/PactImplicits.scala
+++ b/scalapact-circe-0-9/src/main/scala/com/itv/scalapact/circe09/PactImplicits.scala
@@ -65,7 +65,7 @@ object PactImplicits {
   def contentType(contents: Json): MessageContentType =
     contents
       .as[String]
-      .map(_ => MessageContentType.ApplicationText) //TODO it should be simple to support xml
+      .map(_ => MessageContentType.ApplicationText)
       .toOption
       .getOrElse[MessageContentType](MessageContentType.ApplicationJson)
 

--- a/scalapact-circe-0-9/src/main/scala/com/itv/scalapact/circe09/PactImplicits.scala
+++ b/scalapact-circe-0-9/src/main/scala/com/itv/scalapact/circe09/PactImplicits.scala
@@ -30,8 +30,8 @@ object PactImplicits {
 
   implicit val messageEncoder: Encoder[Message] = Encoder.instance { m =>
     Json.obj(
-      "description"   -> m.description.asJson,
-      "providerState" -> m.providerState.asJson,
+      "description"    -> m.description.asJson,
+      "providerStates" -> m.providerStates.asJson,
       "contents" -> (m.contentType match {
         case ApplicationJson => parse(m.contents).toOption.getOrElse(Json.Null)
         case _               => Json.fromString(m.contents)
@@ -47,18 +47,21 @@ object PactImplicits {
   implicit val messageDecoder: Decoder[Message] = Decoder.decodeJson.emap { json =>
     val cursor = json.hcursor
     (for {
-      description   <- cursor.downField("description").as[String]
-      providerState <- cursor.downField("providerState").as[Option[String]]
-      contents      <- contents(cursor)
-      metaData      <- cursor.downField("metaData").as[Metadata]
-      matchingRules <- cursor.downField("matchingRules").as[Option[Message.MatchingRules]]
+      description    <- cursor.downField("description").as[String]
+      providerState  <- cursor.downField("providerState").as[Option[String]]
+      providerStates <- cursor.downField("providerStates").as[Option[List[String]]]
+      contents       <- contents(cursor)
+      metaData       <- cursor.downField("metaData").as[Metadata]
+      matchingRules  <- cursor.downField("matchingRules").as[Option[Message.MatchingRules]]
     } yield
-      Message(description,
-              providerState,
-              contents.as[String].getOrElse(contents.noSpaces),
-              metaData,
-              matchingRules.getOrElse(Map.empty),
-              contentType(contents)))
+      Message(
+        description,
+        providerState.toList ++ providerStates.toList.flatten,
+        contents.as[String].getOrElse(contents.noSpaces),
+        metaData,
+        matchingRules.getOrElse(Map.empty),
+        contentType(contents)
+      ))
       .fold(
         f => Left(s"There was a failure during decoder because ${f.message}: [$f]"),
         Right(_)

--- a/scalapact-circe-0-9/src/main/scala/com/itv/scalapact/circe09/PactReader.scala
+++ b/scalapact-circe-0-9/src/main/scala/com/itv/scalapact/circe09/PactReader.scala
@@ -1,105 +1,133 @@
 package com.itv.scalapact.circe09
 
-import io.circe._
-import io.circe.parser._
-import io.circe.generic.auto._
 import com.itv.scalapact.shared._
 import com.itv.scalapact.shared.matchir.IrNode
 import com.itv.scalapact.shared.typeclasses.IPactReader
+import io.circe._
+import io.circe.parser._
 
 class PactReader extends IPactReader {
 
   def fromJSON(jsonString: String): Option[IrNode] =
     JsonConversionFunctions.fromJSON(jsonString)
 
-  def jsonStringToPact(json: String): Either[String, Pact] = {
-    val brokenPact: Option[(PactActor, PactActor, List[(Option[Interaction], Option[String], Option[String])])] = for {
-      provider     <- JsonBodySpecialCaseHelper.extractPactActor("provider")(json)
-      consumer     <- JsonBodySpecialCaseHelper.extractPactActor("consumer")(json)
-      interactions <- JsonBodySpecialCaseHelper.extractInteractions(json)
-    } yield (provider, consumer, interactions)
-
-    brokenPact.map { bp =>
-      val interactions = bp._3.collect {
-        case (Some(i), r1, r2) =>
-          i.copy(
-            request = i.request.copy(body = r1),
-            response = i.response.copy(body = r2)
-          )
-      }
-
-      Pact(
-        provider = bp._1,
-        consumer = bp._2,
-        messages = Nil, //TODO: implement this
-        interactions = interactions
-          .map(i => i.copy(providerState = i.providerState.orElse(i.provider_state)))
-          .map(i => i.copy(provider_state = None))
+  def jsonStringToPact(json: String): Either[String, Pact] =
+    (for {
+      parsedJson   <- parse(json)
+      provider     <- JsonBodySpecialCaseHelper.extractPactActor("provider")(parsedJson)
+      consumer     <- JsonBodySpecialCaseHelper.extractPactActor("consumer")(parsedJson)
+      interactions <- JsonBodySpecialCaseHelper.extractInteractions(parsedJson)
+      messages     <- JsonBodySpecialCaseHelper.extractMessages(parsedJson)
+    } yield Pact(provider, consumer, interactions, messages))
+      .fold(
+        x => Left(s"There was a failure ${x.getMessage}: [$x]"),
+        Right(_)
       )
-
-    } match {
-      case Some(pact) => Right(pact)
-      case None       => Left(s"Could not read pact from json: $json")
-    }
-  }
-
 }
 
 object JsonBodySpecialCaseHelper {
+  import PactImplicits._
 
+  type JsonParser[T]                = Json => Decoder.Result[T]
+  type InterationTuple              = (Interaction, Option[String], Option[String])
+  type InteractionTupleDecodeResult = Decoder.Result[List[InterationTuple]]
   @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
-  val extractPactActor: String => String => Option[PactActor] = field =>
-    json => {
-      parse(json).toOption.flatMap(_.hcursor.downField(field).focus.flatMap(_.as[PactActor].toOption))
+  val extractPactActor: String => JsonParser[PactActor] = field =>
+    json =>
+      json.asObject
+        .flatMap(_(field).map(_.as[PactActor]))
+        .getOrElse(fail(s"field `$field` does not exist"))
+
+  @SuppressWarnings(Array("org.wartremover.warts.PublicInference", "org.wartremover.warts.Any"))
+  val extractInteractions: JsonParser[List[Interaction]] = json =>
+    extractInteractionsTuple(json).map(_.map {
+      case (interaction, request, response) =>
+        interaction.copy(
+          request = interaction.request.copy(body = request),
+          response = interaction.response.copy(body = response),
+          provider_state = None,
+          providerState = interaction.providerState.orElse(interaction.provider_state)
+        )
+
+    })
+
+  protected[circe09] val extractInteractionsTuple: JsonParser[List[InterationTuple]] = json => {
+    json.asObject
+      .flatMap(_("interactions"))
+      .fold(suceed(Vector.empty[Json]))(
+        _.asArray.fold(fail[Vector[Json]](s"`interactions` field is not an array: [$json]"))(suceed)
+      )
+      .flatMap {
+        _.map(parseInteractionTuple)
+          .foldLeft(suceed(List.empty[InterationTuple])) { (acc: InteractionTupleDecodeResult, next) =>
+            next.fold(
+              fail[List[InterationTuple]],
+              x =>
+                acc.fold[InteractionTupleDecodeResult](
+                  _ => acc,
+                  currentList => x.fold(acc)(nextTuple => suceed(currentList ++ List(nextTuple)))
+              )
+            )
+          }
+      }
   }
 
-  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
-  val extractInteractions: String => Option[List[(Option[Interaction], Option[String], Option[String])]] = json => {
+  private def parseInteractionTuple: JsonParser[Option[InterationTuple]] = json => {
+    val minusRequestBody =
+      json.hcursor.downField("request").downField("body").delete.top match {
+        case ok @ Some(_) => ok
+        case None         => Option(json)
+      }
 
-    val interactions =
-      parse(json).toOption
-        .flatMap { j =>
-          j.hcursor.downField("interactions").focus.flatMap(p => p.asArray.map(_.toList))
-        }
-
-    val makeOptionalBody: Json => Option[String] = {
-      case body: Json if body.isString =>
-        body.asString
-
-      case body =>
-        Option(body.pretty(Printer.spaces2.copy(dropNullValues = true)))
-    }
-
-    interactions.map { is =>
-      is.map { i =>
-        val minusRequestBody =
-          i.hcursor.downField("request").downField("body").delete.top match {
-            case ok @ Some(_) => ok
-            case None         => Option(i)
-          }
-
-        val minusResponseBody = minusRequestBody.flatMap { ii =>
-          ii.hcursor.downField("response").downField("body").delete.top match {
-            case ok @ Some(_) => ok
-            case None         => minusRequestBody // There wasn't a body, but there was still an interaction.
-          }
-        }
-
-        val requestBody = i.hcursor
-          .downField("request")
-          .downField("body")
-          .focus
-          .flatMap { makeOptionalBody }
-
-        val responseBody = i.hcursor
-          .downField("response")
-          .downField("body")
-          .focus
-          .flatMap { makeOptionalBody }
-
-        (minusResponseBody.flatMap(p => p.as[Interaction].toOption), requestBody, responseBody)
+    val minusResponseBody = minusRequestBody.flatMap { ii =>
+      ii.hcursor.downField("response").downField("body").delete.top match {
+        case ok @ Some(_) => ok
+        case None         => minusRequestBody // There wasn't a body, but there was still an interaction.
       }
     }
+
+    val requestBody = json.hcursor
+      .downField("request")
+      .downField("body")
+      .focus
+      .flatMap {
+        makeOptionalBody
+      }
+
+    val responseBody = json.hcursor
+      .downField("response")
+      .downField("body")
+      .focus
+      .flatMap {
+        makeOptionalBody
+      }
+
+    minusResponseBody
+      .map(_.as[Interaction])
+      .map(dr => dr.map(x => Option((x, requestBody, responseBody))))
+      .getOrElse(suceed(None))
   }
+  @SuppressWarnings(Array("org.wartremover.warts.PublicInference", "org.wartremover.warts.Any"))
+  val extractMessages: JsonParser[List[Message]] = _.asObject
+    .flatMap(_("messages"))
+    .map(_.as[List[Message]])
+    .getOrElse(suceed(List.empty[Message]))
+
+  private val makeOptionalBody: Json => Option[String] = {
+    case body: Json if body.isString =>
+      body.asString
+
+    case body =>
+      Option(body.toString)
+  }
+
+  private def fail[T](value: DecodingFailure): Either[DecodingFailure, T] =
+    Left(value)
+
+  private def fail[T](value: String): Either[DecodingFailure, T] =
+    Left(DecodingFailure(value, List.empty))
+
+  private def suceed[T](value: T): Either[DecodingFailure, T] =
+    Right(value)
 
 }

--- a/scalapact-circe-0-9/src/main/scala/com/itv/scalapact/circe09/PactReader.scala
+++ b/scalapact-circe-0-9/src/main/scala/com/itv/scalapact/circe09/PactReader.scala
@@ -31,6 +31,7 @@ class PactReader extends IPactReader {
       Pact(
         provider = bp._1,
         consumer = bp._2,
+        messages = Nil, //TODO: implement this
         interactions = interactions
           .map(i => i.copy(providerState = i.providerState.orElse(i.provider_state)))
           .map(i => i.copy(provider_state = None))

--- a/scalapact-circe-0-9/src/main/scala/com/itv/scalapact/circe09/PactWriter.scala
+++ b/scalapact-circe-0-9/src/main/scala/com/itv/scalapact/circe09/PactWriter.scala
@@ -15,19 +15,18 @@ class PactWriter extends IPactWriter {
     val messages = pact.messages.toVector.map { m =>
       val content = m.contentType.jsonRepresentation match {
         case JsonRepresentation.AsString =>
-          Json.fromString(m.content)
+          Json.fromString(m.contents)
         case JsonRepresentation.AsObject =>
-          parse(m.content).fold(_ => Json.obj(), identity) //we produce a blank object here if the encoder fails!
+          parse(m.contents).fold(_ => Json.obj(), identity) //we produce a blank object here if the encoder fails!
       }
 
       Json.obj(
-        "description" -> Json.fromString(m.description),
+        "description"   -> Json.fromString(m.description),
         "providerState" -> m.providerState.asJson,
-        "contents" -> content,
-        "metaData" -> m.meta.asJson
+        "contents"      -> content,
+        "metaData"      -> m.metaData.asJson
       )
     }
-
 
     val interactions: Vector[Json] =
       pact.interactions.toVector

--- a/scalapact-circe-0-9/src/main/scala/com/itv/scalapact/circe09/package.scala
+++ b/scalapact-circe-0-9/src/main/scala/com/itv/scalapact/circe09/package.scala
@@ -1,8 +1,24 @@
 package com.itv.scalapact
 
-import com.itv.scalapact.shared.typeclasses.{IPactReader, IPactWriter}
+import com.itv.scalapact.shared.{JsonRepresentation, MessageContentType}
+import com.itv.scalapact.shared.typeclasses.{IMessageFormat, IPactReader, IPactWriter, MessageFormatError}
+import io.circe.Json
+import io.circe.parser.parse
+import cats.syntax.either._
 
 package object circe09 {
+
+  object `application/json` extends MessageContentType {
+    override def renderString = "application/json"
+    override def jsonRepresentation = JsonRepresentation.AsObject
+  }
+
+  implicit object JsonMessageFormat extends IMessageFormat[Json] {
+    override def contentType: MessageContentType = `application/json`
+    override def encode(json: Json): String = json.toString()
+    override def decode(s: String): Either[MessageFormatError, Json] =
+      parse(s).leftMap(err => MessageFormatError(err.getMessage()))
+  }
 
   implicit val pactReaderInstance: IPactReader =
     new PactReader

--- a/scalapact-circe-0-9/src/main/scala/com/itv/scalapact/json/package.scala
+++ b/scalapact-circe-0-9/src/main/scala/com/itv/scalapact/json/package.scala
@@ -28,7 +28,7 @@ package object json {
   object ext {
 
     implicit val inferTypeInstance: IInferTypes[Json] = new IInferTypes[Json] {
-      override protected def inferFrom(t: Json): Map[String, String] = typesFrom(".", t, Set.empty).toMap
+      override protected def inferFrom(t: Json): Map[String, String] = typesFrom("$.body.", t, Set.empty).toMap
 
       private def typesFrom(path: String, json: Json, acc: Set[(String, String)]): Set[(String, String)] = {
 

--- a/scalapact-circe-0-9/src/main/scala/com/itv/scalapact/json/package.scala
+++ b/scalapact-circe-0-9/src/main/scala/com/itv/scalapact/json/package.scala
@@ -1,7 +1,11 @@
 package com.itv.scalapact
 
 import com.itv.scalapact.circe09.{PactReader, PactWriter}
-import com.itv.scalapact.shared.typeclasses.{IPactReader, IPactWriter}
+import com.itv.scalapact.shared.MessageContentType
+import com.itv.scalapact.shared.MessageContentType.ApplicationJson
+import com.itv.scalapact.shared.typeclasses.{IMessageFormat, IPactReader, IPactWriter, MessageFormatError}
+import io.circe.Json
+import io.circe.parser.parse
 
 package object json {
   implicit val pactReaderInstance: IPactReader =
@@ -9,4 +13,13 @@ package object json {
 
   implicit val pactWriterInstance: IPactWriter =
     new PactWriter
+
+  implicit val jsonMessageFormatInstance = new IMessageFormat[Json] {
+    override def contentType: MessageContentType = ApplicationJson
+
+    override def encode(t: Json): String = t.noSpaces
+
+    override def decode(s: String): Either[MessageFormatError, Json] =
+      parse(s).fold(m => Left(MessageFormatError(m.message)), Right(_))
+  }
 }

--- a/scalapact-circe-0-9/src/main/scala/com/itv/scalapact/json/package.scala
+++ b/scalapact-circe-0-9/src/main/scala/com/itv/scalapact/json/package.scala
@@ -30,9 +30,7 @@ package object json {
 
       def typesFromJsonObject(path: String, acc: Set[(String, String)])(json: JsonObject): Set[(String, String)] = {
         def typeNumber(jsonNumber: JsonNumber): String =
-          (jsonNumber.toLong.map(x => if (x <= Int.MaxValue && x >= Int.MinValue) "integer" else "long") orElse Some(
-            "double"
-          )).getOrElse("number")
+          jsonNumber.toLong.map(_ => "integer").getOrElse("decimal")
 
         json.keys
           .flatMap(
@@ -43,10 +41,10 @@ package object json {
 
                 jsonValue.fold(
                   Set.empty,
-                  _ => Set(pair("boolean")),
+                  _ => Set.empty,
                   value => Set(pair(typeNumber(value))),
-                  _ => Set(pair("string")),
-                  _ => acc ++ Set(pair("array")),
+                  _ => Set.empty,
+                  _ => Set.empty,
                   x => typesFromJsonObject(s"$currentPath.", Set(pair("object")) ++ acc)(x)
                 )
             }

--- a/scalapact-circe-0-9/src/main/scala/com/itv/scalapact/json/package.scala
+++ b/scalapact-circe-0-9/src/main/scala/com/itv/scalapact/json/package.scala
@@ -14,7 +14,7 @@ package object json {
   implicit val pactWriterInstance: IPactWriter =
     new PactWriter
 
-  implicit val jsonMessageFormatInstance = new IMessageFormat[Json] {
+  implicit val jsonMessageFormatInstance: IMessageFormat[Json] = new IMessageFormat[Json] {
     override def contentType: MessageContentType = ApplicationJson
 
     override def encode(t: Json): String = t.noSpaces

--- a/scalapact-circe-0-9/src/test/scala/com/itv/scalapact/circe09/IITypeInferTypeSpec.scala
+++ b/scalapact-circe-0-9/src/test/scala/com/itv/scalapact/circe09/IITypeInferTypeSpec.scala
@@ -8,7 +8,7 @@ import com.itv.scalapact.shared.MatchingRule
 import org.scalactic.TypeCheckedTripleEquals
 
 class IITypeInferTypeSpec extends FlatSpec with TypeCheckedTripleEquals {
-  import json.inferTypeInstance
+  import json.ext.inferTypeInstance
 
   it should "infer types from a json" in {
     inferTypeInstance

--- a/scalapact-circe-0-9/src/test/scala/com/itv/scalapact/circe09/IITypeInferTypeSpec.scala
+++ b/scalapact-circe-0-9/src/test/scala/com/itv/scalapact/circe09/IITypeInferTypeSpec.scala
@@ -35,12 +35,12 @@ class IITypeInferTypeSpec extends FlatSpec with TypeCheckedTripleEquals {
         )
       ) should ===(
       Map(
-        ".key2"   -> "integer",
-        ".key3"   -> "integer",
-        ".key4"   -> "integer",
-        ".key5"   -> "integer",
-        ".key6"   -> "integer",
-        ".key7.m" -> "decimal"
+        "$.body.key2"   -> "integer",
+        "$.body.key3"   -> "integer",
+        "$.body.key4"   -> "integer",
+        "$.body.key5"   -> "integer",
+        "$.body.key6"   -> "integer",
+        "$.body.key7.m" -> "decimal"
       ).mapValues(matchingRule)
     )
   }

--- a/scalapact-circe-0-9/src/test/scala/com/itv/scalapact/circe09/IITypeInferTypeSpec.scala
+++ b/scalapact-circe-0-9/src/test/scala/com/itv/scalapact/circe09/IITypeInferTypeSpec.scala
@@ -35,15 +35,12 @@ class IITypeInferTypeSpec extends FlatSpec with TypeCheckedTripleEquals {
         )
       ) should ===(
       Map(
-        ".key1"   -> "string",
         ".key2"   -> "integer",
-        ".key3"   -> "long",
+        ".key3"   -> "integer",
         ".key4"   -> "integer",
-        ".key5"   -> "long",
+        ".key5"   -> "integer",
         ".key6"   -> "integer",
-        ".key7.m" -> "double",
-        ".key8"   -> "array",
-        ".key9"   -> "array"
+        ".key7.m" -> "decimal"
       ).mapValues(matchingRule)
     )
   }

--- a/scalapact-circe-0-9/src/test/scala/com/itv/scalapact/circe09/IITypeInferTypeSpec.scala
+++ b/scalapact-circe-0-9/src/test/scala/com/itv/scalapact/circe09/IITypeInferTypeSpec.scala
@@ -1,0 +1,64 @@
+package com.itv.scalapact.circe09
+
+import io.circe.Json
+import com.itv.scalapact.json
+import org.scalatest.{FlatSpec, Matchers}
+import Matchers._
+import com.itv.scalapact.shared.MatchingRule
+import org.scalactic.TypeCheckedTripleEquals
+
+class IITypeInferTypeSpec extends FlatSpec with TypeCheckedTripleEquals {
+  import json.inferTypeInstance
+
+  it should "infer types from a json" in {
+    inferTypeInstance
+      .infer(
+        Json.obj(
+          "key1" -> Json.fromString("value1"),
+          "key2" -> Json.fromInt(333),
+          "key3" -> Json.fromLong(Int.MinValue.toLong - 1),
+          "key4" -> Json.fromLong(Int.MinValue.toLong + 1),
+          "key5" -> Json.fromLong(Int.MaxValue.toLong + 1),
+          "key6" -> Json.fromLong(Int.MaxValue.toLong - 1),
+          "key7" -> Json.obj("m" -> Json.fromDouble(1.1).get),
+          "key8" -> Json.arr(
+            Json.fromBoolean(false),
+            Json.obj(
+              "key" -> Json.fromBoolean(true)
+            )
+          ),
+          "key9" -> Json.arr(
+            Json.obj(
+              "key" -> Json.fromBoolean(true)
+            )
+          )
+        )
+      ) should ===(
+      Map(
+        ".key1"   -> "string",
+        ".key2"   -> "integer",
+        ".key3"   -> "long",
+        ".key4"   -> "integer",
+        ".key5"   -> "long",
+        ".key6"   -> "integer",
+        ".key7.m" -> "double",
+        ".key8"   -> "array",
+        ".key9"   -> "array"
+      ).mapValues(matchingRule)
+    )
+  }
+
+  it should "not infer types from a json that are not objects or arrays" in {
+    inferTypeInstance
+      .infer(Json.fromInt(22)) should ===(Map.empty[String, MatchingRule])
+  }
+
+  it should "not infer types arrays that contain simple types" in {
+    inferTypeInstance
+      .infer(Json.arr(Json.fromString(""))) should ===(Map.empty[String, MatchingRule])
+  }
+
+  /*[{name: "", age: 10, nin: 1000},{name: "", age: 10}]*/
+  def matchingRule(valueType: String): MatchingRule = MatchingRule(Some(valueType), None, None)
+
+}

--- a/scalapact-circe-0-9/src/test/scala/com/itv/scalapact/circe09/IMessageFormatSpec.scala
+++ b/scalapact-circe-0-9/src/test/scala/com/itv/scalapact/circe09/IMessageFormatSpec.scala
@@ -1,0 +1,24 @@
+package com.itv.scalapact.circe09
+
+import io.circe.Json
+import org.scalactic.TypeCheckedTripleEquals
+import org.scalatest.Matchers._
+import org.scalatest.{EitherValues, FlatSpec}
+
+class IMessageFormatSpec extends FlatSpec with EitherValues with TypeCheckedTripleEquals {
+  import com.itv.scalapact.json.jsonMessageFormatInstance
+
+  it should "decode a string to json" in {
+    jsonMessageFormatInstance.decode("""{"key1": "value1"}""").right.value should ===(
+      Json.obj("key1" -> Json.fromString("value1"))
+    )
+  }
+
+  it should "fail when decode a string is not valid json" in {
+    jsonMessageFormatInstance.decode("""{"key2": value2}""").left.value.msg should include("expected json value")
+  }
+
+  it should "encode json to string" in {
+    jsonMessageFormatInstance.encode(Json.obj("key4" -> Json.fromString("value4"))) should ===("""{"key4":"value4"}""")
+  }
+}

--- a/scalapact-circe-0-9/src/test/scala/com/itv/scalapact/circe09/PactFileExamples.scala
+++ b/scalapact-circe-0-9/src/test/scala/com/itv/scalapact/circe09/PactFileExamples.scala
@@ -290,7 +290,7 @@ object PactFileExamples {
     messages = List(
       Message(
         description = "Published credit data",
-        providerStates = List("or maybe 'scenario'? not sure about this"),
+        providerStates = List(ProviderState("or maybe 'scenario'? not sure about this", Map.empty)),
         contents = """Hello world!""",
         metaData = Message.Metadata(),
         matchingRules =
@@ -341,7 +341,9 @@ object PactFileExamples {
                                 |    "messages": [
                                 |        {
                                 |            "description": "Published credit data",
-                                |            "providerStates": ["or maybe 'scenario'? not sure about this"],
+                                |            "providerStates": [
+                                |               { "name" : "or maybe 'scenario'? not sure about this" }
+                                |            ],
                                 |            "contents": "Hello world!",
                                 |            "metaData": {
                                 |            },
@@ -368,7 +370,7 @@ object PactFileExamples {
     messages = List(
       Message(
         description = "Published credit data",
-        providerStates = List("or maybe 'scenario'? not sure about this"),
+        providerStates = List(ProviderState("or maybe 'scenario'? not sure about this", Map.empty)),
         contents = """{"foo":"bar"}""",
         metaData = Message.Metadata("contentType" -> "application/json"),
         matchingRules = Map.empty,
@@ -387,7 +389,7 @@ object PactFileExamples {
                               |    "messages": [
                               |        {
                               |            "description": "Published credit data",
-                              |            "providerStates": ["or maybe 'scenario'? not sure about this"],
+                              |            "providerStates": [{"name": "or maybe 'scenario'? not sure about this"}],
                               |            "contents": {"foo":"bar"},
                               |            "metaData": {
                               |              "contentType": "application/json"
@@ -400,7 +402,7 @@ object PactFileExamples {
     messages = jsonMessage.messages ++ List(
       Message(
         description = "Published another credit data",
-        providerStates = List("or maybe 'scenario'! not sure about this"),
+        providerStates = List(ProviderState("or maybe 'scenario'! not sure about this", Map("randomParameter" -> "randomValue"))),
         contents = """{"boo":"xxx","foo":123}""",
         metaData = Message.Metadata("contentType" -> "application/json"),
         matchingRules = Map(
@@ -423,7 +425,7 @@ object PactFileExamples {
                                   |    "messages": [
                                   |        {
                                   |            "description": "Published credit data",
-                                  |            "providerStates": ["or maybe 'scenario'? not sure about this"],
+                                  |            "providerStates": [{"name": "or maybe 'scenario'? not sure about this"}],
                                   |            "contents": {"foo":"bar"},
                                   |            "metaData": {
                                   |              "contentType": "application/json"
@@ -431,7 +433,12 @@ object PactFileExamples {
                                   |        },
                                   |        {
                                   |            "description": "Published another credit data",
-                                  |            "providerStates": ["or maybe 'scenario'! not sure about this"],
+                                  |            "providerStates": [
+                                  |               {
+                                  |                  "name" : "or maybe 'scenario'! not sure about this",
+                                  |                  "params" : {"randomParameter" : "randomValue"}
+                                  |                }
+                                  |           ],
                                   |            "contents": {"boo":"xxx","foo":123},
                                   |            "matchingRules" : {
                                   |              "body" : {
@@ -465,7 +472,7 @@ object PactFileExamples {
       |    "messages": [
       |        {
       |            "description": "Published credit data",
-      |            "providerStates": ["or maybe 'scenario'? not sure about this"],
+      |            "providerStates": [{"name": "or maybe 'scenario'? not sure about this"}],
       |            "contents": {"foo":"bar"},
       |            "metaData": {
       |              "contentType": "application/json"
@@ -473,7 +480,12 @@ object PactFileExamples {
       |        },
       |        {
       |            "description": "Published another credit data",
-      |            "providerStates": ["or maybe 'scenario'! not sure about this"],
+      |            "providerStates": [
+      |               {
+      |                 "name" : "or maybe 'scenario'! not sure about this",
+      |                 "params" : {"randomParameter" : "randomValue"}
+      |               }
+      |             ],
       |            "contents": {"boo":"xxx","foo":123},
       |            "matchingRules" : {
       |              "body" : {

--- a/scalapact-circe-0-9/src/test/scala/com/itv/scalapact/circe09/PactFileExamples.scala
+++ b/scalapact-circe-0-9/src/test/scala/com/itv/scalapact/circe09/PactFileExamples.scala
@@ -293,7 +293,8 @@ object PactFileExamples {
         providerState = Some("or maybe 'scenario'? not sure about this"),
         contents = """Hello world!""",
         metaData = Message.Metadata(),
-        matchingRules = Map("foo" -> MatchingRule(Some("regex"), Some("\\w+"), None)),
+        matchingRules =
+          Map("body" -> Map("$.foo" -> Message.Matchers(List(MatchingRule(Some("regex"), Some("\\w+"), None))))),
         ApplicationText
       )
     )
@@ -314,10 +315,16 @@ object PactFileExamples {
                                 |            "metaData": {
                                 |            },
                                 |            "matchingRules" : {
-                                |               "foo" : {
-                                |                 "match":"regex",
-                                |                 "regex": "\\w+"
-                                |               }
+                                |              "body" : {
+                                |                "$.foo" : {
+                                |                  "matchers": [
+                                |                    {
+                                |                      "match":"regex",
+                                |                      "regex": "\\w+"
+                                |                    }
+                                |                  ]
+                                |                }
+                                |              }
                                 |            }
                                 |        }
                                 |    ]
@@ -366,7 +373,10 @@ object PactFileExamples {
         contents = """{"boo":"xxx","foo":123}""",
         metaData = Message.Metadata("contentType" -> "application/json"),
         matchingRules = Map(
-          "foo" -> MatchingRule(Some("integer"), None, None)
+          "body" ->
+            Map(
+              "$.foo" -> Message.Matchers(List(MatchingRule(Some("integer"), None, None)))
+            )
         ),
         ApplicationJson
       )
@@ -392,9 +402,15 @@ object PactFileExamples {
                                   |            "description": "Published another credit data",
                                   |            "providerState": "or maybe 'scenario'! not sure about this",
                                   |            "contents": {"boo":"xxx","foo":123},
-                                  |            "matchingRules": {
-                                  |              "foo" : {
-                                  |                  "match": "integer"
+                                  |            "matchingRules" : {
+                                  |              "body" : {
+                                  |                "$.foo" : {
+                                  |                  "matchers": [
+                                  |                    {
+                                  |                      "match":"integer"
+                                  |                    }
+                                  |                  ]
+                                  |                }
                                   |              }
                                   |            },
                                   |            "metaData": {
@@ -428,9 +444,15 @@ object PactFileExamples {
       |            "description": "Published another credit data",
       |            "providerState": "or maybe 'scenario'! not sure about this",
       |            "contents": {"boo":"xxx","foo":123},
-      |            "matchingRules": {
-      |              "foo" : {
-      |                  "match": "integer"
+      |            "matchingRules" : {
+      |              "body" : {
+      |                "$.foo" : {
+      |                  "matchers": [
+      |                    {
+      |                      "match":"integer"
+      |                    }
+      |                  ]
+      |                }
       |              }
       |            },
       |            "metaData": {

--- a/scalapact-circe-0-9/src/test/scala/com/itv/scalapact/circe09/PactFileExamples.scala
+++ b/scalapact-circe-0-9/src/test/scala/com/itv/scalapact/circe09/PactFileExamples.scala
@@ -58,6 +58,7 @@ object PactFileExamples {
   val verySimple = Pact(
     consumer = PactActor("consumer"),
     provider = PactActor("provider"),
+    messages = Nil, //TODO: add this field
     interactions = List(
       Interaction(
         provider_state = None,
@@ -107,6 +108,7 @@ object PactFileExamples {
   val simple = Pact(
     consumer = PactActor("consumer"),
     provider = PactActor("provider"),
+    messages = Nil, //TODO: add this field
     interactions = List(
       Interaction(
         provider_state = None,

--- a/scalapact-circe-0-9/src/test/scala/com/itv/scalapact/circe09/PactFileExamples.scala
+++ b/scalapact-circe-0-9/src/test/scala/com/itv/scalapact/circe09/PactFileExamples.scala
@@ -363,9 +363,11 @@ object PactFileExamples {
       Message(
         description = "Published another credit data",
         providerState = Some("or maybe 'scenario'! not sure about this"),
-        contents = """{"boo":"xxx"}""",
+        contents = """{"boo":"xxx","foo":123}""",
         metaData = Message.Metadata("contentType" -> "application/json"),
-        matchingRules = Map.empty,
+        matchingRules = Map(
+          "foo" -> MatchingRule(Some("integer"),None, None)
+        ),
         ApplicationJson
       )
     )
@@ -389,7 +391,12 @@ object PactFileExamples {
                                   |        {
                                   |            "description": "Published another credit data",
                                   |            "providerState": "or maybe 'scenario'! not sure about this",
-                                  |            "contents": {"boo":"xxx"},
+                                  |            "contents": {"boo":"xxx","foo":123},
+                                  |            "matchingRules": {
+                                  |              "foo" : {
+                                  |                  "match": "integer"
+                                  |              }
+                                  |            },
                                   |            "metaData": {
                                   |              "contentType": "application/json"
                                   |            }
@@ -420,7 +427,12 @@ object PactFileExamples {
       |        {
       |            "description": "Published another credit data",
       |            "providerState": "or maybe 'scenario'! not sure about this",
-      |            "contents": {"boo":"xxx"},
+      |            "contents": {"boo":"xxx","foo":123},
+      |            "matchingRules": {
+      |              "foo" : {
+      |                  "match": "integer"
+      |              }
+      |            },
       |            "metaData": {
       |              "contentType": "application/json"
       |            }

--- a/scalapact-circe-0-9/src/test/scala/com/itv/scalapact/circe09/PactFileExamples.scala
+++ b/scalapact-circe-0-9/src/test/scala/com/itv/scalapact/circe09/PactFileExamples.scala
@@ -1,5 +1,6 @@
 package com.itv.scalapact.circe09
 
+import com.itv.scalapact.shared.MessageContentType.{ApplicationJson, ApplicationText}
 import com.itv.scalapact.shared._
 
 object PactFileExamples {
@@ -292,7 +293,8 @@ object PactFileExamples {
         providerState = Some("or maybe 'scenario'? not sure about this"),
         contents = """Hello world!""",
         metaData = Message.Metadata(),
-        MessageContentType.ApplicationText
+        matchingRules = Map("foo" -> MatchingRule(Some("regex"), Some("\\w+"), None)),
+        ApplicationText
       )
     )
   )
@@ -310,6 +312,12 @@ object PactFileExamples {
                                 |            "providerState": "or maybe 'scenario'? not sure about this",
                                 |            "contents": "Hello world!",
                                 |            "metaData": {
+                                |            },
+                                |            "matchingRules" : {
+                                |               "foo" : {
+                                |                 "match":"regex",
+                                |                 "regex": "\\w+"
+                                |               }
                                 |            }
                                 |        }
                                 |    ]
@@ -325,7 +333,8 @@ object PactFileExamples {
         providerState = Some("or maybe 'scenario'? not sure about this"),
         contents = """{"foo":"bar"}""",
         metaData = Message.Metadata("contentType" -> "application/json"),
-        MessageContentType.ApplicationJson
+        matchingRules = Map.empty,
+        ApplicationJson
       )
     )
   )
@@ -356,7 +365,8 @@ object PactFileExamples {
         providerState = Some("or maybe 'scenario'! not sure about this"),
         contents = """{"boo":"xxx"}""",
         metaData = Message.Metadata("contentType" -> "application/json"),
-        MessageContentType.ApplicationJson
+        matchingRules = Map.empty,
+        ApplicationJson
       )
     )
   )

--- a/scalapact-circe-0-9/src/test/scala/com/itv/scalapact/circe09/PactFileExamples.scala
+++ b/scalapact-circe-0-9/src/test/scala/com/itv/scalapact/circe09/PactFileExamples.scala
@@ -3,83 +3,32 @@ package com.itv.scalapact.circe09
 import com.itv.scalapact.shared._
 
 object PactFileExamples {
-
-  val anotherExample: String =
-    """{
-      |  "provider" : {
-      |    "name" : "Their Provider Service"
-      |  },
-      |  "consumer" : {
-      |    "name" : "My Consumer"
-      |  },
-      |  "interactions" : [
-      |    {
-      |      "description" : "a simple get example with a header matcher",
-      |      "request" : {
-      |        "method" : "GET",
-      |        "path" : "/header-match",
-      |        "headers" : {
-      |          "fish" : "chips",
-      |          "sauce" : "ketchup"
-      |        },
-      |        "matchingRules" : {
-      |          "$.headers.fish" : {
-      |            "match" : "regex",
-      |            "regex" : "\\w+"
-      |          },
-      |          "$.headers.sauce" : {
-      |            "match" : "regex",
-      |            "regex" : "\\w+"
-      |          }
-      |        }
-      |      },
-      |      "response" : {
-      |        "status" : 200,
-      |        "headers" : {
-      |          "fish" : "chips",
-      |          "sauce" : "ketchup"
-      |        },
-      |        "body" : "Hello there!",
-      |        "matchingRules" : {
-      |          "$.headers.fish" : {
-      |            "match" : "regex",
-      |            "regex" : "\\w+"
-      |          },
-      |          "$.headers.sauce" : {
-      |            "match" : "regex",
-      |            "regex" : "\\w+"
-      |          }
-      |        }
-      |      }
-      |    }
-      |  ]
-      |}""".stripMargin
-
+  private val simpleInteraction = Interaction(
+    provider_state = None,
+    providerState = None,
+    description = "a simple request",
+    request = InteractionRequest(
+      method = Option("GET"),
+      path = Option("/"),
+      query = None,
+      headers = None,
+      body = None,
+      matchingRules = None
+    ),
+    response = InteractionResponse(
+      status = Option(200),
+      headers = None,
+      body = Option("""Hello"""),
+      None
+    )
+  )
   val verySimple = Pact(
     consumer = PactActor("consumer"),
     provider = PactActor("provider"),
-    messages = Nil, //TODO: add this field
     interactions = List(
-      Interaction(
-        provider_state = None,
-        providerState = None,
-        description = "a simple request",
-        request = InteractionRequest(
-          method = Option("GET"),
-          path = Option("/"),
-          query = None,
-          headers = None,
-          body = None,
-          matchingRules = None
-        ),
-        response = InteractionResponse(
-          status = Option(200),
-          headers = None,
-          body = Option("""Hello"""),
-          None
-        )
-      )
-    )
+      simpleInteraction
+    ),
+    messages = List.empty
   )
 
   val verySimpleAsString: String =
@@ -108,7 +57,6 @@ object PactFileExamples {
   val simple = Pact(
     consumer = PactActor("consumer"),
     provider = PactActor("provider"),
-    messages = Nil, //TODO: add this field
     interactions = List(
       Interaction(
         provider_state = None,
@@ -131,12 +79,12 @@ object PactFileExamples {
           status = Option(200),
           headers = Option(Map("Content-Type" -> "application/json")),
           body = Option("""{
-              |  "fish" : [
-              |    "cod",
-              |    "haddock",
-              |    "flying"
-              |  ]
-              |}""".stripMargin),
+                          |  "fish" : [
+                          |    "cod",
+                          |    "haddock",
+                          |    "flying"
+                          |  ]
+                          |}""".stripMargin),
           matchingRules = Option(
             Map(
               "$.headers.Accept"         -> MatchingRule(`match` = Option("regex"), regex = Option("\\w+"), min = None),
@@ -161,99 +109,20 @@ object PactFileExamples {
           status = Option(200),
           headers = Option(Map("Content-Type" -> "application/json")),
           body = Option("""{
-              |  "chips" : true,
-              |  "fish" : [
-              |    "cod",
-              |    "haddock"
-              |  ]
-              |}""".stripMargin),
+                          |  "chips" : true,
+                          |  "fish" : [
+                          |    "cod",
+                          |    "haddock"
+                          |  ]
+                          |}""".stripMargin),
           matchingRules = None
         )
       )
-    )
+    ),
+    messages = List.empty
   )
-
+  //FIXME: Add messages to string/json pacts
   val simpleAsString: String = """{
-                         |  "provider" : {
-                         |    "name" : "provider"
-                         |  },
-                         |  "consumer" : {
-                         |    "name" : "consumer"
-                         |  },
-                         |  "interactions" : [
-                         |    {
-                         |      "providerState" : "a simple state",
-                         |      "description" : "a simple request",
-                         |      "request" : {
-                         |        "method" : "GET",
-                         |        "path" : "/fetch-json",
-                         |        "query" : "fish=chips",
-                         |        "headers" : {
-                         |          "Content-Type" : "text/plain"
-                         |        },
-                         |        "body" : "fish",
-                         |        "matchingRules" : {
-                         |          "$.headers.Accept" : {
-                         |            "match" : "regex",
-                         |            "regex" : "\\w+"
-                         |          },
-                         |          "$.headers.Content-Length" : {
-                         |            "match" : "type"
-                         |          }
-                         |        }
-                         |      },
-                         |      "response" : {
-                         |        "status" : 200,
-                         |        "headers" : {
-                         |          "Content-Type" : "application/json"
-                         |        },
-                         |        "body" : {
-                         |          "fish" : [
-                         |            "cod",
-                         |            "haddock",
-                         |            "flying"
-                         |          ]
-                         |        },
-                         |        "matchingRules" : {
-                         |          "$.headers.Accept" : {
-                         |            "match" : "regex",
-                         |            "regex" : "\\w+"
-                         |          },
-                         |          "$.headers.Content-Length" : {
-                         |            "match" : "type"
-                         |          }
-                         |        }
-                         |      }
-                         |    },
-                         |    {
-                         |      "providerState" : "a simple state 2",
-                         |      "description" : "a simple request 2",
-                         |      "request" : {
-                         |        "method" : "GET",
-                         |        "path" : "/fetch-json2",
-                         |        "headers" : {
-                         |          "Content-Type" : "text/plain"
-                         |        },
-                         |        "body" : "fish"
-                         |      },
-                         |      "response" : {
-                         |        "status" : 200,
-                         |        "headers" : {
-                         |          "Content-Type" : "application/json"
-                         |        },
-                         |        "body" : {
-                         |          "chips" : true,
-                         |          "fish" : [
-                         |            "cod",
-                         |            "haddock"
-                         |          ]
-                         |        }
-                         |      }
-                         |    }
-                         |  ]
-                         |}""".stripMargin
-
-  val simpleOldProviderStateAsString: String = """{
                                  |  "provider" : {
                                  |    "name" : "provider"
                                  |  },
@@ -262,16 +131,16 @@ object PactFileExamples {
                                  |  },
                                  |  "interactions" : [
                                  |    {
-                                 |      "provider_state" : "a simple state",
+                                 |      "providerState" : "a simple state",
                                  |      "description" : "a simple request",
                                  |      "request" : {
                                  |        "method" : "GET",
                                  |        "path" : "/fetch-json",
-                                 |        "body" : "fish",
                                  |        "query" : "fish=chips",
                                  |        "headers" : {
                                  |          "Content-Type" : "text/plain"
                                  |        },
+                                 |        "body" : "fish",
                                  |        "matchingRules" : {
                                  |          "$.headers.Accept" : {
                                  |            "match" : "regex",
@@ -306,15 +175,15 @@ object PactFileExamples {
                                  |      }
                                  |    },
                                  |    {
-                                 |      "provider_state" : "a simple state 2",
+                                 |      "providerState" : "a simple state 2",
                                  |      "description" : "a simple request 2",
                                  |      "request" : {
                                  |        "method" : "GET",
                                  |        "path" : "/fetch-json2",
-                                 |        "body" : "fish",
                                  |        "headers" : {
                                  |          "Content-Type" : "text/plain"
-                                 |        }
+                                 |        },
+                                 |        "body" : "fish"
                                  |      },
                                  |      "response" : {
                                  |        "status" : 200,
@@ -332,4 +201,231 @@ object PactFileExamples {
                                  |    }
                                  |  ]
                                  |}""".stripMargin
+
+  val simpleOldProviderStateAsString: String = """{
+                                                 |  "provider" : {
+                                                 |    "name" : "provider"
+                                                 |  },
+                                                 |  "consumer" : {
+                                                 |    "name" : "consumer"
+                                                 |  },
+                                                 |  "interactions" : [
+                                                 |    {
+                                                 |      "provider_state" : "a simple state",
+                                                 |      "description" : "a simple request",
+                                                 |      "request" : {
+                                                 |        "method" : "GET",
+                                                 |        "path" : "/fetch-json",
+                                                 |        "body" : "fish",
+                                                 |        "query" : "fish=chips",
+                                                 |        "headers" : {
+                                                 |          "Content-Type" : "text/plain"
+                                                 |        },
+                                                 |        "matchingRules" : {
+                                                 |          "$.headers.Accept" : {
+                                                 |            "match" : "regex",
+                                                 |            "regex" : "\\w+"
+                                                 |          },
+                                                 |          "$.headers.Content-Length" : {
+                                                 |            "match" : "type"
+                                                 |          }
+                                                 |        }
+                                                 |      },
+                                                 |      "response" : {
+                                                 |        "status" : 200,
+                                                 |        "headers" : {
+                                                 |          "Content-Type" : "application/json"
+                                                 |        },
+                                                 |        "body" : {
+                                                 |          "fish" : [
+                                                 |            "cod",
+                                                 |            "haddock",
+                                                 |            "flying"
+                                                 |          ]
+                                                 |        },
+                                                 |        "matchingRules" : {
+                                                 |          "$.headers.Accept" : {
+                                                 |            "match" : "regex",
+                                                 |            "regex" : "\\w+"
+                                                 |          },
+                                                 |          "$.headers.Content-Length" : {
+                                                 |            "match" : "type"
+                                                 |          }
+                                                 |        }
+                                                 |      }
+                                                 |    },
+                                                 |    {
+                                                 |      "provider_state" : "a simple state 2",
+                                                 |      "description" : "a simple request 2",
+                                                 |      "request" : {
+                                                 |        "method" : "GET",
+                                                 |        "path" : "/fetch-json2",
+                                                 |        "body" : "fish",
+                                                 |        "headers" : {
+                                                 |          "Content-Type" : "text/plain"
+                                                 |        }
+                                                 |      },
+                                                 |      "response" : {
+                                                 |        "status" : 200,
+                                                 |        "headers" : {
+                                                 |          "Content-Type" : "application/json"
+                                                 |        },
+                                                 |        "body" : {
+                                                 |          "chips" : true,
+                                                 |          "fish" : [
+                                                 |            "cod",
+                                                 |            "haddock"
+                                                 |          ]
+                                                 |        }
+                                                 |      }
+                                                 |    }
+                                                 |  ]
+                                                 |}""".stripMargin
+
+  val stringMessage = Pact(
+    consumer = PactActor("Consumer"),
+    provider = PactActor("Provider"),
+    interactions = List.empty,
+    messages = List(
+      Message(
+        description = "Published credit data",
+        providerState = Some("or maybe 'scenario'? not sure about this"),
+        contents = """Hello world!""",
+        metaData = Message.Metadata()
+      )
+    )
+  )
+
+  val stringMessageAsString = """{
+                                |    "consumer": {
+                                |        "name": "Consumer"
+                                |    },
+                                |    "provider": {
+                                |        "name": "Provider"
+                                |    },
+                                |    "messages": [
+                                |        {
+                                |            "description": "Published credit data",
+                                |            "providerState": "or maybe 'scenario'? not sure about this",
+                                |            "contents": "Hello world!",
+                                |            "metaData": {
+                                |            }
+                                |        }
+                                |    ]
+                                |}""".stripMargin
+
+  val jsonMessage = Pact(
+    consumer = PactActor("Consumer"),
+    provider = PactActor("Provider"),
+    interactions = List.empty,
+    messages = List(
+      Message(
+        description = "Published credit data",
+        providerState = Some("or maybe 'scenario'? not sure about this"),
+        contents = """{"foo":"bar"}""",
+        metaData = Message.Metadata("contentType" -> "application/json")
+      )
+    )
+  )
+
+  val jsonMessageAsString = """{
+                              |    "consumer": {
+                              |        "name": "Consumer"
+                              |    },
+                              |    "provider": {
+                              |        "name": "Provider"
+                              |    },
+                              |    "messages": [
+                              |        {
+                              |            "description": "Published credit data",
+                              |            "providerState": "or maybe 'scenario'? not sure about this",
+                              |            "contents": {"foo":"bar"},
+                              |            "metaData": {
+                              |              "contentType": "application/json"
+                              |            }
+                              |        }
+                              |    ]
+                              |}""".stripMargin
+
+  val multipleMessage = jsonMessage.copy(
+    messages = jsonMessage.messages ++ List(
+      Message(
+        description = "Published another credit data",
+        providerState = Some("or maybe 'scenario'! not sure about this"),
+        contents = """{"boo":"xxx"}""",
+        metaData = Message.Metadata("contentType" -> "application/json")
+      )
+    )
+  )
+  val multipleMessageAsString = """{
+                                  |    "consumer": {
+                                  |        "name": "Consumer"
+                                  |    },
+                                  |    "provider": {
+                                  |        "name": "Provider"
+                                  |    },
+                                  |    "messages": [
+                                  |        {
+                                  |            "description": "Published credit data",
+                                  |            "providerState": "or maybe 'scenario'? not sure about this",
+                                  |            "contents": {"foo":"bar"},
+                                  |            "metaData": {
+                                  |              "contentType": "application/json"
+                                  |            }
+                                  |        },
+                                  |        {
+                                  |            "description": "Published another credit data",
+                                  |            "providerState": "or maybe 'scenario'! not sure about this",
+                                  |            "contents": {"boo":"xxx"},
+                                  |            "metaData": {
+                                  |              "contentType": "application/json"
+                                  |            }
+                                  |        }
+                                  |    ]
+                                  |}""".stripMargin
+
+  val multipleMessagesAndInteractions = multipleMessage
+    .copy(interactions = List(simpleInteraction))
+
+  val multipleMessagesAndInteractionsAsString =
+    """{
+      |    "consumer": {
+      |        "name": "Consumer"
+      |    },
+      |    "provider": {
+      |        "name": "Provider"
+      |    },
+      |    "messages": [
+      |        {
+      |            "description": "Published credit data",
+      |            "providerState": "or maybe 'scenario'? not sure about this",
+      |            "contents": {"foo":"bar"},
+      |            "metaData": {
+      |              "contentType": "application/json"
+      |            }
+      |        },
+      |        {
+      |            "description": "Published another credit data",
+      |            "providerState": "or maybe 'scenario'! not sure about this",
+      |            "contents": {"boo":"xxx"},
+      |            "metaData": {
+      |              "contentType": "application/json"
+      |            }
+      |        }
+      |    ],
+      |    "interactions": [
+      |    {
+      |      "description" : "a simple request",
+      |      "request" : {
+      |        "method" : "GET",
+      |        "path" : "/"
+      |      },
+      |      "response" : {
+      |        "status" : 200,
+      |        "body" : "Hello"
+      |      }
+      |     }
+      |    ]
+      | }
+    """.stripMargin
 }

--- a/scalapact-circe-0-9/src/test/scala/com/itv/scalapact/circe09/PactFileExamples.scala
+++ b/scalapact-circe-0-9/src/test/scala/com/itv/scalapact/circe09/PactFileExamples.scala
@@ -122,7 +122,7 @@ object PactFileExamples {
     ),
     messages = List.empty
   )
-  //FIXME: Add messages to string/json pacts
+
   val simpleAsString: String = """{
                                  |  "provider" : {
                                  |    "name" : "provider"
@@ -366,7 +366,7 @@ object PactFileExamples {
         contents = """{"boo":"xxx","foo":123}""",
         metaData = Message.Metadata("contentType" -> "application/json"),
         matchingRules = Map(
-          "foo" -> MatchingRule(Some("integer"),None, None)
+          "foo" -> MatchingRule(Some("integer"), None, None)
         ),
         ApplicationJson
       )

--- a/scalapact-circe-0-9/src/test/scala/com/itv/scalapact/circe09/PactFileExamples.scala
+++ b/scalapact-circe-0-9/src/test/scala/com/itv/scalapact/circe09/PactFileExamples.scala
@@ -290,7 +290,7 @@ object PactFileExamples {
     messages = List(
       Message(
         description = "Published credit data",
-        providerState = Some("or maybe 'scenario'? not sure about this"),
+        providerStates = List("or maybe 'scenario'? not sure about this"),
         contents = """Hello world!""",
         metaData = Message.Metadata(),
         matchingRules =
@@ -299,6 +299,37 @@ object PactFileExamples {
       )
     )
   )
+
+  val simpleMessageWithProviderStateAsString =
+    """{
+      |    "consumer": {
+      |        "name": "Consumer"
+      |    },
+      |    "provider": {
+      |        "name": "Provider"
+      |    },
+      |    "messages": [
+      |        {
+      |            "description": "Published credit data",
+      |            "providerState": "or maybe 'scenario'? not sure about this",
+      |            "contents": "Hello world!",
+      |            "metaData": {
+      |            },
+      |            "matchingRules" : {
+      |              "body" : {
+      |                "$.foo" : {
+      |                  "matchers": [
+      |                    {
+      |                      "match":"regex",
+      |                      "regex": "\\w+"
+      |                    }
+      |                  ]
+      |                }
+      |              }
+      |            }
+      |        }
+      |    ]
+      |}""".stripMargin
 
   val stringMessageAsString = """{
                                 |    "consumer": {
@@ -310,7 +341,7 @@ object PactFileExamples {
                                 |    "messages": [
                                 |        {
                                 |            "description": "Published credit data",
-                                |            "providerState": "or maybe 'scenario'? not sure about this",
+                                |            "providerStates": ["or maybe 'scenario'? not sure about this"],
                                 |            "contents": "Hello world!",
                                 |            "metaData": {
                                 |            },
@@ -337,7 +368,7 @@ object PactFileExamples {
     messages = List(
       Message(
         description = "Published credit data",
-        providerState = Some("or maybe 'scenario'? not sure about this"),
+        providerStates = List("or maybe 'scenario'? not sure about this"),
         contents = """{"foo":"bar"}""",
         metaData = Message.Metadata("contentType" -> "application/json"),
         matchingRules = Map.empty,
@@ -356,7 +387,7 @@ object PactFileExamples {
                               |    "messages": [
                               |        {
                               |            "description": "Published credit data",
-                              |            "providerState": "or maybe 'scenario'? not sure about this",
+                              |            "providerStates": ["or maybe 'scenario'? not sure about this"],
                               |            "contents": {"foo":"bar"},
                               |            "metaData": {
                               |              "contentType": "application/json"
@@ -369,7 +400,7 @@ object PactFileExamples {
     messages = jsonMessage.messages ++ List(
       Message(
         description = "Published another credit data",
-        providerState = Some("or maybe 'scenario'! not sure about this"),
+        providerStates = List("or maybe 'scenario'! not sure about this"),
         contents = """{"boo":"xxx","foo":123}""",
         metaData = Message.Metadata("contentType" -> "application/json"),
         matchingRules = Map(
@@ -392,7 +423,7 @@ object PactFileExamples {
                                   |    "messages": [
                                   |        {
                                   |            "description": "Published credit data",
-                                  |            "providerState": "or maybe 'scenario'? not sure about this",
+                                  |            "providerStates": ["or maybe 'scenario'? not sure about this"],
                                   |            "contents": {"foo":"bar"},
                                   |            "metaData": {
                                   |              "contentType": "application/json"
@@ -400,7 +431,7 @@ object PactFileExamples {
                                   |        },
                                   |        {
                                   |            "description": "Published another credit data",
-                                  |            "providerState": "or maybe 'scenario'! not sure about this",
+                                  |            "providerStates": ["or maybe 'scenario'! not sure about this"],
                                   |            "contents": {"boo":"xxx","foo":123},
                                   |            "matchingRules" : {
                                   |              "body" : {
@@ -434,7 +465,7 @@ object PactFileExamples {
       |    "messages": [
       |        {
       |            "description": "Published credit data",
-      |            "providerState": "or maybe 'scenario'? not sure about this",
+      |            "providerStates": ["or maybe 'scenario'? not sure about this"],
       |            "contents": {"foo":"bar"},
       |            "metaData": {
       |              "contentType": "application/json"
@@ -442,7 +473,7 @@ object PactFileExamples {
       |        },
       |        {
       |            "description": "Published another credit data",
-      |            "providerState": "or maybe 'scenario'! not sure about this",
+      |            "providerStates": ["or maybe 'scenario'! not sure about this"],
       |            "contents": {"boo":"xxx","foo":123},
       |            "matchingRules" : {
       |              "body" : {

--- a/scalapact-circe-0-9/src/test/scala/com/itv/scalapact/circe09/PactFileExamples.scala
+++ b/scalapact-circe-0-9/src/test/scala/com/itv/scalapact/circe09/PactFileExamples.scala
@@ -291,7 +291,8 @@ object PactFileExamples {
         description = "Published credit data",
         providerState = Some("or maybe 'scenario'? not sure about this"),
         contents = """Hello world!""",
-        metaData = Message.Metadata()
+        metaData = Message.Metadata(),
+        MessageContentType.ApplicationText
       )
     )
   )
@@ -323,7 +324,8 @@ object PactFileExamples {
         description = "Published credit data",
         providerState = Some("or maybe 'scenario'? not sure about this"),
         contents = """{"foo":"bar"}""",
-        metaData = Message.Metadata("contentType" -> "application/json")
+        metaData = Message.Metadata("contentType" -> "application/json"),
+        MessageContentType.ApplicationJson
       )
     )
   )
@@ -353,7 +355,8 @@ object PactFileExamples {
         description = "Published another credit data",
         providerState = Some("or maybe 'scenario'! not sure about this"),
         contents = """{"boo":"xxx"}""",
-        metaData = Message.Metadata("contentType" -> "application/json")
+        metaData = Message.Metadata("contentType" -> "application/json"),
+        MessageContentType.ApplicationJson
       )
     )
   )

--- a/scalapact-circe-0-9/src/test/scala/com/itv/scalapact/circe09/RubyJsonHelperSpec.scala
+++ b/scalapact-circe-0-9/src/test/scala/com/itv/scalapact/circe09/RubyJsonHelperSpec.scala
@@ -1,15 +1,21 @@
 package com.itv.scalapact.circe09
 
 import com.itv.scalapact.shared._
-import org.scalatest.{FunSpec, Matchers}
+import org.scalactic.TypeCheckedTripleEquals
+import org.scalatest.{EitherValues, FunSpec, Matchers}
+import io.circe.parser.parse
+import Matchers._
 
-class RubyJsonHelperSpec extends FunSpec with Matchers {
+class RubyJsonHelperSpec extends FunSpec with EitherValues with TypeCheckedTripleEquals {
 
   describe("Handling ruby json") {
 
     it("should be able to extract the provider") {
 
-      JsonBodySpecialCaseHelper.extractPactActor("provider")(PactFileExamples.simpleAsString) shouldEqual Some(
+      JsonBodySpecialCaseHelper
+        .extractPactActor("provider")(parse(PactFileExamples.simpleAsString).right.value)
+        .right
+        .value should ===(
         PactActor("provider")
       )
 
@@ -17,7 +23,10 @@ class RubyJsonHelperSpec extends FunSpec with Matchers {
 
     it("should be able to extract the consumer") {
 
-      JsonBodySpecialCaseHelper.extractPactActor("consumer")(PactFileExamples.simpleAsString) shouldEqual Some(
+      JsonBodySpecialCaseHelper
+        .extractPactActor("consumer")(parse(PactFileExamples.simpleAsString).right.value)
+        .right
+        .value should ===(
         PactActor("consumer")
       )
 
@@ -56,12 +65,12 @@ class RubyJsonHelperSpec extends FunSpec with Matchers {
       )
       val interaction1RequestBody  = Option("fish")
       val interaction1ResponseBody = Option("""{
-          |  "fish" : [
-          |    "cod",
-          |    "haddock",
-          |    "flying"
-          |  ]
-          |}""".stripMargin)
+                                              |  "fish" : [
+                                              |    "cod",
+                                              |    "haddock",
+                                              |    "flying"
+                                              |  ]
+                                              |}""".stripMargin)
 
       val interaction2 = Interaction(
         provider_state = None,
@@ -84,19 +93,22 @@ class RubyJsonHelperSpec extends FunSpec with Matchers {
       )
       val interaction2RequestBody  = Option("fish")
       val interaction2ResponseBody = Option("""{
-          |  "chips" : true,
-          |  "fish" : [
-          |    "cod",
-          |    "haddock"
-          |  ]
-          |}""".stripMargin)
+                                              |  "chips" : true,
+                                              |  "fish" : [
+                                              |    "cod",
+                                              |    "haddock"
+                                              |  ]
+                                              |}""".stripMargin)
 
-      val list = List(
-        (Some(interaction1), interaction1RequestBody, interaction1ResponseBody),
-        (Some(interaction2), interaction2RequestBody, interaction2ResponseBody)
+      JsonBodySpecialCaseHelper
+        .extractInteractionsTuple(parse(PactFileExamples.simpleAsString).right.value)
+        .right
+        .value should ===(
+        List(
+          (interaction1, interaction1RequestBody, interaction1ResponseBody),
+          (interaction2, interaction2RequestBody, interaction2ResponseBody)
+        )
       )
-
-      JsonBodySpecialCaseHelper.extractInteractions(PactFileExamples.simpleAsString) shouldEqual Some(list)
 
     }
 

--- a/scalapact-circe-0-9/src/test/scala/com/itv/scalapact/circe09/ScalaMessagePactReaderWriterSpec.scala
+++ b/scalapact-circe-0-9/src/test/scala/com/itv/scalapact/circe09/ScalaMessagePactReaderWriterSpec.scala
@@ -1,0 +1,48 @@
+package com.itv.scalapact.circe09
+
+import io.circe.parser.parse
+import org.scalactic.TypeCheckedTripleEquals
+import org.scalatest.Matchers._
+import org.scalatest.{EitherValues, FlatSpec}
+
+class ScalaMessagePactReaderWriterSpec extends FlatSpec with EitherValues with TypeCheckedTripleEquals {
+
+  val pactReader = new PactReader
+  val pactWriter = new PactWriter
+
+  List(
+    (PactFileExamples.stringMessageAsString, PactFileExamples.stringMessage),
+    (PactFileExamples.jsonMessageAsString, PactFileExamples.jsonMessage),
+    (PactFileExamples.multipleMessageAsString, PactFileExamples.multipleMessage),
+    (PactFileExamples.multipleMessagesAndInteractionsAsString, PactFileExamples.multipleMessagesAndInteractions)
+  ).foreach {
+    case (expectedWritten, expectedPact) =>
+      it should s"should be able to read Pact files: [$expectedPact]" in {
+
+        val actualPact = pactReader.jsonStringToPact(expectedWritten)
+
+        actualPact should ===(Right(expectedPact))
+      }
+
+      it should s"should be able to write Pact files: [$expectedPact]" in {
+
+        val actualWritten = pactWriter.pactToJsonString(expectedPact)
+
+        parse(actualWritten) should ===(parse(expectedWritten))
+
+      }
+
+      it should s"should be able to eat it's own dog food: [$expectedPact]" in {
+        val actualWritten = pactWriter.pactToJsonString(expectedPact)
+
+        val actualPact = pactReader.jsonStringToPact(actualWritten).right.value
+
+        val `reJson'd` = pactWriter.pactToJsonString(actualPact)
+
+        parse(`reJson'd`) should ===(parse(expectedWritten))
+
+        actualPact should ===(expectedPact)
+      }
+  }
+
+}

--- a/scalapact-circe-0-9/src/test/scala/com/itv/scalapact/circe09/ScalaMessagePactReaderWriterSpec.scala
+++ b/scalapact-circe-0-9/src/test/scala/com/itv/scalapact/circe09/ScalaMessagePactReaderWriterSpec.scala
@@ -10,6 +10,13 @@ class ScalaMessagePactReaderWriterSpec extends FlatSpec with EitherValues with T
   val pactReader = new PactReader
   val pactWriter = new PactWriter
 
+  it should "be able to read message that use 'providerState' instead 'providerStates'" in {
+    val actualPact = pactReader.jsonStringToPact(PactFileExamples.simpleMessageWithProviderStateAsString)
+
+    actualPact should ===(Right(PactFileExamples.stringMessage))
+
+  }
+
   List(
     (PactFileExamples.stringMessageAsString, PactFileExamples.stringMessage),
     (PactFileExamples.jsonMessageAsString, PactFileExamples.jsonMessage),

--- a/scalapact-circe-0-9/src/test/scala/com/itv/scalapact/circe09/ScalaPactReaderWriterSpec.scala
+++ b/scalapact-circe-0-9/src/test/scala/com/itv/scalapact/circe09/ScalaPactReaderWriterSpec.scala
@@ -90,20 +90,6 @@ class ScalaPactReaderWriterSpec extends FunSpec with Matchers {
       parse(written).toOption.get shouldEqual parse(expected).toOption.get
     }
 
-    it("should be able to parse another example") {
-
-      pactReader.jsonStringToPact(PactFileExamples.anotherExample) match {
-        case Left(e) =>
-          fail(e)
-
-        case Right(pact) =>
-          pact.consumer.name shouldEqual "My Consumer"
-          pact.provider.name shouldEqual "Their Provider Service"
-          pact.interactions.head.response.body.get shouldEqual "Hello there!"
-      }
-
-    }
-
   }
 
 }

--- a/scalapact-core/src/main/scala/com/itv/scalapactcore/common/matching/BodyMatching.scala
+++ b/scalapact-core/src/main/scala/com/itv/scalapactcore/common/matching/BodyMatching.scala
@@ -5,17 +5,6 @@ import com.itv.scalapact.shared.typeclasses.IPactReader
 
 object BodyMatching {
 
-  def nodeMatchToMatchResult(irNodeEqualityResult: IrNodeEqualityResult,
-                             rules: IrNodeMatchingRules,
-                             isXml: Boolean): MatchOutcome =
-    irNodeEqualityResult match {
-      case IrNodesEqual =>
-        MatchOutcomeSuccess
-
-      case e: IrNodesNotEqual =>
-        MatchOutcomeFailed(e.renderDifferencesListWithRules(rules, isXml), e.differences.length * 1)
-    }
-
   def matchBodies(headers: Option[Map[String, String]], expected: Option[String], received: Option[String])(
       implicit rules: IrNodeMatchingRules,
       pactReader: IPactReader

--- a/scalapact-core/src/main/scala/com/itv/scalapactcore/common/matching/HeaderMatching.scala
+++ b/scalapact-core/src/main/scala/com/itv/scalapactcore/common/matching/HeaderMatching.scala
@@ -56,6 +56,7 @@ object HeaderMatching {
                 rls
                   .findForPath(IrNodePathEmpty <~ header._1, isXml = false)
                   .map {
+                    //FIXME Avoid pattern matching
                     case IrNodeTypeRule(_) =>
                       MatchOutcomeSuccess
 
@@ -68,6 +69,7 @@ object HeaderMatching {
 
                     case IrNodeMinArrayLengthRule(_, _) =>
                       MatchOutcomeSuccess
+                    case _ => ??? //FIXME add IrNodeIntergerrule
                   }
               }
         }

--- a/scalapact-core/src/main/scala/com/itv/scalapactcore/common/matching/MessageMatchers.scala
+++ b/scalapact-core/src/main/scala/com/itv/scalapactcore/common/matching/MessageMatchers.scala
@@ -1,7 +1,7 @@
 package com.itv.scalapactcore.common.matching
 
-import com.itv.scalapact.shared._
-import com.itv.scalapact.shared.matchir._
+import com.itv.scalapact.shared.matchir.{IrNodeMatchingRules, MatchIr}
+import com.itv.scalapact.shared.Message
 import com.itv.scalapact.shared.typeclasses.IPactReader
 
 object MessageMatchers {
@@ -32,7 +32,7 @@ object MessageMatchers {
 
     }
 
-  def matchSingleMessage(rules: Option[Map[String, MatchingRule]], expected: String, received: String)(
+  def matchSingleMessage(expected: String, received: String)(
       implicit matchingRules: IrNodeMatchingRules,
       pactReader: IPactReader
   ): MatchOutcome =

--- a/scalapact-core/src/main/scala/com/itv/scalapactcore/common/matching/MessageMatchers.scala
+++ b/scalapact-core/src/main/scala/com/itv/scalapactcore/common/matching/MessageMatchers.scala
@@ -1,0 +1,36 @@
+package com.itv.scalapactcore.common.matching
+
+import com.itv.scalapact.shared._
+import com.itv.scalapact.shared.matchir._
+import com.itv.scalapact.shared.typeclasses.IPactReader
+
+object MessageMatchers {
+
+
+  //FIXME: reuse BodyMatching.nodeMatchToMatchResult
+  def nodeMatchToMatchResult(irNodeEqualityResult: IrNodeEqualityResult,
+                             rules: IrNodeMatchingRules,
+                             isXml: Boolean): MatchOutcome =
+    irNodeEqualityResult match {
+      case IrNodesEqual =>
+        MatchOutcomeSuccess
+
+      case e: IrNodesNotEqual =>
+        MatchOutcomeFailed(e.renderDifferencesListWithRules(rules, isXml), e.differences.length * 1)
+    }
+
+  def matchSingleMessage(rules: Option[Map[String, MatchingRule]],
+                         expected: Option[String],
+                         received: Option[String])(implicit matchingRules: IrNodeMatchingRules,
+                                                   pactReader: IPactReader): MatchOutcome = {
+    (expected, received) match {
+      case (Some(e), Some(r)) => MatchIr
+        .fromJSON(pactReader.fromJSON)(e)
+        .flatMap { e =>
+          MatchIr.fromJSON(pactReader.fromJSON)(r).map(r =>{
+            nodeMatchToMatchResult( e =~ r, matchingRules, isXml = false)
+          })
+        }.getOrElse(MatchOutcomeFailed("Failed to parse JSON body", 50))
+    }
+  }
+}

--- a/scalapact-core/src/main/scala/com/itv/scalapactcore/common/matching/MessageMatchers.scala
+++ b/scalapact-core/src/main/scala/com/itv/scalapactcore/common/matching/MessageMatchers.scala
@@ -32,7 +32,7 @@ object MessageMatchers {
 
     }
 
-  def matchSingleMessage(expected: String, received: String, rules: Option[Map[String, MatchingRule]])(
+  def matchSingleMessage(expected: String, received: String, rules: Option[Map[String, MatchingRule]], strict: Boolean)(
       implicit pactReader: IPactReader
   ): MatchOutcome =
     IrNodeMatchingRules.fromPactRules(rules) match {
@@ -43,7 +43,7 @@ object MessageMatchers {
           ee <- MatchIr.fromJSON(pactReader.fromJSON)(expected)
           rr <- MatchIr.fromJSON(pactReader.fromJSON)(received)
         } yield
-          nodeMatchToMatchResult(ee.isEqualTo(rr, strict = false, matchingRules, bePermissive = true),
+          nodeMatchToMatchResult(ee.isEqualTo(rr, strict = strict, matchingRules, bePermissive = !strict),
                                  matchingRules,
                                  isXml = false)
 

--- a/scalapact-core/src/main/scala/com/itv/scalapactcore/common/matching/MessageMatchers.scala
+++ b/scalapact-core/src/main/scala/com/itv/scalapactcore/common/matching/MessageMatchers.scala
@@ -6,6 +6,32 @@ import com.itv.scalapact.shared.typeclasses.IPactReader
 
 object MessageMatchers {
 
+  case class OutcomeAndMessage(outcome: MatchOutcome, closestMatchingMessage: Message)
+
+  def renderOutcome(outcome: Option[OutcomeAndMessage],
+                    renderedOriginal: String,
+                    subject: String): Either[String, Message] =
+    outcome match {
+      case None =>
+        Left("Entirely failed to match, something went horribly wrong.")
+
+      case Some(OutcomeAndMessage(f @ MatchOutcomeFailed(_, _), message)) =>
+        Left(
+          s"""Failed to match $subject
+             | ...original
+             |$renderedOriginal
+             | ...closest match was...
+             |${message.renderAsString}
+             | ...Differences
+             |${f.renderDifferences}
+             """.stripMargin
+          //TODO Match on headers
+        )
+
+      case Some(OutcomeAndMessage(MatchOutcomeSuccess, message)) =>
+        Right(message)
+
+    }
 
   //FIXME: reuse BodyMatching.nodeMatchToMatchResult
   def nodeMatchToMatchResult(irNodeEqualityResult: IrNodeEqualityResult,
@@ -19,18 +45,21 @@ object MessageMatchers {
         MatchOutcomeFailed(e.renderDifferencesListWithRules(rules, isXml), e.differences.length * 1)
     }
 
-  def matchSingleMessage(rules: Option[Map[String, MatchingRule]],
-                         expected: Option[String],
-                         received: Option[String])(implicit matchingRules: IrNodeMatchingRules,
-                                                   pactReader: IPactReader): MatchOutcome = {
+  def matchSingleMessage(rules: Option[Map[String, MatchingRule]], expected: Option[String], received: Option[String])(
+      implicit matchingRules: IrNodeMatchingRules,
+      pactReader: IPactReader
+  ): MatchOutcome =
     (expected, received) match {
-      case (Some(e), Some(r)) => MatchIr
-        .fromJSON(pactReader.fromJSON)(e)
-        .flatMap { e =>
-          MatchIr.fromJSON(pactReader.fromJSON)(r).map(r =>{
-            nodeMatchToMatchResult( e =~ r, matchingRules, isXml = false)
-          })
-        }.getOrElse(MatchOutcomeFailed("Failed to parse JSON body", 50))
+      case (Some(e), Some(r)) =>
+        MatchIr
+          .fromJSON(pactReader.fromJSON)(e)
+          .flatMap { e =>
+            MatchIr
+              .fromJSON(pactReader.fromJSON)(r)
+              .map(r => {
+                nodeMatchToMatchResult(e =~ r, matchingRules, isXml = false)
+              })
+          }
+          .getOrElse(MatchOutcomeFailed("Failed to parse JSON body", 50))
     }
-  }
 }

--- a/scalapact-core/src/main/scala/com/itv/scalapactcore/common/matching/MessageMatchers.scala
+++ b/scalapact-core/src/main/scala/com/itv/scalapactcore/common/matching/MessageMatchers.scala
@@ -25,7 +25,6 @@ object MessageMatchers {
              | ...Differences
              |${f.renderDifferences}
              """.stripMargin
-          //TODO Match on headers
         )
 
       case Some(OutcomeAndMessage(MatchOutcomeSuccess, message)) =>

--- a/scalapact-core/src/main/scala/com/itv/scalapactcore/common/matching/package.scala
+++ b/scalapact-core/src/main/scala/com/itv/scalapactcore/common/matching/package.scala
@@ -1,0 +1,16 @@
+package com.itv.scalapactcore.common
+
+import com.itv.scalapact.shared.matchir.{IrNodeEqualityResult, IrNodeMatchingRules, IrNodesEqual, IrNodesNotEqual}
+
+package object matching {
+  def nodeMatchToMatchResult(irNodeEqualityResult: IrNodeEqualityResult,
+                             rules: IrNodeMatchingRules,
+                             isXml: Boolean): MatchOutcome =
+    irNodeEqualityResult match {
+      case IrNodesEqual =>
+        MatchOutcomeSuccess
+
+      case e: IrNodesNotEqual =>
+        MatchOutcomeFailed(e.renderDifferencesListWithRules(rules, isXml), e.differences.length * 1)
+    }
+}

--- a/scalapact-core/src/main/scala/com/itv/scalapactcore/message/IMessageStubber.scala
+++ b/scalapact-core/src/main/scala/com/itv/scalapactcore/message/IMessageStubber.scala
@@ -6,9 +6,15 @@ import com.itv.scalapactcore.common.matching.MatchOutcome
 
 trait IMessageStubber[A] {
   def consume(description: String)(test: Message => A): IMessageStubber[A]
-  def publish[T](description: String, actualContent: T, meta: Message.Metadata = Message.Metadata.empty)(
+
+  def publish[T](description: String, actualContent: T)(
+      implicit messageFormat: IMessageFormat[T]
+  ): IMessageStubber[A] = publish(description, actualContent, Message.Metadata.empty)
+
+  def publish[T](description: String, actualContent: T, meta: Message.Metadata)(
       implicit messageFormat: IMessageFormat[T]
   ): IMessageStubber[A]
+
   def results: List[A]
   def outcome: MatchOutcome
 }

--- a/scalapact-core/src/main/scala/com/itv/scalapactcore/message/IMessageStubber.scala
+++ b/scalapact-core/src/main/scala/com/itv/scalapactcore/message/IMessageStubber.scala
@@ -2,11 +2,13 @@ package com.itv.scalapactcore.message
 
 import com.itv.scalapact.shared.Message
 import com.itv.scalapact.shared.typeclasses.IMessageFormat
+import com.itv.scalapactcore.common.matching.MatchOutcome
 
 trait IMessageStubber[A] {
   def consume(description: String)(test: Message => A): IMessageStubber[A]
   def publish[T](description: String, actualContent: T, meta: Message.Metadata = Message.Metadata.empty)(
       implicit messageFormat: IMessageFormat[T]
   ): IMessageStubber[A]
-  def currentResult: List[Either[String, A]]
+  def results: List[A]
+  def outcome: MatchOutcome
 }

--- a/scalapact-core/src/main/scala/com/itv/scalapactcore/message/IMessageStubber.scala
+++ b/scalapact-core/src/main/scala/com/itv/scalapactcore/message/IMessageStubber.scala
@@ -1,0 +1,10 @@
+package com.itv.scalapactcore.message
+
+import com.itv.scalapact.shared.Message
+import com.itv.scalapact.shared.typeclasses.IMessageFormat
+
+trait IMessageStubber[A] {
+  def consume(description: String)(test: Message => A): IMessageStubber[A]
+  def publish[T](description: String, actualContent: T)(implicit messageFormat: IMessageFormat[T]): IMessageStubber[A]
+  def currentResult: List[Either[String, A]]
+}

--- a/scalapact-core/src/main/scala/com/itv/scalapactcore/message/IMessageStubber.scala
+++ b/scalapact-core/src/main/scala/com/itv/scalapactcore/message/IMessageStubber.scala
@@ -5,6 +5,8 @@ import com.itv.scalapact.shared.typeclasses.IMessageFormat
 
 trait IMessageStubber[A] {
   def consume(description: String)(test: Message => A): IMessageStubber[A]
-  def publish[T](description: String, actualContent: T)(implicit messageFormat: IMessageFormat[T]): IMessageStubber[A]
+  def publish[T](description: String, actualContent: T, meta: Message.Metadata = Message.Metadata.empty)(
+      implicit messageFormat: IMessageFormat[T]
+  ): IMessageStubber[A]
   def currentResult: List[Either[String, A]]
 }

--- a/scalapact-core/src/main/scala/com/itv/scalapactcore/message/MessageStubber.scala
+++ b/scalapact-core/src/main/scala/com/itv/scalapactcore/message/MessageStubber.scala
@@ -49,7 +49,9 @@ object MessageStubber {
           .map(
             message =>
               OutcomeAndMessage(
-                MessageMatchers.matchSingleMessage(message.contents, messageFormat.encode(actualMessage)),
+                MessageMatchers.matchSingleMessage(message.contents,
+                                                   messageFormat.encode(actualMessage),
+                                                   Some(message.matchingRules)),
                 message
             )
           )

--- a/scalapact-core/src/main/scala/com/itv/scalapactcore/message/MessageStubber.scala
+++ b/scalapact-core/src/main/scala/com/itv/scalapactcore/message/MessageStubber.scala
@@ -1,0 +1,60 @@
+package com.itv.scalapactcore.message
+
+import com.itv.scalapact.shared.matchir.IrNodeMatchingRules
+import com.itv.scalapact.shared.typeclasses.{IMessageFormat, IPactReader}
+import com.itv.scalapact.shared.Message
+import com.itv.scalapactcore.common.matching.MessageMatchers.OutcomeAndMessage
+import com.itv.scalapactcore.common.matching.{MatchOutcomeFailed, MatchOutcomeSuccess, MessageMatchers}
+
+object MessageStubber {
+
+  def apply[A](
+      messages: List[Message],
+      results: List[Either[List[String], A]] = List.empty
+  )(implicit matchingRules: IrNodeMatchingRules, pactReader: IPactReader): IMessageStubber[A] =
+    new IMessageStubber[A] {
+
+      private def messageStub(result: Either[List[String], A]): IMessageStubber[A] =
+        MessageStubber.apply(messages, result :: results)
+      private def fail(result: String): IMessageStubber[A]       = fail(List(result))
+      private def fail(result: List[String]): IMessageStubber[A] = messageStub(Left(result))
+      private def success(result: A): IMessageStubber[A]         = messageStub(Right(result))
+      private def none: IMessageStubber[A]                       = this
+
+      private def noDescriptionFound(description: String) =
+        fail(s"No `$description` found in:\n [ ${messages.map(_.renderAsString).mkString("\n")} \n ]")
+
+      def consume(description: String)(test: Message => A): IMessageStubber[A] =
+        messages
+          .find(_.description == description)
+          .map(test)
+          .fold(noDescriptionFound(description)) { r =>
+            success(r)
+          }
+
+      def publish[T](description: String,
+                     actualMessage: T)(implicit messageFormat: IMessageFormat[T]): IMessageStubber[A] =
+        messages
+          .find(m => m.description == description)
+          .fold(noDescriptionFound(description))(
+            message =>
+              OutcomeAndMessage(
+                MessageMatchers.matchSingleMessage(None,
+                                                   Some(message.content),
+                                                   Some(messageFormat.encode(actualMessage))),
+                message
+              ) match {
+                case OutcomeAndMessage(MatchOutcomeSuccess, _) => none
+                case outcomeAndMessage @ OutcomeAndMessage(MatchOutcomeFailed(_, _), _) =>
+                  fail(
+                    MessageMatchers
+                      .renderOutcome(Some(outcomeAndMessage), messageFormat.encode(actualMessage), description)
+                      .left
+                      .get
+                  )
+            }
+          )
+
+      override def currentResult: List[Either[String, A]] = results.map(_.fold(x => Left(x.mkString("")), Right(_)))
+    }
+}

--- a/scalapact-core/src/main/scala/com/itv/scalapactcore/message/MessageStubber.scala
+++ b/scalapact-core/src/main/scala/com/itv/scalapactcore/message/MessageStubber.scala
@@ -45,13 +45,13 @@ object MessageStubber {
           .map(
             message =>
               OutcomeAndMessage(
-                MessageMatchers.matchSingleMessage(None, message.content, messageFormat.encode(actualMessage)),
+                MessageMatchers.matchSingleMessage(None, message.contents, messageFormat.encode(actualMessage)),
                 message
             )
           )
           .map {
-            case OutcomeAndMessage(oc, message) if !message.meta.forall(n => metadata.get(n._1).contains(n._2)) =>
-              fail(oc + MatchOutcomeFailed(s"Metadata does not match: ${message.meta} /= $metadata"))
+            case OutcomeAndMessage(oc, message) if !message.metaData.forall(n => metadata.get(n._1).contains(n._2)) =>
+              fail(oc + MatchOutcomeFailed(s"Metadata does not match: ${message.metaData} /= $metadata"))
             case OutcomeAndMessage(MatchOutcomeSuccess, _) => none
             case outcomeAndMessage @ OutcomeAndMessage(MatchOutcomeFailed(_, _), _) =>
               fail(

--- a/scalapact-core/src/main/scala/com/itv/scalapactcore/message/MessageStubber.scala
+++ b/scalapact-core/src/main/scala/com/itv/scalapactcore/message/MessageStubber.scala
@@ -39,9 +39,7 @@ object MessageStubber {
           .fold(noDescriptionFound(description))(
             message =>
               OutcomeAndMessage(
-                MessageMatchers.matchSingleMessage(None,
-                                                   Some(message.content),
-                                                   Some(messageFormat.encode(actualMessage))),
+                MessageMatchers.matchSingleMessage(None, message.content, messageFormat.encode(actualMessage)),
                 message
               ) match {
                 case OutcomeAndMessage(MatchOutcomeSuccess, _) => none

--- a/scalapact-core/src/main/scala/com/itv/scalapactcore/message/MessageStubber.scala
+++ b/scalapact-core/src/main/scala/com/itv/scalapactcore/message/MessageStubber.scala
@@ -51,25 +51,16 @@ object MessageStubber {
         messages
           .find(m => m.description == description)
           .map(
-            message => {
-              val bodyRules = "body"
+            message =>
               OutcomeAndMessage(
                 MessageMatchers.matchSingleMessage(
                   message.contents,
                   messageFormat.encode(actualMessage),
-                  message.matchingRules
-                    .get(bodyRules)
-                    .map(_.flatMap {
-                      case (k, v) =>
-                        v.matchers.headOption
-                          .map(x => k.replace("$", "$." + bodyRules) -> x)
-                          .toList //FIXME at the moment we only verify the first matching rule
-                    }),
+                  message.matchingRules,
                   config.strictMode
                 ),
                 message
-              )
-            }
+            )
           )
           .map {
             case OutcomeAndMessage(oc, message) if !message.metaData.forall(n => metadata.get(n._1).contains(n._2)) =>

--- a/scalapact-core/src/main/scala/com/itv/scalapactcore/message/MessageStubber.scala
+++ b/scalapact-core/src/main/scala/com/itv/scalapactcore/message/MessageStubber.scala
@@ -8,10 +8,14 @@ import com.itv.scalapactcore.common.matching.{MatchOutcome, MatchOutcomeFailed, 
 
 object MessageStubber {
 
+  def apply[A](messages: List[Message])(implicit matchingRules: IrNodeMatchingRules,
+                                        pactReader: IPactReader): IMessageStubber[A] =
+    MessageStubber.apply[A](messages, MatchOutcomeSuccess, List.empty)
+
   def apply[A](
       messages: List[Message],
-      outcomes: MatchOutcome = MatchOutcomeSuccess,
-      currentResults: List[A] = List.empty
+      outcomes: MatchOutcome,
+      currentResults: List[A]
   )(implicit matchingRules: IrNodeMatchingRules, pactReader: IPactReader): IMessageStubber[A] =
     new IMessageStubber[A] {
 
@@ -45,7 +49,7 @@ object MessageStubber {
           .map(
             message =>
               OutcomeAndMessage(
-                MessageMatchers.matchSingleMessage(None, message.contents, messageFormat.encode(actualMessage)),
+                MessageMatchers.matchSingleMessage(message.contents, messageFormat.encode(actualMessage)),
                 message
             )
           )
@@ -57,8 +61,7 @@ object MessageStubber {
               fail(
                 MessageMatchers
                   .renderOutcome(Some(outcomeAndMessage), messageFormat.encode(actualMessage), description)
-                  .left
-                  .get
+                  .fold(identity, _ => ???)
               )
           }
           .getOrElse(noDescriptionFound(description))

--- a/scalapact-core/src/main/scala/com/itv/scalapactcore/message/MessageStubber.scala
+++ b/scalapact-core/src/main/scala/com/itv/scalapactcore/message/MessageStubber.scala
@@ -21,14 +21,13 @@ object MessageStubber {
         result.toList ++ results
       )
 
-      private def success(result: A): IMessageStubber[A] = messageStub(MatchOutcomeSuccess, Some(result))
+      private def success(result: A): IMessageStubber[A]          = messageStub(MatchOutcomeSuccess, Some(result))
       private def fail(outcome: MatchOutcome): IMessageStubber[A] = messageStub(outcomes + outcome, None)
-      private def fail(outcome: String): IMessageStubber[A] = messageStub(outcomes + MatchOutcomeFailed(outcome), None)
-      private def none: IMessageStubber[A] = this
-
+      private def fail(outcome: String): IMessageStubber[A]       = messageStub(outcomes + MatchOutcomeFailed(outcome), None)
+      private def none: IMessageStubber[A]                        = this
 
       private def noDescriptionFound(description: String) =
-        fail(s"No `$description` found in:\n [ ${messages.map(_.renderAsString).mkString("\n")} \n ]")
+        fail(s"No description `$description` found in:\n [ ${messages.map(_.renderAsString).mkString("\n")} \n ]")
 
       def consume(description: String)(test: Message => A): IMessageStubber[A] =
         messages
@@ -43,7 +42,8 @@ object MessageStubber {
       ): IMessageStubber[A] =
         messages
           .find(m => m.description == description)
-          .map( message =>
+          .map(
+            message =>
               OutcomeAndMessage(
                 MessageMatchers.matchSingleMessage(None, message.content, messageFormat.encode(actualMessage)),
                 message
@@ -63,7 +63,7 @@ object MessageStubber {
           }
           .getOrElse(noDescriptionFound(description))
 
-      override def results: List[A] = currentResults
+      override def results: List[A]      = currentResults
       override def outcome: MatchOutcome = outcomes
     }
 }

--- a/scalapact-http4s-0-16a/src/main/scala/com/itv/scalapact/http4s16a/impl/PactStubService.scala
+++ b/scalapact-http4s-0-16a/src/main/scala/com/itv/scalapact/http4s16a/impl/PactStubService.scala
@@ -58,7 +58,9 @@ private object PactStubService {
 
         case m if m == "GET" && req.pathInfo.startsWith("/interactions") =>
           val output =
-            pactWriter.pactToJsonString(Pact(PactActor(""), PactActor(""), interactionManager.getInteractions))
+            pactWriter.pactToJsonString(
+              Pact(PactActor(""), PactActor(""), interactionManager.getInteractions, List.empty)
+            )
           Ok(output)
 
         case m if m == "POST" || m == "PUT" && req.pathInfo.startsWith("/interactions") =>
@@ -73,7 +75,9 @@ private object PactStubService {
               interactionManager.addInteractions(r.interactions)
 
               val output =
-                pactWriter.pactToJsonString(Pact(PactActor(""), PactActor(""), interactionManager.getInteractions))
+                pactWriter.pactToJsonString(
+                  Pact(PactActor(""), PactActor(""), interactionManager.getInteractions, List.empty)
+                )
               Ok(output)
 
             case Left(l) =>
@@ -84,7 +88,9 @@ private object PactStubService {
           interactionManager.clearInteractions()
 
           val output =
-            pactWriter.pactToJsonString(Pact(PactActor(""), PactActor(""), interactionManager.getInteractions))
+            pactWriter.pactToJsonString(
+              Pact(PactActor(""), PactActor(""), interactionManager.getInteractions, List.empty)
+            )
           Ok(output)
       }
 

--- a/scalapact-http4s-0-17/src/main/scala/com/itv/scalapact/http4s17/impl/PactStubService.scala
+++ b/scalapact-http4s-0-17/src/main/scala/com/itv/scalapact/http4s17/impl/PactStubService.scala
@@ -67,7 +67,8 @@ private object PactStubService {
 
           case m if m == "GET" && req.pathInfo.startsWith("/interactions") =>
             val output =
-              pactWriter.pactToJsonString(Pact(PactActor(""), PactActor(""), interactionManager.getInteractions))
+              //FIXME: This was added just so that code compiles
+              pactWriter.pactToJsonString(Pact(PactActor(""), PactActor(""), interactionManager.getInteractions, List.empty))
             Ok(output)
 
           case m if m == "POST" || m == "PUT" && req.pathInfo.startsWith("/interactions") =>
@@ -77,8 +78,9 @@ private object PactStubService {
               case Right(r) =>
                 interactionManager.addInteractions(r.interactions)
 
+                //FIXME: This was added just so that code compiles
                 val output =
-                  pactWriter.pactToJsonString(Pact(PactActor(""), PactActor(""), interactionManager.getInteractions))
+                  pactWriter.pactToJsonString(Pact(PactActor(""), PactActor(""), interactionManager.getInteractions, List.empty))
                 Ok(output)
 
               case Left(l) =>
@@ -89,7 +91,7 @@ private object PactStubService {
             interactionManager.clearInteractions()
 
             val output =
-              pactWriter.pactToJsonString(Pact(PactActor(""), PactActor(""), interactionManager.getInteractions))
+              pactWriter.pactToJsonString(Pact(PactActor(""), PactActor(""), interactionManager.getInteractions, List.empty))
             Ok(output)
         }
 

--- a/scalapact-http4s-0-18/src/main/scala/com/itv/scalapact/http4s18/impl/PactStubService.scala
+++ b/scalapact-http4s-0-18/src/main/scala/com/itv/scalapact/http4s18/impl/PactStubService.scala
@@ -66,7 +66,9 @@ object PactStubService {
 
         case m if m == "GET" && req.pathInfo.startsWith("/interactions") =>
           val output =
-            pactWriter.pactToJsonString(Pact(PactActor(""), PactActor(""), interactionManager.getInteractions))
+            pactWriter.pactToJsonString(
+              Pact(PactActor(""), PactActor(""), interactionManager.getInteractions, List.empty)
+            )
           Ok(output)
 
         case m if m == "POST" || m == "PUT" && req.pathInfo.startsWith("/interactions") =>
@@ -77,7 +79,9 @@ object PactStubService {
               interactionManager.addInteractions(r.interactions)
 
               val output =
-                pactWriter.pactToJsonString(Pact(PactActor(""), PactActor(""), interactionManager.getInteractions))
+                pactWriter.pactToJsonString(
+                  Pact(PactActor(""), PactActor(""), interactionManager.getInteractions, List.empty)
+                )
               Ok(output)
 
             case Left(l) =>
@@ -88,7 +92,9 @@ object PactStubService {
           interactionManager.clearInteractions()
 
           val output =
-            pactWriter.pactToJsonString(Pact(PactActor(""), PactActor(""), interactionManager.getInteractions))
+            pactWriter.pactToJsonString(
+              Pact(PactActor(""), PactActor(""), interactionManager.getInteractions, List.empty)
+            )
           Ok(output)
       }
 

--- a/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactContractWriter.scala
+++ b/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactContractWriter.scala
@@ -29,7 +29,7 @@ object ScalaPactContractWriter {
       }
 
       val string = simplifyName(
-        pactDescription.consumer + pactDescription.provider + pactDescription.interactions
+        pactDescription.consumer + pactDescription.provider + pactDescription.interactions + pactDescription.messages
           .map(_.description)
           .mkString + System.currentTimeMillis().toString
       )

--- a/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactContractWriter.scala
+++ b/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactContractWriter.scala
@@ -29,9 +29,11 @@ object ScalaPactContractWriter {
       }
 
       val string = simplifyName(
-        pactDescription.consumer + pactDescription.provider + pactDescription.interactions + pactDescription.messages
-          .map(_.description)
-          .mkString + System.currentTimeMillis().toString
+        pactDescription.consumer
+          + pactDescription.provider
+          + pactDescription.interactions.map(_.description).mkString
+          + pactDescription.messages.map(_.description).mkString
+          + System.currentTimeMillis().toString
       )
 
       val sha1 = java.security.MessageDigest

--- a/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactContractWriter.scala
+++ b/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactContractWriter.scala
@@ -69,7 +69,8 @@ object ScalaPactContractWriter {
       Pact(
         provider = PactActor(pactDescription.provider),
         consumer = PactActor(pactDescription.consumer),
-        interactions = pactDescription.interactions.map { convertInteractionsFinalToInteractions }
+        messages = pactDescription.messages,
+        interactions = pactDescription.interactions.map(convertInteractionsFinalToInteractions)
     )
 
   lazy val convertInteractionsFinalToInteractions: ScalaPactInteractionFinal => Interaction = i => {
@@ -122,6 +123,6 @@ object ScalaPactContractWriter {
   implicit private val mapToBoolean: Map[String, String] => Boolean = v => v.nonEmpty
 
   implicit private def valueToOptional[A](value: A)(implicit p: A => Boolean): Option[A] =
-    if (p(value)) Option(value) else None
+    Option(value).filter(p)
 
 }

--- a/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactForger.scala
+++ b/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactForger.scala
@@ -47,12 +47,20 @@ object ScalaPactForger {
       copy(meta = meta)
 
     def withContent[T](value: T)(implicit format: IMessageFormat[T], iInferTypes: IInferTypes[T]): Message =
-      Message(description,
-              providerState,
-              format.encode(value),
-              meta,
-              iInferTypes.infer(value) ++ matchingRules,
-              format.contentType)
+      Message(
+        description,
+        providerState,
+        format.encode(value),
+        meta,
+        addDollarWheRequired(iInferTypes.infer(value)) ++ addDollarWheRequired(matchingRules),
+        format.contentType
+      )
+
+    private def addDollarWheRequired(rules: Map[String, MatchingRule]): Map[String, MatchingRule] = rules.map {
+      case (k, v) if k.startsWith("$") => k        -> v
+      case (k, v) if k.startsWith(".") => "$" + k  -> v
+      case (k, v)                      => "$." + k -> v
+    }
   }
 
   sealed trait ForgePactElements {

--- a/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactForger.scala
+++ b/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactForger.scala
@@ -31,7 +31,7 @@ object ScalaPactForger {
   }
 
   case class PartialScalaPactMessage(description: String,
-                                     providerStates: List[String],
+                                     providerStates: List[ProviderState],
                                      meta: Message.Metadata,
                                      matchingRules: MatchingRules) {
 
@@ -45,7 +45,7 @@ object ScalaPactForger {
         throw new RuntimeException(s"$jsonPath is invalid") //FIXME At the moment we only support body verifications
     }
 
-    def withProviderState(state: String): PartialScalaPactMessage =
+    def withProviderState(state: ProviderState): PartialScalaPactMessage =
       copy(providerStates = providerStates ++ List(state))
 
     def withMeta(meta: Message.Metadata): PartialScalaPactMessage =

--- a/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactForger.scala
+++ b/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactForger.scala
@@ -1,6 +1,5 @@
 package com.itv.scalapact
 
-import com.itv.scalapact.ScalaPactForger.ScalaPactOptions
 import com.itv.scalapact.ScalaPactVerify.ScalaPactVerifyFailed
 import com.itv.scalapact.shared.Maps._
 import com.itv.scalapact.shared.typeclasses._
@@ -95,11 +94,11 @@ object ScalaPactForger {
           pactReader: IPactReader
       ): List[A] = {
         contractWriter.writeContract(scalaPactDescriptionFinal(options))
-        val ms = test(MessageStubber(this.messages))
-        if (ms.outcome.isSuccess){
-          ms.results
-        } else {
-          PactLogger.error(ms.outcome.renderAsString.red)
+        val result = test(MessageStubber(this.messages))
+        if (result.outcome.isSuccess)
+          result.results
+        else {
+          PactLogger.error(result.outcome.renderAsString.red)
           throw new ScalaPactVerifyFailed
         }
       }

--- a/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactForger.scala
+++ b/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactForger.scala
@@ -93,7 +93,14 @@ object ScalaPactForger {
           )
         )(test)
 
+
+      def runMessageTests[A](test: Message => A): A =
+        test(this.messages.head)
     }
+
+
+
+
 
   }
   object message {

--- a/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactForger.scala
+++ b/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactForger.scala
@@ -5,7 +5,6 @@ import com.itv.scalapact.shared.Maps._
 import com.itv.scalapact.shared.typeclasses._
 import com.itv.scalapact.shared._
 import com.itv.scalapactcore.message.{IMessageStubber, MessageStubber}
-import com.itv.scalapact.shared.ColourOuput._
 
 import scala.language.implicitConversions
 import scala.util.Properties
@@ -133,6 +132,7 @@ object ScalaPactForger {
           implicit contractWriter: messageSpec.IContractWriter,
           pactReader: IPactReader
       ): List[A] = {
+        import com.itv.scalapact.shared.ColourOuput._
         contractWriter.writeContract(scalaPactDescriptionFinal(options))
         val result = test(MessageStubber(this.messages, config))
         if (result.outcome.isSuccess)

--- a/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactForger.scala
+++ b/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactForger.scala
@@ -35,8 +35,12 @@ object ScalaPactForger {
                                      meta: Message.Metadata,
                                      matchingRules: Map[String, MatchingRule]) {
 
-    def withRegexMatchingRule(key: String, regex: String): PartialScalaPactMessage =
-      withMatchingRule(key, MatchingRule(Some("regex"), Some(regex), None))
+    def withRegexMatchingRule(key: String, regex: String): PartialScalaPactMessage = key match {
+
+      case value if value.startsWith("$.body") =>
+        withMatchingRule(key.replace("$.body", "$"), MatchingRule(Some("regex"), Some(regex), None))
+      case _ => this //TODO Review this
+    }
 
     def withMatchingRule(key: String, value: MatchingRule): PartialScalaPactMessage =
       copy(matchingRules = matchingRules + (key -> value))

--- a/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactForger.scala
+++ b/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactForger.scala
@@ -4,7 +4,6 @@ import com.itv.scalapact.ScalaPactVerify.ScalaPactVerifyFailed
 import com.itv.scalapact.shared.Maps._
 import com.itv.scalapact.shared.typeclasses._
 import com.itv.scalapact.shared._
-
 import com.itv.scalapactcore.message.{IMessageStubber, MessageStubber}
 import com.itv.scalapact.shared.ColourOuput._
 
@@ -96,9 +95,19 @@ object ScalaPactForger {
       def runMessageTests[A](test: IMessageStubber[A] => IMessageStubber[A])(
           implicit contractWriter: messageSpec.IContractWriter,
           pactReader: IPactReader
+      ): List[A] = runMessageTests(MessageStubber.Config(strictMode = false))(test)
+
+      def runStrictMessageTests[A](test: IMessageStubber[A] => IMessageStubber[A])(
+          implicit contractWriter: messageSpec.IContractWriter,
+          pactReader: IPactReader
+      ): List[A] = runMessageTests(MessageStubber.Config(strictMode = true))(test)
+
+      private def runMessageTests[A](config: MessageStubber.Config)(test: IMessageStubber[A] => IMessageStubber[A])(
+          implicit contractWriter: messageSpec.IContractWriter,
+          pactReader: IPactReader
       ): List[A] = {
         contractWriter.writeContract(scalaPactDescriptionFinal(options))
-        val result = test(MessageStubber(this.messages))
+        val result = test(MessageStubber(this.messages, config))
         if (result.outcome.isSuccess)
           result.results
         else {

--- a/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactForger.scala
+++ b/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactForger.scala
@@ -35,14 +35,15 @@ object ScalaPactForger {
                                      meta: Message.Metadata,
                                      matchingRules: Map[String, MatchingRule]) {
 
-    def withRegexMatchingRule(key: String, regex: String): PartialScalaPactMessage = key match {
-      case value if value.startsWith("$.body") =>
-        withMatchingRule(key.replace("$.body", "$"), MatchingRule(Some("regex"), Some(regex), None))
-      case _ => this //TODO Review this
-    }
+    def withRegexMatchingRule(jsonPath: String, regex: String): PartialScalaPactMessage =
+      withMatchingRule(jsonPath, MatchingRule(Some("regex"), Some(regex), None))
 
-    def withMatchingRule(key: String, value: MatchingRule): PartialScalaPactMessage =
-      copy(matchingRules = matchingRules + (key -> value))
+    def withMatchingRule(jsonPath: String, value: MatchingRule): PartialScalaPactMessage = jsonPath match {
+      case x if x.startsWith("$.body") =>
+        copy(matchingRules = matchingRules + (jsonPath.replace("$.body", "$") -> value))
+      case _ =>
+        throw new RuntimeException(s"$jsonPath is invalid") //FIXME At the moment we only support body verifications
+    }
 
     def withProviderState(state: String): PartialScalaPactMessage =
       copy(providerStates = providerStates ++ List(state))

--- a/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactForger.scala
+++ b/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactForger.scala
@@ -95,12 +95,13 @@ object ScalaPactForger {
           pactReader: IPactReader
       ): List[A] = {
         contractWriter.writeContract(scalaPactDescriptionFinal(options))
-        val (y, x) = test(MessageStubber(this.messages)).currentResult.partition(_.isLeft)
-
-        if (y.nonEmpty) {
-          PactLogger.error(y.map(_.left.get).mkString("\n").red)
+        val ms = test(MessageStubber(this.messages))
+        if (ms.outcome.isSuccess){
+          ms.results
+        } else {
+          PactLogger.error(ms.outcome.renderAsString.red)
           throw new ScalaPactVerifyFailed
-        } else x.map(_.right.get)
+        }
       }
 
       private def scalaPactDescriptionFinal(options: ScalaPactOptions): ScalaPactDescriptionFinal =

--- a/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactForger.scala
+++ b/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactForger.scala
@@ -33,6 +33,10 @@ object ScalaPactForger {
                                      providerState: Option[String],
                                      meta: Message.Metadata,
                                      matchingRules: Map[String, MatchingRule]) {
+
+    def withRegex(key: String, regex: String): PartialScalaPactMessage =
+      withMatchingRule(key, MatchingRule(Some("regex"), Some(regex), None))
+
     def withMatchingRule(key: String, value: MatchingRule): PartialScalaPactMessage =
       copy(matchingRules = matchingRules + (key -> value))
 

--- a/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactForger.scala
+++ b/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactForger.scala
@@ -46,8 +46,13 @@ object ScalaPactForger {
     def withMeta(meta: Message.Metadata): PartialScalaPactMessage =
       copy(meta = meta)
 
-    def withContent[T](value: T)(implicit format: IMessageFormat[T]): Message =
-      Message(description, providerState, format.encode(value), meta, matchingRules, format.contentType)
+    def withContent[T](value: T)(implicit format: IMessageFormat[T], iInferTypes: IInferTypes[T]): Message =
+      Message(description,
+              providerState,
+              format.encode(value),
+              meta,
+              iInferTypes.infer(value) ++ matchingRules,
+              format.contentType)
   }
 
   sealed trait ForgePactElements {

--- a/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactForger.scala
+++ b/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactForger.scala
@@ -142,8 +142,7 @@ object ScalaPactForger {
               throw new ScalaPactVerifyFailed
             },
             _ => {
-              val messages = this.messages
-              MessageVerifier(messages, config)(test)
+              MessageVerifier(this.messages, config)(test)
             }
           )
       }

--- a/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactForger.scala
+++ b/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactForger.scala
@@ -164,7 +164,7 @@ object ScalaPactForger {
   object MessageVerifier {
     def apply[A](messages: List[Message], config: MessageStubber.Config)(
         test: IMessageStubber[A] => IMessageStubber[A]
-    )(implicit matchingRules: IrNodeMatchingRules, pactReader: IPactReader) = {
+    )(implicit matchingRules: IrNodeMatchingRules, pactReader: IPactReader): List[A] = {
       import com.itv.scalapact.shared.ColourOuput._
       val result = test(MessageStubber(messages, config))
       if (result.outcome.isSuccess)

--- a/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactForger.scala
+++ b/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactForger.scala
@@ -31,12 +31,11 @@ object ScalaPactForger {
   }
 
   case class PartialScalaPactMessage(description: String,
-                                     providerState: Option[String],
+                                     providerStates: List[String],
                                      meta: Message.Metadata,
                                      matchingRules: Map[String, MatchingRule]) {
 
     def withRegexMatchingRule(key: String, regex: String): PartialScalaPactMessage = key match {
-
       case value if value.startsWith("$.body") =>
         withMatchingRule(key.replace("$.body", "$"), MatchingRule(Some("regex"), Some(regex), None))
       case _ => this //TODO Review this
@@ -46,7 +45,7 @@ object ScalaPactForger {
       copy(matchingRules = matchingRules + (key -> value))
 
     def withProviderState(state: String): PartialScalaPactMessage =
-      copy(providerState = Some(state))
+      copy(providerStates = providerStates ++ List(state))
 
     def withMeta(meta: Message.Metadata): PartialScalaPactMessage =
       copy(meta = meta)
@@ -55,7 +54,7 @@ object ScalaPactForger {
       val stringToMatchers: MatchingRules = merge(iInferTypes.infer(value), matchingRules)
       Message(
         description,
-        providerState,
+        providerStates,
         format.encode(value),
         meta,
         stringToMatchers.headOption.fold[MatchingRules](Map.empty)(_ => stringToMatchers),
@@ -216,7 +215,7 @@ object ScalaPactForger {
   object message {
 
     def description(desc: String): PartialScalaPactMessage =
-      PartialScalaPactMessage(desc, None, Map.empty, Map.empty)
+      PartialScalaPactMessage(desc, List.empty, Map.empty, Map.empty)
   }
 
   object interaction {

--- a/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactForger.scala
+++ b/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactForger.scala
@@ -118,7 +118,8 @@ object ScalaPactForger {
   }
 
   object messageSpec {
-    implicit def default(implicit options: ScalaPactOptions, pactWriter: IPactWriter) = IContractWriter()
+    implicit def default(implicit options: ScalaPactOptions, pactWriter: IPactWriter): IContractWriter =
+      IContractWriter()
 
     trait IContractWriter {
       def writeContract(scalaPactDescriptionFinal: ScalaPactDescriptionFinal): Unit

--- a/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactForger.scala
+++ b/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactForger.scala
@@ -30,16 +30,16 @@ object ScalaPactForger {
     protected val strict: Boolean = true
   }
 
-  case class PartialScalaPactMessage(description: String, providerState: Option[String], meta: Map[String, String]) {
+  case class PartialScalaPactMessage(description: String, providerState: Option[String], meta: Message.Metadata) {
 
     def withProviderState(state: String): PartialScalaPactMessage =
       copy(providerState = Some(state))
 
-    def withMeta(meta: Map[String, String]): PartialScalaPactMessage =
+    def withMeta(meta: Message.Metadata): PartialScalaPactMessage =
       copy(meta = meta)
 
     def withContent[T](value: T)(implicit format: IMessageFormat[T]): Message =
-      Message(description, format.contentType, providerState, format.encode(value), meta)
+      Message(description, providerState, format.encode(value), meta, format.contentType)
   }
 
   sealed trait ForgePactElements {

--- a/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactForger.scala
+++ b/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactForger.scala
@@ -94,8 +94,8 @@ object ScalaPactForger {
         if (y.nonEmpty)
           throw new ScalaPactVerifyFailed
         else x.map(_.right.get)
-
       }
+
 
       private def scalaPactDescriptionFinal(options: ScalaPactOptions): ScalaPactDescriptionFinal =
         ScalaPactDescriptionFinal(

--- a/scalapact-shared/src/main/scala/com/itv/scalapact/shared/Pact.scala
+++ b/scalapact-shared/src/main/scala/com/itv/scalapact/shared/Pact.scala
@@ -1,5 +1,7 @@
 package com.itv.scalapact.shared
 
+import com.itv.scalapact.shared.MessageContentType.ApplicationJson
+
 sealed trait JsonRepresentation
 object JsonRepresentation {
   object AsString extends JsonRepresentation
@@ -30,17 +32,16 @@ object MessageContentType {
   def unnaply(mct: MessageContentType): String = mct.renderString
 }
 
-case class Message(description: String,
-                   contentType: MessageContentType,
-                   providerState: Option[String],
-                   content: String,
-                   meta: Message.Metadata) {
+case class Message(description: String, providerState: Option[String], contents: String, metaData: Message.Metadata) {
+  def contentType: MessageContentType =
+    metaData.get("Content-Type").map(MessageContentType.apply).getOrElse(ApplicationJson)
+
   def renderAsString: String = s"""Message
                                    |  description:   [$description]
                                    |  contentType: [${contentType.renderString}]
                                    |  providerState: [${providerState.getOrElse("<none>")}]
-                                   |  meta: [${meta.mkString(",")}]
-                                   |  $content""".stripMargin
+                                   |  meta: [${metaData.mkString(",")}]
+                                   |  $contents""".stripMargin
 }
 
 object Message {

--- a/scalapact-shared/src/main/scala/com/itv/scalapact/shared/Pact.scala
+++ b/scalapact-shared/src/main/scala/com/itv/scalapact/shared/Pact.scala
@@ -53,11 +53,7 @@ object Message {
 
 }
 
-//FIXME: Remove default for messages once contract is stable
-case class Pact(provider: PactActor,
-                consumer: PactActor,
-                interactions: List[Interaction],
-                messages: List[Message] = List.empty) {
+case class Pact(provider: PactActor, consumer: PactActor, interactions: List[Interaction], messages: List[Message]) {
   def withoutSslHeader: Pact = copy(interactions = interactions.map(_.withoutSslHeader))
 
   def renderAsString: String =
@@ -66,6 +62,7 @@ case class Pact(provider: PactActor,
        |  provider: [${provider.renderAsString}]
        |  interactions:
        |${interactions.map(_.renderAsString).mkString("\n")}
+       |  messages:
        |${messages.map(_.renderAsString).mkString("\n")}
      """.stripMargin
 

--- a/scalapact-shared/src/main/scala/com/itv/scalapact/shared/Pact.scala
+++ b/scalapact-shared/src/main/scala/com/itv/scalapact/shared/Pact.scala
@@ -1,6 +1,6 @@
 package com.itv.scalapact.shared
 
-import com.itv.scalapact.shared.MessageContentType.{ApplicationJson, ApplicationText}
+import com.itv.scalapact.shared.MessageContentType._
 
 sealed trait JsonRepresentation
 object JsonRepresentation {
@@ -37,13 +37,11 @@ object MessageContentType {
   def unnaply(mct: MessageContentType): String = mct.renderString
 }
 
-case class Message(description: String, providerState: Option[String], contents: String, metaData: Message.Metadata) {
-  def contentType: MessageContentType =
-    metaData
-      .get("Content-Type")
-      .orElse(metaData.get("contentType"))
-      .map(MessageContentType.apply)
-      .getOrElse(ApplicationText)
+case class Message(description: String,
+                   providerState: Option[String],
+                   contents: String,
+                   metaData: Message.Metadata,
+                   contentType: MessageContentType = ApplicationJson) {
 
   def renderAsString: String = s"""Message
                                    |  description:   [$description]

--- a/scalapact-shared/src/main/scala/com/itv/scalapact/shared/Pact.scala
+++ b/scalapact-shared/src/main/scala/com/itv/scalapact/shared/Pact.scala
@@ -25,6 +25,10 @@ object MessageContentType {
     override val renderString = "application/json"
     override val jsonRepresentation = JsonRepresentation.AsObject
   }
+  def apply(mct: String): MessageContentType = mct match {
+    case "application/json" => ApplicationJson
+  }
+  def unnaply(mct: MessageContentType) : String = mct.renderString
 }
 
 case class Message(description: String,
@@ -32,8 +36,8 @@ case class Message(description: String,
                    providerState: Option[String],
                    content: String,
                    meta: Map[String, String])
-
-case class Pact(provider: PactActor, consumer: PactActor, interactions: List[Interaction], messages: List[Message]) {
+//FIXME: Remove default for messages once contract is stable
+case class Pact(provider: PactActor, consumer: PactActor, interactions: List[Interaction], messages: List[Message] = List.empty) {
   def withoutSslHeader: Pact = copy(interactions = interactions.map(_.withoutSslHeader))
 
   def renderAsString: String =

--- a/scalapact-shared/src/main/scala/com/itv/scalapact/shared/Pact.scala
+++ b/scalapact-shared/src/main/scala/com/itv/scalapact/shared/Pact.scala
@@ -41,7 +41,7 @@ case class Message(description: String,
                    providerState: Option[String],
                    contents: String,
                    metaData: Message.Metadata,
-                   matchingRules: Map[String, MatchingRule],
+                   matchingRules: Message.MatchingRules,
                    contentType: MessageContentType) {
 
   def renderAsString: String = s"""Message
@@ -56,6 +56,15 @@ case class Message(description: String,
 object Message {
 
   type Metadata = Map[String, String]
+
+  type MatchingRules = Map[String, Map[String, Message.Matchers]]
+
+  case class Matchers(matchers: List[MatchingRule])
+
+  object Matchers {
+
+    def from(rules: MatchingRule*): Message.Matchers = Message.Matchers(rules.toList)
+  }
 
   def apply(description: String, providerState: Option[String], contents: String, metaData: Metadata): Message =
     new Message(description, providerState, contents, metaData, Map.empty, ApplicationJson)

--- a/scalapact-shared/src/main/scala/com/itv/scalapact/shared/Pact.scala
+++ b/scalapact-shared/src/main/scala/com/itv/scalapact/shared/Pact.scala
@@ -59,7 +59,7 @@ object Message {
     new Message(description, providerState, contents, metaData, ApplicationJson)
 
   object Metadata {
-    val empty                                 = Metadata()
+    val empty: Metadata                       = Metadata()
     def apply(x: (String, String)*): Metadata = x.toMap
   }
 

--- a/scalapact-shared/src/main/scala/com/itv/scalapact/shared/Pact.scala
+++ b/scalapact-shared/src/main/scala/com/itv/scalapact/shared/Pact.scala
@@ -58,11 +58,9 @@ object MessageStub {
         messages
           .find(m => m.description == description)
           .fold(fail(s"No $description found"))(m => {
-            if (m.content == test)
-              none
-            else
-              fail(s"Expected different content: ${m.content} /= ${test}")
-
+            Option(m)
+              .filter(_.content == test) //FIXME: This can't really be done here; Matchers are a concept of scala-pact core and core depends on shared, not the other way around
+              .fold(fail(s"Expected different content: ${m.content} /= ${test}"))(_ => none)
           })
       //FIXME it should not use == (do the same as http)
 

--- a/scalapact-shared/src/main/scala/com/itv/scalapact/shared/Pact.scala
+++ b/scalapact-shared/src/main/scala/com/itv/scalapact/shared/Pact.scala
@@ -36,9 +36,9 @@ object MessageContentType {
   }
   def unnaply(mct: MessageContentType): String = mct.renderString
 }
-
+case class ProviderState(name: String, params: Map[String, String])
 case class Message(description: String,
-                   providerStates: List[String],
+                   providerStates: List[ProviderState],
                    contents: String,
                    metaData: Message.Metadata,
                    matchingRules: Message.MatchingRules,
@@ -96,7 +96,7 @@ object Message {
     def from(rules: MatchingRule*): Message.Matchers = Message.Matchers(rules.toList)
   }
 
-  def apply(description: String, providerStates: List[String], contents: String, metaData: Metadata): Message =
+  def apply(description: String, providerStates: List[ProviderState], contents: String, metaData: Metadata): Message =
     new Message(description, providerStates, contents, metaData, Map.empty, ApplicationJson)
 
   object Metadata {

--- a/scalapact-shared/src/main/scala/com/itv/scalapact/shared/Pact.scala
+++ b/scalapact-shared/src/main/scala/com/itv/scalapact/shared/Pact.scala
@@ -38,7 +38,7 @@ object MessageContentType {
 }
 
 case class Message(description: String,
-                   providerState: Option[String],
+                   providerStates: List[String],
                    contents: String,
                    metaData: Message.Metadata,
                    matchingRules: Message.MatchingRules,
@@ -47,7 +47,7 @@ case class Message(description: String,
   def renderAsString: String = s"""Message
                                    |  description:   [$description]
                                    |  contentType: [${contentType.renderString}]
-                                   |  providerState: [${providerState.getOrElse("<none>")}]
+                                   |  providerStates: [${providerStates.mkString(",")}]
                                    |  meta: [${metaData.mkString(",")}]
                                    |  matchingRules: [${matchingRules.mkString(",")}]
                                    |  $contents""".stripMargin
@@ -66,8 +66,8 @@ object Message {
     def from(rules: MatchingRule*): Message.Matchers = Message.Matchers(rules.toList)
   }
 
-  def apply(description: String, providerState: Option[String], contents: String, metaData: Metadata): Message =
-    new Message(description, providerState, contents, metaData, Map.empty, ApplicationJson)
+  def apply(description: String, providerStates: List[String], contents: String, metaData: Metadata): Message =
+    new Message(description, providerStates, contents, metaData, Map.empty, ApplicationJson)
 
   object Metadata {
     val empty: Metadata                       = Metadata()

--- a/scalapact-shared/src/main/scala/com/itv/scalapact/shared/Pact.scala
+++ b/scalapact-shared/src/main/scala/com/itv/scalapact/shared/Pact.scala
@@ -41,6 +41,7 @@ case class Message(description: String,
                    providerState: Option[String],
                    contents: String,
                    metaData: Message.Metadata,
+                   matchingRules: Map[String, MatchingRule],
                    contentType: MessageContentType) {
 
   def renderAsString: String = s"""Message
@@ -48,6 +49,7 @@ case class Message(description: String,
                                    |  contentType: [${contentType.renderString}]
                                    |  providerState: [${providerState.getOrElse("<none>")}]
                                    |  meta: [${metaData.mkString(",")}]
+                                   |  matchingRules: [${matchingRules.mkString(",")}]
                                    |  $contents""".stripMargin
 }
 
@@ -56,7 +58,7 @@ object Message {
   type Metadata = Map[String, String]
 
   def apply(description: String, providerState: Option[String], contents: String, metaData: Metadata): Message =
-    new Message(description, providerState, contents, metaData, ApplicationJson)
+    new Message(description, providerState, contents, metaData, Map.empty, ApplicationJson)
 
   object Metadata {
     val empty: Metadata                       = Metadata()

--- a/scalapact-shared/src/main/scala/com/itv/scalapact/shared/Pact.scala
+++ b/scalapact-shared/src/main/scala/com/itv/scalapact/shared/Pact.scala
@@ -34,7 +34,7 @@ case class Message(description: String,
                    contentType: MessageContentType,
                    providerState: Option[String],
                    content: String,
-                   meta: Map[String, String]) {
+                   meta: Message.Metadata) {
   def renderAsString: String = s"""Message
                                    |  description:   [$description]
                                    |  contentType: [${contentType.renderString}]
@@ -42,6 +42,17 @@ case class Message(description: String,
                                    |  meta: [${meta.mkString(",")}]
                                    |  $content""".stripMargin
 }
+
+object Message {
+  type Metadata = Map[String, String]
+
+  object Metadata {
+    val empty                                 = Metadata()
+    def apply(x: (String, String)*): Metadata = x.toMap
+  }
+
+}
+
 //FIXME: Remove default for messages once contract is stable
 case class Pact(provider: PactActor,
                 consumer: PactActor,

--- a/scalapact-shared/src/main/scala/com/itv/scalapact/shared/Pact.scala
+++ b/scalapact-shared/src/main/scala/com/itv/scalapact/shared/Pact.scala
@@ -41,7 +41,7 @@ case class Message(description: String,
                    providerState: Option[String],
                    contents: String,
                    metaData: Message.Metadata,
-                   contentType: MessageContentType = ApplicationJson) {
+                   contentType: MessageContentType) {
 
   def renderAsString: String = s"""Message
                                    |  description:   [$description]
@@ -54,6 +54,9 @@ case class Message(description: String,
 object Message {
 
   type Metadata = Map[String, String]
+
+  def apply(description: String, providerState: Option[String], contents: String, metaData: Metadata): Message =
+    new Message(description, providerState, contents, metaData, ApplicationJson)
 
   object Metadata {
     val empty                                 = Metadata()

--- a/scalapact-shared/src/main/scala/com/itv/scalapact/shared/Pact.scala
+++ b/scalapact-shared/src/main/scala/com/itv/scalapact/shared/Pact.scala
@@ -1,5 +1,13 @@
 package com.itv.scalapact.shared
 
+trait FormatError
+
+trait PactFormat[T] {
+  def contentType: String
+  def encode(t: T): String
+  def decode(s: String): Either[FormatError, T]
+}
+
 case class Pact(provider: PactActor, consumer: PactActor, interactions: List[Interaction]) {
   def withoutSslHeader: Pact = copy(interactions = interactions.map(_.withoutSslHeader))
 

--- a/scalapact-shared/src/main/scala/com/itv/scalapact/shared/matchir/IrNode.scala
+++ b/scalapact-shared/src/main/scala/com/itv/scalapact/shared/matchir/IrNode.scala
@@ -474,7 +474,7 @@ case class IrStringNode(value: String) extends IrNodePrimitive {
   def primitiveTypeName: String  = "string"
 }
 
-case class IrIntegerNode(value: Long) extends IrNodePrimitive {
+case class IrIntegerNode(value: BigInt) extends IrNodePrimitive {
   def isString: Boolean          = false
   def isNumber: Boolean          = true
   def isBoolean: Boolean         = false
@@ -485,7 +485,7 @@ case class IrIntegerNode(value: Long) extends IrNodePrimitive {
   def renderAsString: String     = value.toString.replaceAll("\\.0", "")
   def primitiveTypeName: String  = "integer"
 }
-case class IrDecimalNode(value: Double) extends IrNodePrimitive {
+case class IrDecimalNode(value: BigDecimal) extends IrNodePrimitive {
   def isString: Boolean          = false
   def isNumber: Boolean          = true
   def isBoolean: Boolean         = false

--- a/scalapact-shared/src/main/scala/com/itv/scalapact/shared/matchir/IrNode.scala
+++ b/scalapact-shared/src/main/scala/com/itv/scalapact/shared/matchir/IrNode.scala
@@ -473,16 +473,28 @@ case class IrStringNode(value: String) extends IrNodePrimitive {
   def renderAsString: String     = value
   def primitiveTypeName: String  = "string"
 }
-case class IrNumberNode(value: Double) extends IrNodePrimitive {
+
+case class IrIntegerNode(value: Long) extends IrNodePrimitive {
   def isString: Boolean          = false
   def isNumber: Boolean          = true
   def isBoolean: Boolean         = false
   def isNull: Boolean            = false
   def asString: Option[String]   = None
-  def asNumber: Option[Double]   = Option(value)
+  def asNumber: Option[Double]   = Option(value.toDouble)
   def asBoolean: Option[Boolean] = None
   def renderAsString: String     = value.toString.replaceAll("\\.0", "")
-  def primitiveTypeName: String  = "number"
+  def primitiveTypeName: String  = "integer"
+}
+case class IrDecimalNode(value: Double) extends IrNodePrimitive {
+  def isString: Boolean          = false
+  def isNumber: Boolean          = true
+  def isBoolean: Boolean         = false
+  def isNull: Boolean            = false
+  def asString: Option[String]   = None
+  def asNumber: Option[Double]   = Option(value.toDouble)
+  def asBoolean: Option[Boolean] = None
+  def renderAsString: String     = value.toString.replaceAll("\\.0", "")
+  def primitiveTypeName: String  = "decimal"
 }
 case class IrBooleanNode(value: Boolean) extends IrNodePrimitive {
   def isString: Boolean          = false

--- a/scalapact-shared/src/main/scala/com/itv/scalapact/shared/matchir/IrNodeRule.scala
+++ b/scalapact-shared/src/main/scala/com/itv/scalapact/shared/matchir/IrNodeRule.scala
@@ -233,7 +233,6 @@ case class IrNodeMatchingRules(rules: List[IrNodeRule], withTracing: RuleProcess
 
     (parentTypeRules ++ findForPath(path, isXml))
       .map {
-        //TODO Avoid pattern matching
         case IrNodeTypeRule(_) =>
           RuleProcessTracing.log(s"Checking type... (${expected.primitiveTypeName} vs ${actual.primitiveTypeName})")
 
@@ -281,6 +280,11 @@ case class IrNodeMatchingRules(rules: List[IrNodeRule], withTracing: RuleProcess
           RuleProcessTracing.log(s"  ...n/a")
           None
 
+        case IrNodeIntegerRule(_) =>
+          None
+        case IrNodeDecimalRule(_) =>
+          None
+
         case _ =>
           RuleProcessTracing.log("Checking failed, unexpected condition met.")
           None
@@ -324,8 +328,12 @@ object IrNodeMatchingRules {
     (IrNodePath.fromPactPath(pair._1), pair._2) match {
       case (e: PactPathParseFailure, _) =>
         Left(e.errorString)
+      case (PactPathParseSuccess(path), MatchingRule(Some("number"), None, None)) =>
+        Right(IrNodeMatchingRules(IrNodeDecimalRule(path)))
       case (PactPathParseSuccess(path), MatchingRule(Some("integer"), None, None)) =>
         Right(IrNodeMatchingRules(IrNodeIntegerRule(path)))
+      case (PactPathParseSuccess(path), MatchingRule(Some("decimal"), None, None)) =>
+        Right(IrNodeMatchingRules(IrNodeDecimalRule(path)))
       case (PactPathParseSuccess(path), MatchingRule(Some("type"), None, None)) =>
         Right(IrNodeMatchingRules(IrNodeTypeRule(path)))
 

--- a/scalapact-shared/src/main/scala/com/itv/scalapact/shared/matchir/MatchIr.scala
+++ b/scalapact-shared/src/main/scala/com/itv/scalapact/shared/matchir/MatchIr.scala
@@ -28,13 +28,13 @@ trait XmlConversionFunctions extends PrimitiveConversionFunctions {
           IrNodeAttributes(Map(k -> IrNodeAttribute(IrNullNode, pathToParent <@ k)))
 
         case (k, v) if v.matches(isIntegerValueRegex) =>
-          safeStringToLong(v)
+          safeStringToBigInt(v)
             .map(IrIntegerNode)
             .map(vv => IrNodeAttributes(Map(k -> IrNodeAttribute(vv, pathToParent <@ k))))
             .getOrElse(IrNodeAttributes.empty)
 
         case (k, v) if v.matches(isDecimalValueRegex) =>
-          safeStringToDouble(v)
+          safeStringToBigDecimal(v)
             .map(IrDecimalNode)
             .map(vv => IrNodeAttributes(Map(k -> IrNodeAttribute(vv, pathToParent <@ k))))
             .getOrElse(IrNodeAttributes.empty)
@@ -55,8 +55,8 @@ trait XmlConversionFunctions extends PrimitiveConversionFunctions {
     nodes match {
       case Nil if value == null                      => Option(IrNullNode)
       case Nil if value.isEmpty                      => None
-      case Nil if value.matches(isIntegerValueRegex) => safeStringToLong(value).map(IrIntegerNode)
-      case Nil if value.matches(isDecimalValueRegex) => safeStringToDouble(value).map(IrDecimalNode)
+      case Nil if value.matches(isIntegerValueRegex) => safeStringToBigInt(value).map(IrIntegerNode)
+      case Nil if value.matches(isDecimalValueRegex) => safeStringToBigDecimal(value).map(IrDecimalNode)
       case Nil if value.matches(isBooleanValueRegex) => safeStringToBoolean(value).map(IrBooleanNode)
       case Nil                                       => Option(IrStringNode(value))
       case _                                         => None
@@ -120,23 +120,41 @@ trait PrimitiveConversionFunctions {
   val isDecimalValueRegex = """^-?\d+\.?\d*$"""
   val isBooleanValueRegex = """^(true|false)$"""
 
-  def safeStringToLong(str: String): Option[Long] =
+//  def safeStringToLong(str: String): Option[Long] =
+//    try {
+//      Option(str.toLong)
+//    } catch {
+//      case _: Throwable =>
+//        PactLogger.error(s"Failed to convert string '$str' to number (double)".red)
+//        None
+//    }
+
+  def safeStringToBigInt(str: String): Option[BigInt] =
     try {
-      Option(str.toLong)
+      Option(BigInt(str)) //TODO Review this
     } catch {
       case _: Throwable =>
         PactLogger.error(s"Failed to convert string '$str' to number (double)".red)
         None
     }
 
-  def safeStringToDouble(str: String): Option[Double] =
+  def safeStringToBigDecimal(str: String): Option[BigDecimal] =
     try {
-      Option(str.toDouble)
+      Option(BigDecimal(str)) //Review this
     } catch {
       case _: Throwable =>
         PactLogger.error(s"Failed to convert string '$str' to number (double)".red)
         None
     }
+
+//  def safeStringToDouble(str: String): Option[Double] =
+//    try {
+//      Option(str.toDouble)
+//    } catch {
+//      case _: Throwable =>
+//        PactLogger.error(s"Failed to convert string '$str' to number (double)".red)
+//        None
+//    }
 
   def safeStringToBoolean(str: String): Option[Boolean] =
     try {

--- a/scalapact-shared/src/main/scala/com/itv/scalapact/shared/typeclasses/IInferTypes.scala
+++ b/scalapact-shared/src/main/scala/com/itv/scalapact/shared/typeclasses/IInferTypes.scala
@@ -1,0 +1,12 @@
+package com.itv.scalapact.shared.typeclasses
+
+import com.itv.scalapact.shared.MatchingRule
+
+trait IInferTypes[T] {
+  def infer(t: T): Map[String, MatchingRule] =
+    inferFrom(t).mapValues(
+      v => MatchingRule(Some(v), None, None)
+    )
+
+  protected def inferFrom(t: T): Map[String, String]
+}

--- a/scalapact-shared/src/main/scala/com/itv/scalapact/shared/typeclasses/IInferTypes.scala
+++ b/scalapact-shared/src/main/scala/com/itv/scalapact/shared/typeclasses/IInferTypes.scala
@@ -12,7 +12,7 @@ trait IInferTypes[T] {
 }
 
 object IInferTypes {
-  implicit def noneInferTypeInstance[T] = new IInferTypes[T] {
+  implicit def noneInferTypeInstance[T]: IInferTypes[T] = new IInferTypes[T] {
     override protected def inferFrom(t: T): Map[String, String] = Map.empty
   }
 }

--- a/scalapact-shared/src/main/scala/com/itv/scalapact/shared/typeclasses/IInferTypes.scala
+++ b/scalapact-shared/src/main/scala/com/itv/scalapact/shared/typeclasses/IInferTypes.scala
@@ -10,3 +10,9 @@ trait IInferTypes[T] {
 
   protected def inferFrom(t: T): Map[String, String]
 }
+
+object IInferTypes {
+  implicit def noneInferTypeInstance[T] = new IInferTypes[T] {
+    override protected def inferFrom(t: T): Map[String, String] = Map.empty
+  }
+}

--- a/scalapact-shared/src/main/scala/com/itv/scalapact/shared/typeclasses/IMessageFormat.scala
+++ b/scalapact-shared/src/main/scala/com/itv/scalapact/shared/typeclasses/IMessageFormat.scala
@@ -1,0 +1,11 @@
+package com.itv.scalapact.shared.typeclasses
+
+import com.itv.scalapact.shared.MessageContentType
+
+case class MessageFormatError(msg: String) extends Throwable
+
+trait IMessageFormat[T] {
+  def contentType: MessageContentType
+  def encode(t: T): String
+  def decode(s: String): Either[MessageFormatError, T]
+}

--- a/tests-with-deps/src/test/scala/com/itv/scalapact/MessageVerificationSpec.scala
+++ b/tests-with-deps/src/test/scala/com/itv/scalapact/MessageVerificationSpec.scala
@@ -34,6 +34,23 @@ class MessageVerificationSpec extends FlatSpec with TypeCheckedTripleEquals with
       )
     )
   )
+
+  val personalData        = Json.obj("bar" -> jNumber(1234))
+  val multipleMessagesUrl = "http://multiple-pacts.itv.com"
+  val multipleMessages = samplePact.copy(
+    messages = samplePact.messages ++ List(
+      Message(
+        description = "Published personal data",
+        providerState = Some("or maybe 'scenario'? not sure about this"),
+        contents = personalData.nospaces,
+        metaData = Message.Metadata.empty,
+        matchingRules = Map(
+          ".bar" -> MatchingRule(Some("integer"), None, None)
+        ),
+        ApplicationJson
+      )
+    )
+  )
   implicit val httpClient: IScalaPactHttpClient[Task] = mockHttpClient
 
   it should " be able to verify a simple contract from pact source as json string" in {
@@ -71,6 +88,30 @@ class MessageVerificationSpec extends FlatSpec with TypeCheckedTripleEquals with
     }
   }
 
+  it should "be able to verify a multiple contract" in {
+    verifyPact
+      .withPactSource(pactBroker(multipleMessagesUrl, "Provider", List("Consumer")))
+      .noSetupRequired
+      .runMessageTests[Task, Assertion]() {
+        _.consume("Published credit data") { message =>
+          message should ===(samplePact.messages.headOption.value)
+        }.publish("Published personal data", Json.obj("bar" -> jNumber(888)))
+      }
+  }
+
+  it should "fail be able to verify when publish something different from the contract (double instead of integer)" in {
+    a[ScalaPactVerifyFailed] should be thrownBy {
+      verifyPact
+        .withPactSource(pactBroker(multipleMessagesUrl, "Provider", List("Consumer")))
+        .noSetupRequired
+        .runMessageTests[Task, Assertion]() {
+          _.consume("Published credit data") { message =>
+            message should ===(samplePact.messages.headOption.value)
+          }.publish("Published personal data", Json.obj("bar" -> jNumber(888.0)))
+        }
+    }
+  }
+
   private def mockHttpClient =
     new IScalaPactHttpClient[Task] {
       override def doRequest(
@@ -89,6 +130,8 @@ class MessageVerificationSpec extends FlatSpec with TypeCheckedTripleEquals with
       ): Either[Throwable, SimpleResponse] = simpleRequest match {
         case s if s.baseUrl.startsWith(samplePactUrl) =>
           Right(SimpleResponse(200, Map.empty, Some(samplePact.asJson.nospaces)))
+        case s if s.baseUrl.startsWith(multipleMessagesUrl) =>
+          Right(SimpleResponse(200, Map.empty, Some(multipleMessages.asJson.nospaces)))
         case _ => Right(SimpleResponse(404, Map.empty, None))
       }
 

--- a/tests-with-deps/src/test/scala/com/itv/scalapact/MessageVerificationSpec.scala
+++ b/tests-with-deps/src/test/scala/com/itv/scalapact/MessageVerificationSpec.scala
@@ -1,20 +1,24 @@
 package com.itv.scalapact
 
-import com.itv.scalapact.ScalaPactVerify.{pactAsJsonString, verifyPact}
+import com.itv.scalapact.ScalaPactVerify.{ScalaPactVerifyFailed, pactAsJsonString, pactBroker, verifyPact}
 import com.itv.scalapact.shared.MessageContentType.ApplicationJson
-import com.itv.scalapact.shared.{Message, Pact, PactActor}
+import com.itv.scalapact.shared._
 import org.scalatest.{Assertion, FlatSpec, Matchers, OptionValues}
 import Matchers._
-import com.itv.scalapact.shared.matchir.IrNode
-import com.itv.scalapact.shared.typeclasses.IPactReader
+import com.itv.scalapact.shared.typeclasses.IScalaPactHttpClient
+import fs2.Task
 import org.scalactic.TypeCheckedTripleEquals
 
+import scala.concurrent.duration.Duration
+
 class MessageVerificationSpec extends FlatSpec with TypeCheckedTripleEquals with OptionValues {
-  import json.{pactReaderInstance => _, _}
+
+  import json._
   import argonaut._
   import Argonaut._
   import com.itv.scalapact.argonaut62.PactImplicits._
 
+  val samplePactUrl = "http://pact.itv.com"
   val samplePact = Pact(
     consumer = PactActor("Consumer"),
     provider = PactActor("Provider"),
@@ -30,22 +34,69 @@ class MessageVerificationSpec extends FlatSpec with TypeCheckedTripleEquals with
       )
     )
   )
+  implicit val httpClient: IScalaPactHttpClient[Task] = mockHttpClient
 
-  implicit val reader: IPactReader = new IPactReader {
-    override def jsonStringToPact(json: String): Either[String, Pact] = Right(samplePact)
-
-    override def fromJSON(jsonString: String): Option[IrNode] = ???
-  }
-
-  it should " be able to verify a simple contract" in {
+  it should " be able to verify a simple contract from pact source as json string" in {
     verifyPact
       .withPactSource(pactAsJsonString(samplePact.asJson.nospaces))
       .noSetupRequired
-      .runMessageTests[Assertion] { r =>
-        r.consume("Published credit data") { message =>
+      .runMessageTests[Task, Assertion]() {
+        _.consume("Published credit data") { message =>
           message should ===(samplePact.messages.headOption.value)
         }
       }
-
   }
+
+  it should "be able to verify a simple contract from pact broker" in {
+    verifyPact
+      .withPactSource(pactBroker(samplePactUrl, "Provider", List("Consumer")))
+      .noSetupRequired
+      .runMessageTests[Task, Assertion]() {
+        _.consume("Published credit data") { message =>
+          message should ===(samplePact.messages.headOption.value)
+        }
+      }
+  }
+
+  it should "fail to verify a simple contract from pact broker when the pact broker url does not exist" in {
+    a[ScalaPactVerifyFailed] should be thrownBy {
+      verifyPact
+        .withPactSource(pactBroker("http://mypacts.json", "Provider", List("Consumer")))
+        .noSetupRequired
+        .runMessageTests[Task, Assertion]() {
+          _.consume("Published credit data") { message =>
+            message should ===(samplePact.messages.headOption.value)
+          }
+        }
+    }
+  }
+
+  private def mockHttpClient =
+    new IScalaPactHttpClient[Task] {
+      override def doRequest(
+          simpleRequest: SimpleRequest
+      )(implicit sslContextMap: SslContextMap): Task[SimpleResponse] = ???
+
+      override def doInteractionRequest(
+          url: String,
+          ir: InteractionRequest,
+          clientTimeout: Duration,
+          sslContextName: Option[String]
+      )(implicit sslContextMap: SslContextMap): Task[InteractionResponse] = ???
+
+      override def doRequestSync(simpleRequest: SimpleRequest)(
+          implicit sslContextMap: SslContextMap
+      ): Either[Throwable, SimpleResponse] = simpleRequest match {
+        case s if s.baseUrl.startsWith(samplePactUrl) =>
+          Right(SimpleResponse(200, Map.empty, Some(samplePact.asJson.nospaces)))
+        case _ => Right(SimpleResponse(404, Map.empty, None))
+      }
+
+      override def doInteractionRequestSync(
+          url: String,
+          ir: InteractionRequest,
+          clientTimeout: Duration,
+          sslContextName: Option[String]
+      )(implicit sslContextMap: SslContextMap): Either[Throwable, InteractionResponse] = ???
+    }
 }

--- a/tests-with-deps/src/test/scala/com/itv/scalapact/MessageVerificationSpec.scala
+++ b/tests-with-deps/src/test/scala/com/itv/scalapact/MessageVerificationSpec.scala
@@ -45,7 +45,9 @@ class MessageVerificationSpec extends FlatSpec with TypeCheckedTripleEquals with
         contents = personalData.nospaces,
         metaData = Message.Metadata.empty,
         matchingRules = Map(
-          ".bar" -> MatchingRule(Some("integer"), None, None)
+          "body" -> Map(
+            "$.bar" -> Message.Matchers.from(MatchingRule(Some("integer"), None, None))
+          )
         ),
         ApplicationJson
       )
@@ -94,7 +96,7 @@ class MessageVerificationSpec extends FlatSpec with TypeCheckedTripleEquals with
       .noSetupRequired
       .runMessageTests[Task, Assertion]() {
         _.consume("Published credit data") { message =>
-          message should ===(samplePact.messages.headOption.value)
+          message should ===(multipleMessages.messages.headOption.value)
         }.publish("Published personal data", Json.obj("bar" -> jNumber(888)))
       }
   }
@@ -131,6 +133,7 @@ class MessageVerificationSpec extends FlatSpec with TypeCheckedTripleEquals with
         case s if s.baseUrl.startsWith(samplePactUrl) =>
           Right(SimpleResponse(200, Map.empty, Some(samplePact.asJson.nospaces)))
         case s if s.baseUrl.startsWith(multipleMessagesUrl) =>
+          println(multipleMessages.asJson.spaces4)
           Right(SimpleResponse(200, Map.empty, Some(multipleMessages.asJson.nospaces)))
         case _ => Right(SimpleResponse(404, Map.empty, None))
       }

--- a/tests-with-deps/src/test/scala/com/itv/scalapact/MessageVerificationSpec.scala
+++ b/tests-with-deps/src/test/scala/com/itv/scalapact/MessageVerificationSpec.scala
@@ -26,7 +26,7 @@ class MessageVerificationSpec extends FlatSpec with TypeCheckedTripleEquals with
     messages = List(
       Message(
         description = "Published credit data",
-        providerState = Some("or maybe 'scenario'? not sure about this"),
+        providerStates = List("or maybe 'scenario'? not sure about this"),
         contents = """{"foo":"bar"}""",
         metaData = Message.Metadata("contentType" -> "application/json"),
         matchingRules = Map.empty,
@@ -41,7 +41,7 @@ class MessageVerificationSpec extends FlatSpec with TypeCheckedTripleEquals with
     messages = samplePact.messages ++ List(
       Message(
         description = "Published personal data",
-        providerState = Some("or maybe 'scenario'? not sure about this"),
+        providerStates = List("or maybe 'scenario'? not sure about this"),
         contents = personalData.nospaces,
         metaData = Message.Metadata.empty,
         matchingRules = Map(

--- a/tests-with-deps/src/test/scala/com/itv/scalapact/MessageVerificationSpec.scala
+++ b/tests-with-deps/src/test/scala/com/itv/scalapact/MessageVerificationSpec.scala
@@ -26,7 +26,7 @@ class MessageVerificationSpec extends FlatSpec with TypeCheckedTripleEquals with
     messages = List(
       Message(
         description = "Published credit data",
-        providerStates = List("or maybe 'scenario'? not sure about this"),
+        providerStates = List(ProviderState("or maybe 'scenario'? not sure about this", Map.empty)),
         contents = """{"foo":"bar"}""",
         metaData = Message.Metadata("contentType" -> "application/json"),
         matchingRules = Map.empty,
@@ -41,7 +41,7 @@ class MessageVerificationSpec extends FlatSpec with TypeCheckedTripleEquals with
     messages = samplePact.messages ++ List(
       Message(
         description = "Published personal data",
-        providerStates = List("or maybe 'scenario'? not sure about this"),
+        providerStates = List(ProviderState("or maybe 'scenario'? not sure about this", Map.empty)),
         contents = personalData.nospaces,
         metaData = Message.Metadata.empty,
         matchingRules = Map(

--- a/tests-with-deps/src/test/scala/com/itv/scalapact/MessageVerificationSpec.scala
+++ b/tests-with-deps/src/test/scala/com/itv/scalapact/MessageVerificationSpec.scala
@@ -1,0 +1,51 @@
+package com.itv.scalapact
+
+import com.itv.scalapact.ScalaPactVerify.{pactAsJsonString, verifyPact}
+import com.itv.scalapact.shared.MessageContentType.ApplicationJson
+import com.itv.scalapact.shared.{Message, Pact, PactActor}
+import org.scalatest.{Assertion, FlatSpec, Matchers, OptionValues}
+import Matchers._
+import com.itv.scalapact.shared.matchir.IrNode
+import com.itv.scalapact.shared.typeclasses.IPactReader
+import org.scalactic.TypeCheckedTripleEquals
+
+class MessageVerificationSpec extends FlatSpec with TypeCheckedTripleEquals with OptionValues {
+  import json.{pactReaderInstance => _, _}
+  import argonaut._
+  import Argonaut._
+  import com.itv.scalapact.argonaut62.PactImplicits._
+
+  val samplePact = Pact(
+    consumer = PactActor("Consumer"),
+    provider = PactActor("Provider"),
+    interactions = List.empty,
+    messages = List(
+      Message(
+        description = "Published credit data",
+        providerState = Some("or maybe 'scenario'? not sure about this"),
+        contents = """{"foo":"bar"}""",
+        metaData = Message.Metadata("contentType" -> "application/json"),
+        matchingRules = Map.empty,
+        ApplicationJson
+      )
+    )
+  )
+
+  implicit val reader: IPactReader = new IPactReader {
+    override def jsonStringToPact(json: String): Either[String, Pact] = Right(samplePact)
+
+    override def fromJSON(jsonString: String): Option[IrNode] = ???
+  }
+
+  it should " be able to verify a simple contract" in {
+    verifyPact
+      .withPactSource(pactAsJsonString(samplePact.asJson.nospaces))
+      .noSetupRequired
+      .runMessageTests[Assertion] { r =>
+        r.consume("Published credit data") { message =>
+          message should ===(samplePact.messages.headOption.value)
+        }
+      }
+
+  }
+}

--- a/tests-with-deps/src/test/scala/com/itv/scalapact/ScalaPactForgerSpec.scala
+++ b/tests-with-deps/src/test/scala/com/itv/scalapact/ScalaPactForgerSpec.scala
@@ -1,7 +1,5 @@
 package com.itv.scalapact
 
-import java.util.concurrent.atomic.AtomicReference
-
 import argonaut.Json
 import argonaut._
 import Argonaut._
@@ -13,7 +11,7 @@ import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest.{EitherValues, FlatSpec, OptionValues}
 import org.scalatest.Matchers._
 
-class ScalaPactForgerTest extends FlatSpec with OptionValues with EitherValues with TypeCheckedTripleEquals {
+class ScalaPactForgerSpec extends FlatSpec with OptionValues with EitherValues with TypeCheckedTripleEquals {
 
   import com.itv.scalapact.json._
   implicit val defaultOptions = ScalaPactOptions(writePactFiles = true, outputPath = "/tmp")
@@ -200,18 +198,6 @@ class ScalaPactForgerTest extends FlatSpec with OptionValues with EitherValues w
         _.publish("description", Json.obj("key1" -> jString("1"), "key2" -> jString("foo3")))
       }
     }
-  }
-
-  case class StubContractWriter(
-      actualPact: AtomicReference[Option[ScalaPactForger.ScalaPactDescriptionFinal]] = new AtomicReference(None)
-  ) extends IContractWriter {
-
-    def messages: List[Message] = actualPact.get().map(_.messages).toList.flatten
-
-    def interactions = actualPact.get().map(_.interactions).toList.flatten
-
-    override def writeContract(scalaPactDescriptionFinal: ScalaPactForger.ScalaPactDescriptionFinal): Unit =
-      actualPact.set(Some(scalaPactDescriptionFinal))
   }
 
   def toJson(value: String) = Parse.parse(value).right.value

--- a/tests-with-deps/src/test/scala/com/itv/scalapact/ScalaPactForgerTest.scala
+++ b/tests-with-deps/src/test/scala/com/itv/scalapact/ScalaPactForgerTest.scala
@@ -52,8 +52,8 @@ class ScalaPactForgerTest extends FlatSpec with OptionValues with EitherValues w
       _.consume("description") { message =>
         message.contentType should ===(ApplicationJson)
 
-        message.meta should ===(Message.Metadata.empty)
-        toJson(message.content) should ===(firstExpectedMessage)
+        message.metaData should ===(Message.Metadata.empty)
+        toJson(message.contents) should ===(firstExpectedMessage)
         message
       }
     }(writer, implicitly, implicitly)
@@ -68,14 +68,14 @@ class ScalaPactForgerTest extends FlatSpec with OptionValues with EitherValues w
         val newStub = stub
           .consume("description") { message =>
             message.contentType should ===(ApplicationJson)
-            message.meta should ===(Message.Metadata.empty)
-            toJson(message.content) should ===(firstExpectedMessage)
+            message.metaData should ===(Message.Metadata.empty)
+            toJson(message.contents) should ===(firstExpectedMessage)
             message
           }
           .consume("description2") { message =>
             message.contentType should ===(ApplicationJson)
-            message.meta should ===(secondExpectedMetadata)
-            toJson(message.content) should ===(secondExpectedMessage)
+            message.metaData should ===(secondExpectedMetadata)
+            toJson(message.contents) should ===(secondExpectedMessage)
             message
           }
 

--- a/tests-with-deps/src/test/scala/com/itv/scalapact/ScalaPactForgerTest.scala
+++ b/tests-with-deps/src/test/scala/com/itv/scalapact/ScalaPactForgerTest.scala
@@ -1,32 +1,169 @@
 package com.itv.scalapact
 
-import org.scalatest.FlatSpec
-import com.itv.scalapact.{ScalaPactForger, ScalaPactMockConfig}
-import com.itv.scalapact.ScalaPactForger.{forgePact, interaction, message}
+import java.util.concurrent.atomic.AtomicReference
+
+import com.itv.scalapact.ScalaPactForger.{
+  IContractWriter,
+  ScalaPactInteractionFinal,
+  ScalaPactOptions,
+  forgePact,
+  interaction,
+  message
+}
+import com.itv.scalapact.ScalaPactVerify.ScalaPactVerifyFailed
+import com.itv.scalapact.argonaut62.PactWriter
 import com.itv.scalapact.shared.MessageContentType.ApplicationJson
-import com.itv.scalapact.shared.{Message, MessageContentType}
 import com.itv.scalapact.shared.typeclasses.{IMessageFormat, MessageFormatError}
+import com.itv.scalapact.shared.{Message, MessageContentType}
+import org.scalactic.TypeCheckedTripleEquals
+import org.scalatest.{FlatSpec, OptionValues}
 import org.scalatest.Matchers._
 
-class ScalaPactForgerTest extends FlatSpec {
-  it should "create a specification of the message" in {
-     val expectedMessage = ApplicationJson.renderString
+class ScalaPactForgerTest extends FlatSpec with OptionValues with TypeCheckedTripleEquals {
 
-    forgePact
-      .between("Consumer")
-      .and("Provider")
-      .addMessage(
+  implicit val defaultWriter = new PactWriter
+
+  val noMetadata = Map.empty[String, String]
+
+  implicit val defaultOptions =
+    ScalaPactOptions(writePactFiles = true, outputPath = "/tmp")
+
+  implicit val defaultWriterContract = IContractWriter()
+
+  val stringMessageFormat = new IMessageFormat[String] {
+    override def contentType: MessageContentType = ApplicationJson
+
+    override def encode(t: String): String = contentType.renderString
+
+    override def decode(s: String): Either[MessageFormatError, String] = Right(contentType.renderString)
+  }
+
+  val expectedMessage = ApplicationJson.renderString
+
+  val specWithOneMessage = forgePact
+    .between("Consumer")
+    .and("Provider")
+    .addMessage(
+      message
+        .description("description")
+        .withProviderState("whatever")
+        .withMeta(noMetadata)
+        .withContent(expectedMessage)(stringMessageFormat)
+    )
+
+  val specWithMultipleMessages = specWithOneMessage
+    .addMessage(
+      message
+        .description("description2")
+        .withProviderState("whatever")
+        .withMeta(noMetadata)
+        .withContent(expectedMessage)(stringMessageFormat)
+    )
+
+  it should "create a specification of the message" in {
+    val writer = StubContractWriter()
+
+    val actualMessage = specWithOneMessage.runMessageTests[Message] {
+      _.consume("description") { message =>
+        message.contentType should ===(ApplicationJson)
+
+        message.meta should ===(noMetadata)
+        message.content should ===(expectedMessage)
         message
-          .description("")
-          //TODO: .expectsToReceive("something")
-          .withMeta(Map.empty)
-          .withContent(expectedMessage)(new IMessageFormat[String] {
-            override def contentType: MessageContentType = ApplicationJson
-            override def encode(t: String): String = contentType.renderString
-            override def decode(s: String): Either[MessageFormatError, String] = Right(contentType.renderString)
-          })
-      ).runMessageTests { actualMessage: Message =>
-      actualMessage.content should ===(expectedMessage)
+      }
+    }(writer)
+    writer.messages should ===(actualMessage)
+  }
+
+  it should "create a specification for multiple messages" in {
+    val writer = StubContractWriter()
+
+    specWithMultipleMessages
+      .runMessageTests[Message](stub => {
+        val newStub = stub
+          .consume("description") { message =>
+            message.contentType should ===(ApplicationJson)
+            message.meta should ===(noMetadata)
+            message.content should ===(expectedMessage)
+            message
+          }
+          .consume("description2") { message =>
+            message.contentType should ===(ApplicationJson)
+            message.meta should ===(noMetadata)
+            message.content should ===(expectedMessage)
+            message
+          }
+
+        writer.messages.map(Right(_)) should contain theSameElementsAs (newStub.currentResult)
+        newStub
+      })(writer)
+
+  }
+
+  it should "create a specification for multiple messages and interactions" in {
+    val writer = StubContractWriter()
+
+    specWithMultipleMessages
+      .addInteraction(
+        interaction
+          .description("Some interaction")
+          .given("Some state")
+          .willRespondWith(200)
+      )
+      .runMessageTests[Unit](_.consume("description") { _ =>
+        ()
+      })(writer)
+    writer.interactions should have size 1
+    writer.messages should have size 2
+  }
+
+  it should "fail when the description does not exist" in {
+
+    a[ScalaPactVerifyFailed] should be thrownBy {
+      specWithOneMessage.runMessageTests[Unit] {
+        _.consume("description1") { message =>
+          }
+      }
     }
   }
+
+  it should "fail when the description does not exist with multiple messages" in {
+
+    a[ScalaPactVerifyFailed] should be thrownBy {
+      specWithMultipleMessages.runMessageTests[Any] { stub =>
+        stub
+          .consume("description1") { message =>
+            }
+          .consume("description2") { message =>
+            }
+      }
+    }
+  }
+
+  it should "succeed if the published message is in the right format" in {
+    specWithOneMessage.runMessageTests[Any] {
+      _.publish("description", expectedMessage)
+    }
+  }
+
+  it should "fail if the published message is not in the right format" in {
+    a[ScalaPactVerifyFailed] should be thrownBy {
+      specWithOneMessage.runMessageTests[Any] {
+        _.publish("description", "")
+      }
+    }
+  }
+
+  case class StubContractWriter(
+      actualPact: AtomicReference[Option[ScalaPactForger.ScalaPactDescriptionFinal]] = new AtomicReference(None)
+  ) extends IContractWriter {
+
+    def messages: List[Message] = actualPact.get().map(_.messages).toList.flatten
+
+    def interactions: List[ScalaPactInteractionFinal] = actualPact.get().map(_.interactions).toList.flatten
+
+    override def writeContract(scalaPactDescriptionFinal: ScalaPactForger.ScalaPactDescriptionFinal): Unit =
+      actualPact.set(Some(scalaPactDescriptionFinal))
+  }
+
 }

--- a/tests-with-deps/src/test/scala/com/itv/scalapact/ScalaPactForgerTest.scala
+++ b/tests-with-deps/src/test/scala/com/itv/scalapact/ScalaPactForgerTest.scala
@@ -29,7 +29,7 @@ class ScalaPactForgerTest extends FlatSpec with OptionValues with EitherValues w
         .description("description")
         .withProviderState("whatever")
         .withMeta(Message.Metadata.empty)
-        .withMatchingRule(".key2", MatchingRule(Some("regex"), Some("\\d+"), None))
+        .withRegex(".key2", "\\d+")
         .withContent(firstExpectedMessage)
     )
 

--- a/tests-with-deps/src/test/scala/com/itv/scalapact/ScalaPactForgerTest.scala
+++ b/tests-with-deps/src/test/scala/com/itv/scalapact/ScalaPactForgerTest.scala
@@ -95,7 +95,7 @@ class ScalaPactForgerTest extends FlatSpec with OptionValues with EitherValues w
             message
           }
 
-        writer.messages.map(Right(_)) should contain theSameElementsAs newStub.currentResult
+        writer.messages should contain theSameElementsAs newStub.results
         newStub
       })(writer, implicitly, implicitly)
 

--- a/tests-with-deps/src/test/scala/com/itv/scalapact/ScalaPactForgerTest.scala
+++ b/tests-with-deps/src/test/scala/com/itv/scalapact/ScalaPactForgerTest.scala
@@ -32,9 +32,7 @@ class ScalaPactForgerTest extends FlatSpec with OptionValues with TypeCheckedTri
 
   val stringMessageFormat = new IMessageFormat[String] {
     override def contentType: MessageContentType = ApplicationJson
-
     override def encode(t: String): String = contentType.renderString
-
     override def decode(s: String): Either[MessageFormatError, String] = Right(contentType.renderString)
   }
 
@@ -94,7 +92,7 @@ class ScalaPactForgerTest extends FlatSpec with OptionValues with TypeCheckedTri
             message
           }
 
-        writer.messages.map(Right(_)) should contain theSameElementsAs (newStub.currentResult)
+        writer.messages.map(Right(_)) should contain theSameElementsAs newStub.currentResult
         newStub
       })(writer)
 

--- a/tests-with-deps/src/test/scala/com/itv/scalapact/ScalaPactForgerTest.scala
+++ b/tests-with-deps/src/test/scala/com/itv/scalapact/ScalaPactForgerTest.scala
@@ -1,0 +1,32 @@
+package com.itv.scalapact
+
+import org.scalatest.FlatSpec
+import com.itv.scalapact.{ScalaPactForger, ScalaPactMockConfig}
+import com.itv.scalapact.ScalaPactForger.{forgePact, interaction, message}
+import com.itv.scalapact.shared.MessageContentType.ApplicationJson
+import com.itv.scalapact.shared.{Message, MessageContentType}
+import com.itv.scalapact.shared.typeclasses.{IMessageFormat, MessageFormatError}
+import org.scalatest.Matchers._
+
+class ScalaPactForgerTest extends FlatSpec {
+  it should "create a specification of the message" in {
+     val expectedMessage = ApplicationJson.renderString
+
+    forgePact
+      .between("Consumer")
+      .and("Provider")
+      .addMessage(
+        message
+          .description("")
+          //TODO: .expectsToReceive("something")
+          .withMeta(Map.empty)
+          .withContent(expectedMessage)(new IMessageFormat[String] {
+            override def contentType: MessageContentType = ApplicationJson
+            override def encode(t: String): String = contentType.renderString
+            override def decode(s: String): Either[MessageFormatError, String] = Right(contentType.renderString)
+          })
+      ).runMessageTests { actualMessage: Message =>
+      actualMessage.content should ===(expectedMessage)
+    }
+  }
+}

--- a/tests-with-deps/src/test/scala/com/itv/scalapact/ScalaPactForgerTest.scala
+++ b/tests-with-deps/src/test/scala/com/itv/scalapact/ScalaPactForgerTest.scala
@@ -132,10 +132,26 @@ class ScalaPactForgerTest extends FlatSpec with OptionValues with EitherValues w
     }
   }
 
+  it should "succeed in strict mode if the published message is in the right format" in {
+    specWithOneMessage.runStrictMessageTests[Any] {
+      _.publish("description", firstExpectedMessage)
+    }
+  }
+
   it should "succeed if the published message is in the right format and different content" in {
     specWithOneMessage.runMessageTests[Any] {
-      _.publish("description", Json.obj("key1" -> jNumber(1), "key2" -> jString("123")))
+      _.publish("description", Json.obj("key1" -> jNumber(1), "key2" -> jString("123"), "foo" -> jString("bar")))
     }
+  }
+
+  it should "fail in strict mode if the published message is in the right format but has some extra field" in {
+    a[ScalaPactVerifyFailed] should be thrownBy {
+      specWithOneMessage.runStrictMessageTests[Any] {
+        _.publish("description",
+                  Json.obj("key1" -> jNumber(1), "key2" -> jString("444"), "foo" -> jString("unexpected key")))
+      }
+    }
+
   }
 
   it should "fail if the published message is in the right format however it breaks the rules" in {

--- a/tests-with-deps/src/test/scala/com/itv/scalapact/ScalaPactMessageForgerSpec.scala
+++ b/tests-with-deps/src/test/scala/com/itv/scalapact/ScalaPactMessageForgerSpec.scala
@@ -6,7 +6,7 @@ import Argonaut._
 import com.itv.scalapact.ScalaPactForger.{ScalaPactOptions, forgePact, interaction, message, messageSpec}
 import com.itv.scalapact.ScalaPactVerify.ScalaPactVerifyFailed
 import com.itv.scalapact.shared.MessageContentType.ApplicationJson
-import com.itv.scalapact.shared.{MatchingRule, Message}
+import com.itv.scalapact.shared.{MatchingRule, Message, ProviderState}
 import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest.{EitherValues, FlatSpec, OptionValues}
 import org.scalatest.Matchers._
@@ -25,7 +25,7 @@ class ScalaPactMessageForgerSpec extends FlatSpec with OptionValues with EitherV
     .addMessage(
       message
         .description("description")
-        .withProviderState("whatever")
+        .withProviderState(ProviderState("whatever",Map.empty))
         .withMeta(Message.Metadata.empty)
         .withRegexMatchingRule("$.body.key2", "\\d+")
         .withContent(firstExpectedMessage)
@@ -37,7 +37,7 @@ class ScalaPactMessageForgerSpec extends FlatSpec with OptionValues with EitherV
     .addMessage(
       message
         .description("description")
-        .withProviderState("whatever")
+        .withProviderState(ProviderState("whatever",Map.empty))
         .withMeta(Message.Metadata.empty)
         .withRegexMatchingRule("$.body.key2", "\\d{4}")
         .withRegexMatchingRule("$.body.key2", "\\d{3}")
@@ -50,7 +50,7 @@ class ScalaPactMessageForgerSpec extends FlatSpec with OptionValues with EitherV
     .addMessage(
       message
         .description("description2")
-        .withProviderState("whatever")
+        .withProviderState(ProviderState("whatever",Map.empty))
         .withMeta(secondExpectedMetadata)
         .withContent(secondExpectedMessage)
     )
@@ -184,7 +184,7 @@ class ScalaPactMessageForgerSpec extends FlatSpec with OptionValues with EitherV
       .addMessage(
         message
           .description("description")
-          .withProviderState("whatever")
+          .withProviderState(ProviderState("whatever",Map.empty))
           .withMeta(Message.Metadata.empty)
           .withRegexMatchingRule("$.body.key2", "\\d{4}")
           .withRegexMatchingRule("$.body.key2", "\\d{3}")
@@ -197,7 +197,7 @@ class ScalaPactMessageForgerSpec extends FlatSpec with OptionValues with EitherV
       .addMessage(
         message
           .description("description")
-          .withProviderState("whatever")
+          .withProviderState(ProviderState("whatever",Map.empty))
           .withMeta(Message.Metadata.empty)
           .withRegexMatchingRule("$.body.key2", "\\d{3}")
           .withRegexMatchingRule("$.body.key2", "\\d{4}")
@@ -261,7 +261,7 @@ class ScalaPactMessageForgerSpec extends FlatSpec with OptionValues with EitherV
     a[RuntimeException] should be thrownBy {
       message
         .description("description")
-        .withProviderState("whatever")
+        .withProviderState(ProviderState("whatever",Map.empty))
         .withMeta(Message.Metadata.empty)
         .withRegexMatchingRule(".key2", "\\d+")
 

--- a/tests-with-deps/src/test/scala/com/itv/scalapact/ScalaPactMessageForgerSpec.scala
+++ b/tests-with-deps/src/test/scala/com/itv/scalapact/ScalaPactMessageForgerSpec.scala
@@ -114,10 +114,9 @@ class ScalaPactMessageForgerSpec extends FlatSpec with OptionValues with EitherV
   it should "fail when the description does not exist with multiple messages" in {
 
     a[ScalaPactVerifyFailed] should be thrownBy {
-      specWithMultipleMessages.runMessageTests[Any] { stub =>
-        stub
-          .consume("description1") { message =>
-            }
+      specWithMultipleMessages.runMessageTests[Any] {
+        _.consume("description1") { message =>
+          }
           .consume("description2") { message =>
             }
       }

--- a/tests-with-deps/src/test/scala/com/itv/scalapact/ScalaPactMessageForgerSpec.scala
+++ b/tests-with-deps/src/test/scala/com/itv/scalapact/ScalaPactMessageForgerSpec.scala
@@ -204,6 +204,17 @@ class ScalaPactMessageForgerSpec extends FlatSpec with OptionValues with EitherV
     }
   }
 
+  it should "fail when the json path does not start with '$.body'" in {
+    a[RuntimeException] should be thrownBy {
+      message
+        .description("description")
+        .withProviderState("whatever")
+        .withMeta(Message.Metadata.empty)
+        .withRegexMatchingRule(".key2", "\\d+")
+
+    }
+  }
+
   def toJson(value: String) = Parse.parse(value).right.value
 
 }

--- a/tests-with-deps/src/test/scala/com/itv/scalapact/ScalaPactMessageForgerSpec.scala
+++ b/tests-with-deps/src/test/scala/com/itv/scalapact/ScalaPactMessageForgerSpec.scala
@@ -11,7 +11,7 @@ import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest.{EitherValues, FlatSpec, OptionValues}
 import org.scalatest.Matchers._
 
-class ScalaPactForgerSpec extends FlatSpec with OptionValues with EitherValues with TypeCheckedTripleEquals {
+class ScalaPactMessageForgerSpec extends FlatSpec with OptionValues with EitherValues with TypeCheckedTripleEquals {
 
   import com.itv.scalapact.json._
   implicit val defaultOptions = ScalaPactOptions(writePactFiles = true, outputPath = "/tmp")

--- a/tests-with-deps/src/test/scala/com/itv/scalapact/ScalaPactMessageForgerSpec.scala
+++ b/tests-with-deps/src/test/scala/com/itv/scalapact/ScalaPactMessageForgerSpec.scala
@@ -27,7 +27,7 @@ class ScalaPactMessageForgerSpec extends FlatSpec with OptionValues with EitherV
         .description("description")
         .withProviderState("whatever")
         .withMeta(Message.Metadata.empty)
-        .withRegexMatchingRule(".key2", "\\d+")
+        .withRegexMatchingRule("$.body.key2", "\\d+")
         .withContent(firstExpectedMessage)
     )
 
@@ -53,7 +53,7 @@ class ScalaPactMessageForgerSpec extends FlatSpec with OptionValues with EitherV
           message.matchingRules should ===(
             Map(
               "body" ->
-                Map(".key2" -> Message.Matchers.from(MatchingRule(Some("regex"), Some("\\d+"), None)))
+                Map("$.key2" -> Message.Matchers.from(MatchingRule(Some("regex"), Some("\\d+"), None)))
             )
           )
           message.metaData should ===(Message.Metadata.empty)

--- a/tests-with-deps/src/test/scala/com/itv/scalapact/ScalaPactMessageForgerSpec.scala
+++ b/tests-with-deps/src/test/scala/com/itv/scalapact/ScalaPactMessageForgerSpec.scala
@@ -27,7 +27,7 @@ class ScalaPactMessageForgerSpec extends FlatSpec with OptionValues with EitherV
         .description("description")
         .withProviderState("whatever")
         .withMeta(Message.Metadata.empty)
-        .withRegex(".key2", "\\d+")
+        .withRegexMatchingRule(".key2", "\\d+")
         .withContent(firstExpectedMessage)
     )
 
@@ -50,7 +50,12 @@ class ScalaPactMessageForgerSpec extends FlatSpec with OptionValues with EitherV
       .runMessageTests[Message] {
         _.consume("description") { message =>
           message.contentType should ===(ApplicationJson)
-          message.matchingRules should ===(Map(".key2" -> MatchingRule(Some("regex"), Some("\\d+"), None)))
+          message.matchingRules should ===(
+            Map(
+              "body" ->
+                Map(".key2" -> Message.Matchers.from(MatchingRule(Some("regex"), Some("\\d+"), None)))
+            )
+          )
           message.metaData should ===(Message.Metadata.empty)
           toJson(message.contents) should ===(firstExpectedMessage)
           message

--- a/tests-with-deps/src/test/scala/com/itv/scalapact/StubContractWriter.scala
+++ b/tests-with-deps/src/test/scala/com/itv/scalapact/StubContractWriter.scala
@@ -1,0 +1,18 @@
+package com.itv.scalapact
+
+import java.util.concurrent.atomic.AtomicReference
+
+import com.itv.scalapact.ScalaPactForger.messageSpec.IContractWriter
+import com.itv.scalapact.shared.Message
+
+case class StubContractWriter(
+    actualPact: AtomicReference[Option[ScalaPactForger.ScalaPactDescriptionFinal]] = new AtomicReference(None)
+) extends IContractWriter {
+
+  def messages: List[Message] = actualPact.get().map(_.messages).toList.flatten
+
+  def interactions = actualPact.get().map(_.interactions).toList.flatten
+
+  override def writeContract(scalaPactDescriptionFinal: ScalaPactForger.ScalaPactDescriptionFinal): Unit =
+    actualPact.set(Some(scalaPactDescriptionFinal))
+}

--- a/tests-with-deps/src/test/scala/com/itv/scalapact/StubContractWriter.scala
+++ b/tests-with-deps/src/test/scala/com/itv/scalapact/StubContractWriter.scala
@@ -13,6 +13,8 @@ case class StubContractWriter(
 
   def interactions = actualPact.get().map(_.interactions).toList.flatten
 
-  override def writeContract(scalaPactDescriptionFinal: ScalaPactForger.ScalaPactDescriptionFinal): Unit =
-    actualPact.set(Some(scalaPactDescriptionFinal))
+  override def writeContract(
+      scalaPactDescriptionFinal: ScalaPactForger.ScalaPactDescriptionFinal
+  ): Either[Throwable, Unit] =
+    Right(actualPact.set(Some(scalaPactDescriptionFinal)))
 }

--- a/tests-with-deps/src/test/scala/com/itv/scalapact/TypeInfererSpec.scala
+++ b/tests-with-deps/src/test/scala/com/itv/scalapact/TypeInfererSpec.scala
@@ -4,9 +4,8 @@ import argonaut.Json
 import argonaut._
 import Argonaut._
 import com.itv.scalapact.ScalaPactForger.{ScalaPactOptions, forgePact, message, messageSpec}
-
 import com.itv.scalapact.shared.typeclasses.IInferTypes
-import com.itv.scalapact.shared.{MatchingRule, Message}
+import com.itv.scalapact.shared.{MatchingRule, Message, ProviderState}
 import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest.{EitherValues, FlatSpec, OptionValues}
 import org.scalatest.Matchers._
@@ -88,7 +87,7 @@ class TypeInfererSpec extends FlatSpec with OptionValues with EitherValues with 
   private def baseMessage: ScalaPactForger.PartialScalaPactMessage =
     message
       .description("description")
-      .withProviderState("whatever")
+      .withProviderState(ProviderState("whatever", Map.empty))
       .withMeta(Message.Metadata.empty)
 
   private def matchingRulesFrom(

--- a/tests-with-deps/src/test/scala/com/itv/scalapact/TypeInfererSpec.scala
+++ b/tests-with-deps/src/test/scala/com/itv/scalapact/TypeInfererSpec.scala
@@ -39,7 +39,7 @@ class TypeInfererSpec extends FlatSpec with OptionValues with EitherValues with 
                       writer) should ===(
       List(
         Map(
-          "$.key1" -> MatchingRule(Some("int"), None, None)
+          ".key1" -> MatchingRule(Some("int"), None, None)
         )
       )
     )
@@ -55,7 +55,7 @@ class TypeInfererSpec extends FlatSpec with OptionValues with EitherValues with 
                           .withRegex(".key2", "\\d+")
                           .withContent(Json.obj("key1" -> jNumber(1), "key2" -> jString("444")))
                       ),
-                      writer) should ===(List(Map("$.key2" -> MatchingRule(Some("regex"), Some("\\d+"), None))))
+                      writer) should ===(List(Map(".key2" -> MatchingRule(Some("regex"), Some("\\d+"), None))))
   }
 
   it should "merge the inferred matching rules to the message when the user use $" in {

--- a/tests-with-deps/src/test/scala/com/itv/scalapact/TypeInfererSpec.scala
+++ b/tests-with-deps/src/test/scala/com/itv/scalapact/TypeInfererSpec.scala
@@ -55,7 +55,7 @@ class TypeInfererSpec extends FlatSpec with OptionValues with EitherValues with 
 
     matchingRulesFrom(baseSpec(
                         baseMessage
-                          .withRegexMatchingRule("$.key2", "\\d+")
+                          .withRegexMatchingRule("$.body.key2", "\\d+")
                           .withContent(Json.obj("key1" -> jNumber(1), "key2" -> jString("444")))
                       ),
                       writer) should ===(
@@ -70,7 +70,7 @@ class TypeInfererSpec extends FlatSpec with OptionValues with EitherValues with 
 
     matchingRulesFrom(baseSpec(
                         baseMessage
-                          .withRegexMatchingRule("$.key2", "\\d+")
+                          .withRegexMatchingRule("$.body.key2", "\\d+")
                           .withContent(Json.obj("key1" -> jString(""), "key2" -> jString("444")))
                       ),
                       writer) should ===(

--- a/tests-with-deps/src/test/scala/com/itv/scalapact/TypeInfererSpec.scala
+++ b/tests-with-deps/src/test/scala/com/itv/scalapact/TypeInfererSpec.scala
@@ -28,7 +28,7 @@ class TypeInfererSpec extends FlatSpec with OptionValues with EitherValues with 
   }
 
   it should "add the infered matching rules to the message" in {
-    implicit val typeInferer: IInferTypes[Json] = inferTypesFrom(Map("$.key1" -> "int"))
+    implicit val typeInferer: IInferTypes[Json] = inferTypesFrom(Map("$.body.key1" -> "int"))
 
     val writer = StubContractWriter()
 
@@ -49,7 +49,7 @@ class TypeInfererSpec extends FlatSpec with OptionValues with EitherValues with 
   }
 
   it should "merge the inferred matching rules to the message" in {
-    implicit val typeInferer: IInferTypes[Json] = inferTypesFrom(Map(".key2" -> "int"))
+    implicit val typeInferer: IInferTypes[Json] = inferTypesFrom(Map("$.body.key2" -> "integer"))
 
     val writer = StubContractWriter()
 
@@ -59,22 +59,14 @@ class TypeInfererSpec extends FlatSpec with OptionValues with EitherValues with 
                           .withContent(Json.obj("key1" -> jNumber(1), "key2" -> jString("444")))
                       ),
                       writer) should ===(
-      List(Map("body" -> Map("$.key2" -> Message.Matchers.from(MatchingRule(Some("regex"), Some("\\d+"), None)))))
-    )
-  }
-
-  it should "merge the inferred matching rules to the message when the user use $" in {
-    implicit val typeInferer: IInferTypes[Json] = inferTypesFrom(Map(".key2" -> "int"))
-
-    val writer = StubContractWriter()
-
-    matchingRulesFrom(baseSpec(
-                        baseMessage
-                          .withRegexMatchingRule("$.body.key2", "\\d+")
-                          .withContent(Json.obj("key1" -> jString(""), "key2" -> jString("444")))
-                      ),
-                      writer) should ===(
-      List(Map("body" -> Map("$.key2" -> Message.Matchers.from(MatchingRule(Some("regex"), Some("\\d+"), None)))))
+      List(
+        Map(
+          "body" -> Map(
+            "$.key2" -> Message.Matchers.from(MatchingRule(Some("regex"), Some("\\d+"), None),
+                                              MatchingRule(Some("integer"), None, None))
+          )
+        )
+      )
     )
   }
 

--- a/tests-with-deps/src/test/scala/com/itv/scalapact/shared/matchir/IrNodeRuleSpec.scala
+++ b/tests-with-deps/src/test/scala/com/itv/scalapact/shared/matchir/IrNodeRuleSpec.scala
@@ -187,6 +187,90 @@ class IrNodeRuleSpec extends FunSpec with Matchers {
       (expected =<>= actual).isEqual shouldEqual false
     }
 
+    it("should validate a node using a type matching rule for integers") {
+      IrNodeMatchingRules(
+        IrNodeIntegerRule(IrNodePath.empty <~ "number")
+      )
+
+      val expected: IrNode = MatchIr
+        .fromJSON(JsonConversionFunctions.fromJSON)(
+          """
+            |{
+            |  "number": 18.0
+            |}
+          """.stripMargin
+        )
+        .get
+
+      val actual: IrNode = MatchIr
+        .fromJSON(JsonConversionFunctions.fromJSON)(
+          """
+            |{
+            |  "number": 18
+            |}
+          """.stripMargin
+        )
+        .get
+
+      (expected =<>= actual).isEqual shouldEqual false
+    }
+
+    it("should return false if node types are different using a type matching rule for decimals") {
+      implicit val rules: IrNodeMatchingRules = IrNodeMatchingRules(
+        IrNodeIntegerRule(IrNodePath.empty <~ "number")
+      )
+
+      val expected: IrNode = MatchIr
+        .fromJSON(JsonConversionFunctions.fromJSON)(
+          """
+            |{
+            |  "number": 18
+            |}
+          """.stripMargin
+        )
+        .get
+
+      val actual: IrNode = MatchIr
+        .fromJSON(JsonConversionFunctions.fromJSON)(
+          """
+            |{
+            |  "number": 18.0
+            |}
+          """.stripMargin
+        )
+        .get
+
+      (expected =<>= actual).isEqual shouldEqual false
+    }
+
+    it("should return true if node types are different using a type matching rule for decimals") {
+      implicit val rules: IrNodeMatchingRules = IrNodeMatchingRules(
+        IrNodeIntegerRule(IrNodePath.empty <~ "number")
+      )
+
+      val expected: IrNode = MatchIr
+        .fromJSON(JsonConversionFunctions.fromJSON)(
+          """
+            |{
+            |  "number": 18
+            |}
+          """.stripMargin
+        )
+        .get
+
+      val actual: IrNode = MatchIr
+        .fromJSON(JsonConversionFunctions.fromJSON)(
+          """
+            |{
+            |  "number": 19999
+            |}
+          """.stripMargin
+        )
+        .get
+
+      check(expected =<>= actual)
+    }
+
     it("should be able to validate a node primitive using regex") {
 
       implicit val rules: IrNodeMatchingRules =

--- a/tests-with-deps/src/test/scala/com/itv/scalapact/shared/matchir/MatchIrSpec.scala
+++ b/tests-with-deps/src/test/scala/com/itv/scalapact/shared/matchir/MatchIrSpec.scala
@@ -5,6 +5,8 @@ import org.scalatest.{FunSpec, Matchers}
 
 class MatchIrSpec extends FunSpec with Matchers {
 
+  //TODO Support Decimal in the test
+
   def check(res: IrNodeEqualityResult): Unit =
     res match {
       case p @ IrNodesEqual   => p shouldEqual IrNodesEqual
@@ -124,7 +126,7 @@ class MatchIrSpec extends FunSpec with Matchers {
           .withAttributes(
             IrNodeAttributes(
               Map(
-                "id"          -> IrNodeAttribute(IrNumberNode(3), IrNodePathEmpty <~ "fish" <@ "id"),
+                "id"          -> IrNodeAttribute(IrIntegerNode(3), IrNodePathEmpty <~ "fish" <@ "id"),
                 "description" -> IrNodeAttribute(IrStringNode("A fish"), IrNodePathEmpty <~ "fish" <@ "description"),
                 "endangered"  -> IrNodeAttribute(IrBooleanNode(false), IrNodePathEmpty <~ "fish" <@ "endangered")
               )
@@ -207,9 +209,9 @@ class MatchIrSpec extends FunSpec with Matchers {
           MatchIrConstants.rootNodeLabel,
           IrNode(
             "myDates",
-            IrNode("myDates", IrNumberNode(20)).withPath(IrNodePathEmpty <~ "myDates" <~ 0),
-            IrNode("myDates", IrNumberNode(5)).withPath(IrNodePathEmpty <~ "myDates" <~ 1),
-            IrNode("myDates", IrNumberNode(70)).withPath(IrNodePathEmpty <~ "myDates" <~ 2)
+            IrNode("myDates", IrIntegerNode(20)).withPath(IrNodePathEmpty <~ "myDates" <~ 0),
+            IrNode("myDates", IrIntegerNode(5)).withPath(IrNodePathEmpty <~ "myDates" <~ 1),
+            IrNode("myDates", IrIntegerNode(70)).withPath(IrNodePathEmpty <~ "myDates" <~ 2)
           ).withPath(IrNodePathEmpty <~ "myDates").markAsArray
         ).withPath(IrNodePathEmpty)
 
@@ -227,9 +229,9 @@ class MatchIrSpec extends FunSpec with Matchers {
       val ir: IrNode =
         IrNode(
           MatchIrConstants.rootNodeLabel,
-          IrNode(MatchIrConstants.unnamedNodeLabel, IrNumberNode(1)).withPath(IrNodePathEmpty <~ 0),
-          IrNode(MatchIrConstants.unnamedNodeLabel, IrNumberNode(2)).withPath(IrNodePathEmpty <~ 1),
-          IrNode(MatchIrConstants.unnamedNodeLabel, IrNumberNode(3)).withPath(IrNodePathEmpty <~ 2)
+          IrNode(MatchIrConstants.unnamedNodeLabel, IrIntegerNode(1)).withPath(IrNodePathEmpty <~ 0),
+          IrNode(MatchIrConstants.unnamedNodeLabel, IrIntegerNode(2)).withPath(IrNodePathEmpty <~ 1),
+          IrNode(MatchIrConstants.unnamedNodeLabel, IrIntegerNode(3)).withPath(IrNodePathEmpty <~ 2)
         ).withPath(IrNodePathEmpty).markAsArray
 
       check(MatchIr.fromJSON(JsonConversionFunctions.fromJSON)(json).get =<>= ir)

--- a/tests-with-deps/src/test/scala/com/itv/scalapactcore/common/InteractionMatchersSpec.scala
+++ b/tests-with-deps/src/test/scala/com/itv/scalapactcore/common/InteractionMatchersSpec.scala
@@ -61,6 +61,51 @@ class InteractionMatchersSpec extends FunSpec with Matchers {
 
     }
 
+    it("should be able to apply the type rules for integer") {
+      val rules = Map(
+        "$.headers.key1" -> MatchingRule(Some("integer"), None, None),
+      )
+
+      val expected = Map("key1" -> "112", "key2" -> "1.44")
+      val received = Map("key1" -> "114", "key2" -> "1.44", "rock" -> "sandstone", "metal" -> "steel")
+
+      matchHeaders(Some(rules), expected, received).isSuccess shouldEqual true
+    }
+
+    it("should be able to apply the type rules for decimal)") {
+      val rules = Map(
+        "$.headers.key2" -> MatchingRule(Some("decimal"), None, None)
+      )
+
+      val expected = Map("key1" -> "112", "key2" -> "1.44")
+      val received = Map("key1" -> "112", "key2" -> "1.45", "rock" -> "sandstone", "metal" -> "steel")
+
+      matchHeaders(Some(rules), expected, received).isSuccess shouldEqual true
+    }
+
+    it("should fail to apply the type rules when the value is not an integer") {
+      val rules = Map(
+        "$.headers.key1" -> MatchingRule(Some("integer"), None, None)
+      )
+
+      val expected = Map("key1" -> "112", "key2"        -> "1.44")
+      val received = Map("key1" -> "112.000001", "key2" -> "1.44", "rock" -> "sandstone", "metal" -> "steel")
+
+      matchHeaders(Some(rules), expected, received).isSuccess shouldEqual false
+    }
+
+    it("should fail to apply the type rules when the value is not a decimal") {
+      val rules = Map(
+        "$.headers.key1" -> MatchingRule(Some("integer"), None, None),
+        "$.headers.key2" -> MatchingRule(Some("decimal"), None, None)
+      )
+
+      val expected = Map("key1" -> "112", "key2" -> "1.44")
+      val received = Map("key1" -> "112", "key2" -> "1d", "rock" -> "sandstone", "metal" -> "steel")
+
+      matchHeaders(Some(rules), expected, received).isSuccess shouldEqual false
+    }
+
     it("should be able to find the expected subset in a collection of headers") {
 
       val expected = Map("fish" -> "chips", "mammal" -> "bear")


### PR DESCRIPTION
- Messages can now be specified as part of the pact definition.
- Added support for "integer" , "decimal" matching rules
- Messages support both providerState(as in V2) and providerStates(as in V3)
- Added opt in automatic type inferrer support for circe 09

 
The following is an example of how the new functionalities can be used to publish a contract using the new module:
```scala
forgePact
    .between("Consumer")
    .and("Provider")
    .addMessage(
      message
        .description("description")
        .withProviderState(ProviderState("whatever",Map.empty))
        .withMeta(Message.Metadata.empty)
        .withRegexMatchingRule("$.body.key2", "\\d+")
        .withContent(Json.obj("key1" -> jNumber(1), "key2" -> jString("444")))
    ) .runMessageTests[Assertion] {
        _.consume("description") { message =>
          message.contentType should ===(ApplicationJson)
          message.matchingRules should ===(
            Map(
              "body" ->
                Map("$.key2" -> Message.Matchers.from(MatchingRule(Some("regex"), Some("\\d+"), None)))
            )
          )
          message.metaData should ===(Message.Metadata.empty)
          toJson(message.contents) should ===(firstExpectedMessage)
        }
      }
```
(Note: a publisher of a pact can both use the `publish` and `consume` provided by the message stubber provided by the `runMessageTests` method)

The following is an example of the contract consumption : 
```scala
verifyPact
      .withPactSource(pactAsJsonString(samplePact.asJson.nospaces))
      .noSetupRequired
      .runMessageTests[Task, Assertion]() {
        _.consume("Published credit data") { message =>
          message should ===(samplePact.messages.headOption.value)
        }
```
(Note: same as before,  `publish` and `consume` can both be used by the message stubber provided by the `runMessageTests` method


