### PR TITLE
Added support to missing http methods.

### DIFF
--- a/scalapact-http4s-0-16a/src/main/scala/com/itv/scalapact/http4s16a/impl/Http4sRequestResponseFactory.scala
+++ b/scalapact-http4s-0-16a/src/main/scala/com/itv/scalapact/http4s16a/impl/Http4sRequestResponseFactory.scala
@@ -48,6 +48,18 @@ object Http4sRequestResponseFactory {
 
       case OPTIONS =>
         Method.OPTIONS
+
+      case PATCH =>
+        Method.PATCH
+
+      case CONNECT =>
+        Method.CONNECT
+
+      case TRACE =>
+        Method.TRACE
+
+      case HEAD =>
+        Method.HEAD
     }
 
   def buildRequest(request: SimpleRequest): Task[Request] =

--- a/scalapact-http4s-0-17/src/main/scala/com/itv/scalapact/http4s17/impl/Http4sRequestResponseFactory.scala
+++ b/scalapact-http4s-0-17/src/main/scala/com/itv/scalapact/http4s17/impl/Http4sRequestResponseFactory.scala
@@ -50,6 +50,18 @@ object Http4sRequestResponseFactory {
 
       case OPTIONS =>
         Method.OPTIONS
+
+      case PATCH =>
+        Method.PATCH
+
+      case CONNECT =>
+        Method.CONNECT
+
+      case TRACE =>
+        Method.TRACE
+
+      case HEAD =>
+        Method.HEAD
     }
 
   def buildRequest(request: SimpleRequest)(implicit strategy: Strategy): Task[Request] =

--- a/scalapact-http4s-0-18/src/main/scala/com/itv/scalapact/http4s18/impl/Http4sRequestResponseFactory.scala
+++ b/scalapact-http4s-0-18/src/main/scala/com/itv/scalapact/http4s18/impl/Http4sRequestResponseFactory.scala
@@ -48,6 +48,18 @@ object Http4sRequestResponseFactory {
 
       case OPTIONS =>
         Method.OPTIONS
+
+      case PATCH =>
+        Method.PATCH
+
+      case CONNECT =>
+        Method.CONNECT
+
+      case TRACE =>
+        Method.TRACE
+
+      case HEAD =>
+        Method.HEAD
     }
 
   def buildRequest(request: SimpleRequest): IO[Request[IO]] =

--- a/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactForger.scala
+++ b/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactForger.scala
@@ -248,4 +248,20 @@ object ScalaPactForger {
     val method = "OPTIONS"
   }
 
+  case object PATCH extends ScalaPactMethod {
+    val method = "PATCH"
+  }
+
+  case object CONNECT extends ScalaPactMethod {
+    val method = "CONNECT"
+  }
+
+  case object TRACE extends ScalaPactMethod {
+    val method = "TRACE"
+  }
+
+  case object HEAD extends ScalaPactMethod {
+    val method = "HEAD"
+  }
+
 }

--- a/scalapact-shared/src/main/scala/com/itv/scalapact/shared/HttpMethod.scala
+++ b/scalapact-shared/src/main/scala/com/itv/scalapact/shared/HttpMethod.scala
@@ -21,6 +21,18 @@ object HttpMethod {
       case "OPTIONS" =>
         Option(OPTIONS)
 
+      case "PATCH" =>
+        Option(PATCH)
+
+      case "CONNECT" =>
+        Option(CONNECT)
+
+      case "TRACE" =>
+        Option(TRACE)
+
+      case "HEAD" =>
+        Option(HEAD)
+
       case _ =>
         None
     }
@@ -33,5 +45,8 @@ object HttpMethod {
   case object PUT     extends HttpMethod
   case object DELETE  extends HttpMethod
   case object OPTIONS extends HttpMethod
-
+  case object PATCH   extends HttpMethod
+  case object CONNECT extends HttpMethod
+  case object TRACE   extends HttpMethod
+  case object HEAD    extends HttpMethod
 }


### PR DESCRIPTION
This is adding the missing HTTP methods(HEAD, CONNECT, PATCH, TRACE) in response to this issue:
https://github.com/ITV/scala-pact/issues/80

Followed all procedures described in http://io.itv.com/scala-pact/contributing.html

Thanks!

