### PR TITLE
Added possibility to change request per interaction

### DIFF
--- a/example/consumer/src/test/scala/com/example/consumer/ProviderClientSpec.scala
+++ b/example/consumer/src/test/scala/com/example/consumer/ProviderClientSpec.scala
@@ -39,7 +39,7 @@ class ProviderClientSpec extends FunSpec with Matchers {
             .description("Fetching results")
             .given("Results: Bob, Fred, Harry")
             .uponReceiving("/results")
-            .willRespondWith(200, body)
+            .willRespondWith(200, Map("Pact" -> "modifiedRequest"), body)
         )
         .runConsumerTest { mockConfig =>
           val results = ProviderClient.fetchResults(mockConfig.baseUrl)

--- a/example/provider/delivered_pacts/Consumer_Provider.json
+++ b/example/provider/delivered_pacts/Consumer_Provider.json
@@ -46,6 +46,9 @@
       "description" : "Fetching results",
       "response" : {
         "status" : 200,
+        "headers" : {
+          "Pact" : "modifiedRequest"
+        },
         "body" : {
           "count" : 3,
           "results" : [

--- a/example/provider/delivered_pacts/Consumer_Provider.json
+++ b/example/provider/delivered_pacts/Consumer_Provider.json
@@ -9,25 +9,6 @@
     {
       "request" : {
         "method" : "GET",
-        "path" : "/results"
-      },
-      "description" : "Fetching results",
-      "response" : {
-        "status" : 200,
-        "body" : {
-          "count" : 3,
-          "results" : [
-            "Bob",
-            "Fred",
-            "Harry"
-          ]
-        }
-      },
-      "providerState" : "Results: Bob, Fred, Harry"
-    },
-    {
-      "request" : {
-        "method" : "GET",
         "path" : "/auth_token",
         "matchingRules" : {
           "$.headers.Name" : {
@@ -56,6 +37,25 @@
           }
         }
       }
+    },
+    {
+      "request" : {
+        "method" : "GET",
+        "path" : "/results"
+      },
+      "description" : "Fetching results",
+      "response" : {
+        "status" : 200,
+        "body" : {
+          "count" : 3,
+          "results" : [
+            "Bob",
+            "Fred",
+            "Harry"
+          ]
+        }
+      },
+      "providerState" : "Results: Bob, Fred, Harry"
     }
   ]
 }

--- a/example/provider/pact.sbt
+++ b/example/provider/pact.sbt
@@ -2,6 +2,8 @@
 import java.io.PrintWriter
 
 import com.itv.scalapact.plugin._
+import com.itv.scalapact.shared.InteractionRequest
+import com.itv.scalapactcore.verifier.Verifier.ProviderStateResult
 
 import scala.concurrent.duration._
 
@@ -23,7 +25,8 @@ providerStateMatcher := {
     writer.print("Bob,Fred,Harry")
     writer.close()
 
-    true
+    val newHeader = "Pact" -> "modifiedRequest"
+    ProviderStateResult(true, { req: InteractionRequest => req.copy(headers = Option(req.headers.fold(Map(newHeader))(_ + newHeader))) })
 }
 
 // Old style - still supported

--- a/example/provider/src/main/scala/com/example/provider/Provider.scala
+++ b/example/provider/src/main/scala/com/example/provider/Provider.scala
@@ -18,8 +18,9 @@ object Provider {
   import TokenResponseImplicits._
 
   val service = HttpService {
-    case GET -> Root / "results" =>
-      Ok(ResultResponse(3, loadPeople).asJson)
+    case request @ GET -> Root / "results" =>
+      val pactHeader = request.headers.get(CaseInsensitiveString("Pact")).map(_.value).getOrElse("")
+      Ok(ResultResponse(3, loadPeople).asJson).putHeaders(Header("Pact", pactHeader))
 
     case request @ GET -> Root / "auth_token" =>
       val acceptHeader = request.headers.get(CaseInsensitiveString("Accept")).map(_.value)

--- a/example/provider_tests/delivered_pacts/Consumer_Provider.json
+++ b/example/provider_tests/delivered_pacts/Consumer_Provider.json
@@ -46,6 +46,9 @@
       "description" : "Fetching results",
       "response" : {
         "status" : 200,
+        "headers" : {
+          "Pact" : "modifiedRequest"
+        },
         "body" : {
           "count" : 3,
           "results" : [

--- a/example/provider_tests/delivered_pacts/Consumer_Provider.json
+++ b/example/provider_tests/delivered_pacts/Consumer_Provider.json
@@ -9,25 +9,6 @@
     {
       "request" : {
         "method" : "GET",
-        "path" : "/results"
-      },
-      "description" : "Fetching results",
-      "response" : {
-        "status" : 200,
-        "body" : {
-          "count" : 3,
-          "results" : [
-            "Bob",
-            "Fred",
-            "Harry"
-          ]
-        }
-      },
-      "providerState" : "Results: Bob, Fred, Harry"
-    },
-    {
-      "request" : {
-        "method" : "GET",
         "path" : "/auth_token",
         "matchingRules" : {
           "$.headers.Name" : {
@@ -56,6 +37,25 @@
           }
         }
       }
+    },
+    {
+      "request" : {
+        "method" : "GET",
+        "path" : "/results"
+      },
+      "description" : "Fetching results",
+      "response" : {
+        "status" : 200,
+        "body" : {
+          "count" : 3,
+          "results" : [
+            "Bob",
+            "Fred",
+            "Harry"
+          ]
+        }
+      },
+      "providerState" : "Results: Bob, Fred, Harry"
     }
   ]
 }

--- a/example/provider_tests/src/main/scala/com/example/provider/Provider.scala
+++ b/example/provider_tests/src/main/scala/com/example/provider/Provider.scala
@@ -13,8 +13,10 @@ object Provider {
   val service: (String => List[String]) => (Int => String) => HttpService[IO] = loadPeopleData =>
     genToken =>
       HttpService[IO] {
-        case GET -> Root / "results" =>
-          Ok(ResultResponse(3, loadPeopleData("people.txt")).asJson)
+        case request @ GET -> Root / "results" =>
+          val pactHeader = request.headers.get(CaseInsensitiveString("Pact")).map(_.value).getOrElse("")
+
+          Ok(ResultResponse(3, loadPeopleData("people.txt")).asJson).putHeaders(Header("Pact", pactHeader))
 
         case request @ GET -> Root / "auth_token" =>
           val acceptHeader = request.headers.get(CaseInsensitiveString("Accept")).map(_.value)

--- a/example/provider_tests/src/test/scala/com/example/provider/VerifyContractsSpec.scala
+++ b/example/provider_tests/src/test/scala/com/example/provider/VerifyContractsSpec.scala
@@ -4,6 +4,7 @@ import cats.effect.IO
 import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
 import org.http4s.server.Server
 import com.itv.scalapact.ScalaPactVerify._
+import com.itv.scalapactcore.verifier.Verifier.ProviderStateResult
 
 class VerifyContractsSpec extends FunSpec with Matchers with BeforeAndAfterAll {
 
@@ -36,7 +37,11 @@ class VerifyContractsSpec extends FunSpec with Matchers with BeforeAndAfterAll {
 
       verifyPact
         .withPactSource(loadFromLocal("delivered_pacts"))
-        .noSetupRequired // We did the setup in the beforeAll() function
+        .setupProviderState("given") {
+          case "Results: Bob, Fred, Harry" =>
+            val newHeader = "Pact" -> "modifiedRequest"
+            ProviderStateResult(true, req => req.copy(headers = Option(req.headers.fold(Map(newHeader))(_ + newHeader))))
+        }
         .runVerificationAgainst("localhost", 8080)
 
     }

--- a/sbt-scalapact-shared/src/test/scala/com/itv/scalapact/plugin/shared/ScalaPactVerifyCommandSpec.scala
+++ b/sbt-scalapact-shared/src/test/scala/com/itv/scalapact/plugin/shared/ScalaPactVerifyCommandSpec.scala
@@ -1,5 +1,7 @@
 package com.itv.scalapact.plugin.shared
 
+import com.itv.scalapact.shared.InteractionRequest
+import com.itv.scalapactcore.verifier.Verifier.SetupProviderState
 import org.scalatest.{FunSpec, Matchers}
 
 class ScalaPactVerifyCommandSpec extends FunSpec with Matchers {
@@ -11,20 +13,20 @@ class ScalaPactVerifyCommandSpec extends FunSpec with Matchers {
       // We perform a side effect just to prove the function is being called.
       var result = ""
 
-      val directPactStates: Seq[(String, String => Boolean)] = Seq(
+      val directPactStates: Seq[(String, SetupProviderState)] = Seq(
         (
           "abc",
           (_: String) => {
             result = "abc"
-            true
+            (true, identity[InteractionRequest])
           }
         )
       )
 
-      val patternMatchedStates: PartialFunction[String, Boolean] = {
+      val patternMatchedStates: PartialFunction[String, (Boolean, InteractionRequest => InteractionRequest)] = {
         case "def" =>
           result = "def"
-          true
+          (true, identity[InteractionRequest])
       }
 
       val combined =
@@ -32,19 +34,19 @@ class ScalaPactVerifyCommandSpec extends FunSpec with Matchers {
 
       withClue("With key: abc") {
         result = ""
-        combined("abc") shouldEqual true
+        combined("abc")._1 shouldEqual true
         result shouldEqual "abc"
       }
 
       withClue("With key: def") {
         result = ""
-        combined("def") shouldEqual true
+        combined("def")._1 shouldEqual true
         result shouldEqual "def"
       }
 
       withClue("With key: fish") {
         result = ""
-        combined("fish") shouldEqual false
+        combined("fish")._1 shouldEqual false
         result shouldEqual ""
       }
 
@@ -55,30 +57,30 @@ class ScalaPactVerifyCommandSpec extends FunSpec with Matchers {
       // We perform a side effect just to prove the function is being called.
       var result = ""
 
-      val directPactStates: Seq[(String, String => Boolean)] = Seq(
+      val directPactStates: Seq[(String, SetupProviderState)] = Seq(
         (
           "abc",
           (_: String) => {
             result = "abc"
-            true
+            (true, identity[InteractionRequest])
           }
         )
       )
 
-      val patternMatchedStates: PartialFunction[String, Boolean] = { case (_: String) => false }
+      val patternMatchedStates: PartialFunction[String, (Boolean, InteractionRequest => InteractionRequest)] = { case (_: String) => (false, identity[InteractionRequest]) }
 
       val combined =
         ScalaPactVerifyCommand.combineProviderStatesIntoTotalFunction(directPactStates, patternMatchedStates)
 
       withClue("With key: abc") {
         result = ""
-        combined("abc") shouldEqual true
+        combined("abc")._1 shouldEqual true
         result shouldEqual "abc"
       }
 
       withClue("With key: fish") {
         result = ""
-        combined("fish") shouldEqual false
+        combined("fish")._1 shouldEqual false
         result shouldEqual ""
       }
 
@@ -89,12 +91,12 @@ class ScalaPactVerifyCommandSpec extends FunSpec with Matchers {
       // We perform a side effect just to prove the function is being called.
       var result = ""
 
-      val directPactStates: Seq[(String, String => Boolean)] = Seq()
+      val directPactStates: Seq[(String, SetupProviderState)] = Seq()
 
-      val patternMatchedStates: PartialFunction[String, Boolean] = {
+      val patternMatchedStates: PartialFunction[String, (Boolean, InteractionRequest => InteractionRequest)] = {
         case "def" =>
           result = "def"
-          true
+          (true, identity[InteractionRequest])
       }
 
       val combined =
@@ -102,13 +104,13 @@ class ScalaPactVerifyCommandSpec extends FunSpec with Matchers {
 
       withClue("With key: def") {
         result = ""
-        combined("def") shouldEqual true
+        combined("def")._1 shouldEqual true
         result shouldEqual "def"
       }
 
       withClue("With key: fish") {
         result = ""
-        combined("fish") shouldEqual false
+        combined("fish")._1 shouldEqual false
         result shouldEqual ""
       }
 
@@ -119,15 +121,15 @@ class ScalaPactVerifyCommandSpec extends FunSpec with Matchers {
       // We perform a side effect just to prove the function is being called.
       var result = ""
 
-      val directPactStates: Seq[(String, String => Boolean)]     = Seq()
-      val patternMatchedStates: PartialFunction[String, Boolean] = { case (_: String) => false }
+      val directPactStates: Seq[(String, SetupProviderState)]     = Seq()
+      val patternMatchedStates: PartialFunction[String, (Boolean, InteractionRequest => InteractionRequest)] = { case (_: String) => (false, identity[InteractionRequest]) }
 
       val combined =
         ScalaPactVerifyCommand.combineProviderStatesIntoTotalFunction(directPactStates, patternMatchedStates)
 
       withClue("With key: fish") {
         result = ""
-        combined("fish") shouldEqual false
+        combined("fish")._1 shouldEqual false
         result shouldEqual ""
       }
 

--- a/sbt-scalapact-shared/src/test/scala/com/itv/scalapact/plugin/shared/ScalaPactVerifyCommandSpec.scala
+++ b/sbt-scalapact-shared/src/test/scala/com/itv/scalapact/plugin/shared/ScalaPactVerifyCommandSpec.scala
@@ -1,7 +1,6 @@
 package com.itv.scalapact.plugin.shared
 
-import com.itv.scalapact.shared.InteractionRequest
-import com.itv.scalapactcore.verifier.Verifier.SetupProviderState
+import com.itv.scalapactcore.verifier.Verifier.{ProviderStateResult, SetupProviderState}
 import org.scalatest.{FunSpec, Matchers}
 
 class ScalaPactVerifyCommandSpec extends FunSpec with Matchers {
@@ -18,15 +17,15 @@ class ScalaPactVerifyCommandSpec extends FunSpec with Matchers {
           "abc",
           (_: String) => {
             result = "abc"
-            (true, identity[InteractionRequest])
+            ProviderStateResult(true)
           }
         )
       )
 
-      val patternMatchedStates: PartialFunction[String, (Boolean, InteractionRequest => InteractionRequest)] = {
+      val patternMatchedStates: PartialFunction[String, ProviderStateResult] = {
         case "def" =>
           result = "def"
-          (true, identity[InteractionRequest])
+          ProviderStateResult(true)
       }
 
       val combined =
@@ -34,19 +33,19 @@ class ScalaPactVerifyCommandSpec extends FunSpec with Matchers {
 
       withClue("With key: abc") {
         result = ""
-        combined("abc")._1 shouldEqual true
+        combined("abc").result shouldEqual true
         result shouldEqual "abc"
       }
 
       withClue("With key: def") {
         result = ""
-        combined("def")._1 shouldEqual true
+        combined("def").result shouldEqual true
         result shouldEqual "def"
       }
 
       withClue("With key: fish") {
         result = ""
-        combined("fish")._1 shouldEqual false
+        combined("fish").result shouldEqual false
         result shouldEqual ""
       }
 
@@ -62,25 +61,25 @@ class ScalaPactVerifyCommandSpec extends FunSpec with Matchers {
           "abc",
           (_: String) => {
             result = "abc"
-            (true, identity[InteractionRequest])
+            ProviderStateResult(true)
           }
         )
       )
 
-      val patternMatchedStates: PartialFunction[String, (Boolean, InteractionRequest => InteractionRequest)] = { case (_: String) => (false, identity[InteractionRequest]) }
+      val patternMatchedStates: PartialFunction[String, ProviderStateResult] = { case (_: String) => ProviderStateResult() }
 
       val combined =
         ScalaPactVerifyCommand.combineProviderStatesIntoTotalFunction(directPactStates, patternMatchedStates)
 
       withClue("With key: abc") {
         result = ""
-        combined("abc")._1 shouldEqual true
+        combined("abc").result shouldEqual true
         result shouldEqual "abc"
       }
 
       withClue("With key: fish") {
         result = ""
-        combined("fish")._1 shouldEqual false
+        combined("fish").result shouldEqual false
         result shouldEqual ""
       }
 
@@ -93,10 +92,10 @@ class ScalaPactVerifyCommandSpec extends FunSpec with Matchers {
 
       val directPactStates: Seq[(String, SetupProviderState)] = Seq()
 
-      val patternMatchedStates: PartialFunction[String, (Boolean, InteractionRequest => InteractionRequest)] = {
+      val patternMatchedStates: PartialFunction[String, ProviderStateResult] = {
         case "def" =>
           result = "def"
-          (true, identity[InteractionRequest])
+          ProviderStateResult(true)
       }
 
       val combined =
@@ -104,13 +103,13 @@ class ScalaPactVerifyCommandSpec extends FunSpec with Matchers {
 
       withClue("With key: def") {
         result = ""
-        combined("def")._1 shouldEqual true
+        combined("def").result shouldEqual true
         result shouldEqual "def"
       }
 
       withClue("With key: fish") {
         result = ""
-        combined("fish")._1 shouldEqual false
+        combined("fish").result shouldEqual false
         result shouldEqual ""
       }
 
@@ -122,14 +121,14 @@ class ScalaPactVerifyCommandSpec extends FunSpec with Matchers {
       var result = ""
 
       val directPactStates: Seq[(String, SetupProviderState)]     = Seq()
-      val patternMatchedStates: PartialFunction[String, (Boolean, InteractionRequest => InteractionRequest)] = { case (_: String) => (false, identity[InteractionRequest]) }
+      val patternMatchedStates: PartialFunction[String, ProviderStateResult] = { case (_: String) => ProviderStateResult() }
 
       val combined =
         ScalaPactVerifyCommand.combineProviderStatesIntoTotalFunction(directPactStates, patternMatchedStates)
 
       withClue("With key: fish") {
         result = ""
-        combined("fish")._1 shouldEqual false
+        combined("fish").result shouldEqual false
         result shouldEqual ""
       }
 

--- a/sbt-scalapact/src/main/scala/com/itv/scalapact/plugin/ScalaPactPlugin.scala
+++ b/sbt-scalapact/src/main/scala/com/itv/scalapact/plugin/ScalaPactPlugin.scala
@@ -3,8 +3,8 @@ package com.itv.scalapact.plugin
 import com.itv.scalapact.json._
 import com.itv.scalapact.http._
 import com.itv.scalapact.plugin.shared._
-import com.itv.scalapact.shared.{InteractionRequest, ScalaPactSettings}
-import com.itv.scalapactcore.verifier.Verifier.SetupProviderState
+import com.itv.scalapact.shared.ScalaPactSettings
+import com.itv.scalapactcore.verifier.Verifier.{ProviderStateResult, SetupProviderState}
 import sbt.Keys._
 import sbt.plugins.JvmPlugin
 import sbt.{Def, _}
@@ -15,11 +15,10 @@ object ScalaPactPlugin extends AutoPlugin {
   override def trigger: PluginTrigger   = allRequirements
 
   object autoImport {
-    implicit def toSetupProviderState(bool: Boolean): (Boolean, InteractionRequest => InteractionRequest) = (bool, identity[InteractionRequest])
+    implicit def toSetupProviderState(bool: Boolean): ProviderStateResult = ProviderStateResult(bool)
 
-    val providerStateMatcher: SettingKey[PartialFunction[String, (Boolean, InteractionRequest => InteractionRequest)]] =
-      SettingKey[PartialFunction[String, (Boolean, InteractionRequest => InteractionRequest)]]("provider-state-matcher",
-        "Alternative partial function for provider state setup")
+    val providerStateMatcher: SettingKey[PartialFunction[String, ProviderStateResult]] =
+      SettingKey[PartialFunction[String, ProviderStateResult]]("provider-state-matcher", "Alternative partial function for provider state setup")
 
     val providerStates: SettingKey[Seq[(String, SetupProviderState)]] =
       SettingKey[Seq[(String, SetupProviderState)]]("provider-states", "A list of provider state setup functions")
@@ -73,9 +72,7 @@ object ScalaPactPlugin extends AutoPlugin {
 
   import autoImport._
 
-  private val pf: PartialFunction[String, (Boolean, InteractionRequest => InteractionRequest)] = { case _: String =>
-    false
-  }
+  private val pf: PartialFunction[String, ProviderStateResult] = { case _: String => false }
 
   @SuppressWarnings(Array("org.wartremover.warts.Any"))
   private val pactSettings = Seq(
@@ -96,7 +93,7 @@ object ScalaPactPlugin extends AutoPlugin {
     _ >: Seq[(String, SetupProviderState)] with Seq[(String, String)] with Boolean with ScalaPactEnv with Map[
       String,
       String
-    ] with String with Seq[String] with PartialFunction[String, (Boolean, InteractionRequest => InteractionRequest)] with Task[Unit] with InputTask[Unit]
+    ] with String with Seq[String] with PartialFunction[String, ProviderStateResult] with Task[Unit] with InputTask[Unit]
   ]] = {
     pactSettings ++ Seq(
       // Tasks

--- a/sbt-scalapact/src/main/scala/com/itv/scalapact/plugin/ScalaPactPlugin.scala
+++ b/sbt-scalapact/src/main/scala/com/itv/scalapact/plugin/ScalaPactPlugin.scala
@@ -3,8 +3,8 @@ package com.itv.scalapact.plugin
 import com.itv.scalapact.json._
 import com.itv.scalapact.http._
 import com.itv.scalapact.plugin.shared._
-import com.itv.scalapact.shared.ScalaPactSettings
-
+import com.itv.scalapact.shared.{InteractionRequest, ScalaPactSettings}
+import com.itv.scalapactcore.verifier.Verifier.SetupProviderState
 import sbt.Keys._
 import sbt.plugins.JvmPlugin
 import sbt.{Def, _}
@@ -15,12 +15,14 @@ object ScalaPactPlugin extends AutoPlugin {
   override def trigger: PluginTrigger   = allRequirements
 
   object autoImport {
-    val providerStateMatcher: SettingKey[PartialFunction[String, Boolean]] =
-      SettingKey[PartialFunction[String, Boolean]]("provider-state-matcher",
-                                                   "Alternative partial function for provider state setup")
+    implicit def toSetupProviderState(bool: Boolean): (Boolean, InteractionRequest => InteractionRequest) = (bool, identity[InteractionRequest])
 
-    val providerStates: SettingKey[Seq[(String, String => Boolean)]] =
-      SettingKey[Seq[(String, String => Boolean)]]("provider-states", "A list of provider state setup functions")
+    val providerStateMatcher: SettingKey[PartialFunction[String, (Boolean, InteractionRequest => InteractionRequest)]] =
+      SettingKey[PartialFunction[String, (Boolean, InteractionRequest => InteractionRequest)]]("provider-state-matcher",
+        "Alternative partial function for provider state setup")
+
+    val providerStates: SettingKey[Seq[(String, SetupProviderState)]] =
+      SettingKey[Seq[(String, SetupProviderState)]]("provider-states", "A list of provider state setup functions")
 
     val pactBrokerAddress: SettingKey[String] =
       SettingKey[String]("pactBrokerAddress", "The base url to publish / pull pact contract files to and from.")
@@ -71,7 +73,9 @@ object ScalaPactPlugin extends AutoPlugin {
 
   import autoImport._
 
-  private val pf: PartialFunction[String, Boolean] = { case _: String => false }
+  private val pf: PartialFunction[String, (Boolean, InteractionRequest => InteractionRequest)] = { case _: String =>
+    false
+  }
 
   @SuppressWarnings(Array("org.wartremover.warts.Any"))
   private val pactSettings = Seq(
@@ -89,10 +93,10 @@ object ScalaPactPlugin extends AutoPlugin {
 
   @SuppressWarnings(Array("org.wartremover.warts.Any"))
   override lazy val projectSettings: Seq[Def.Setting[
-    _ >: Seq[(String, String => Boolean)] with Seq[(String, String)] with Boolean with ScalaPactEnv with Map[
+    _ >: Seq[(String, SetupProviderState)] with Seq[(String, String)] with Boolean with ScalaPactEnv with Map[
       String,
       String
-    ] with String with Seq[String] with PartialFunction[String, Boolean] with Task[Unit] with InputTask[Unit]
+    ] with String with Seq[String] with PartialFunction[String, (Boolean, InteractionRequest => InteractionRequest)] with Task[Unit] with InputTask[Unit]
   ]] = {
     pactSettings ++ Seq(
       // Tasks

--- a/scalapact-core/src/main/scala/com/itv/scalapactcore/verifier/Verifier.scala
+++ b/scalapact-core/src/main/scala/com/itv/scalapactcore/verifier/Verifier.scala
@@ -11,7 +11,12 @@ import com.itv.scalapact.shared.typeclasses.{IPactReader, IScalaPactHttpClient}
 import com.itv.scalapactcore.verifier.Verifier.SetupProviderState
 
 object Verifier {
-  type SetupProviderState = String => (Boolean, InteractionRequest => InteractionRequest)
+  case class ProviderStateResult(result: Boolean, modifyRequest: InteractionRequest => InteractionRequest)
+  object ProviderStateResult {
+    def apply(): ProviderStateResult = new ProviderStateResult(false, identity[InteractionRequest])
+    def apply(result: Boolean): ProviderStateResult = new ProviderStateResult(result, identity[InteractionRequest])
+  }
+  type SetupProviderState = String => ProviderStateResult
 
   def verify[F[_]](
       loadPactFiles: String => ScalaPactSettings => ConfigAndPacts,
@@ -151,7 +156,7 @@ object Verifier {
             PactLogger.message("--------------------".yellow.bold)
             PactLogger.message(s"Attempting to run provider state: ${ps.key}".yellow.bold)
 
-            val (success, modifyRequest) = ps.f(ps.key)
+            val ProviderStateResult(success, modifyRequest) = ps.f(ps.key)
 
             if (success)
               PactLogger.message(s"Provider state ran successfully".yellow.bold)

--- a/scalapact-docs/src/main/paradox/examples/provider.md
+++ b/scalapact-docs/src/main/paradox/examples/provider.md
@@ -45,7 +45,7 @@ The internal verification does not make use of provider states since the service
 }
 ```
 
-The function signature is `String => Boolean` where the `String` is the key value of the pact contract and `Boolean` is a way for you to say if your setup operation was a success or a failure.
+The function signature is `String => (Boolean, InteractionRequest => InteractionRequest)` where the `String` is the key value of the pact contract, `Boolean` is a way for you to say if your setup operation was a success or a failure and `InteractionRequest => InteractionRequest` is a function to modify the request before sending it, for example in case that you need to add a header for authorization. There is an implicit to allow you write the function as `String => Boolean` if you dont have the need to modify the request.
 
 ## Things to note
 1. The consumer and provider scala projects both use different case classes to represent the data. This does not matter, only the Pact file matters.

--- a/scalapact-docs/src/main/paradox/examples/provider.md
+++ b/scalapact-docs/src/main/paradox/examples/provider.md
@@ -45,7 +45,7 @@ The internal verification does not make use of provider states since the service
 }
 ```
 
-The function signature is `String => (Boolean, InteractionRequest => InteractionRequest)` where the `String` is the key value of the pact contract, `Boolean` is a way for you to say if your setup operation was a success or a failure and `InteractionRequest => InteractionRequest` is a function to modify the request before sending it, for example in case that you need to add a header for authorization. There is an implicit to allow you write the function as `String => Boolean` if you dont have the need to modify the request.
+The function signature is `String => ProviderStateResult` where the `String` is the key value of the pact contract, `ProviderStateResult.result` is a way for you to say if your setup operation was a success or a failure and `ProviderStateResult.modifyRequest` is a function to modify the request before sending it, for example in case that you need to add a header for authorization. There is an implicit to allow you write the function as `String => Boolean` if you dont have the need to modify the request.
 
 ## Things to note
 1. The consumer and provider scala projects both use different case classes to represent the data. This does not matter, only the Pact file matters.

--- a/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactVerify.scala
+++ b/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactVerify.scala
@@ -8,11 +8,11 @@ import com.itv.scalapact.shared._
 
 import scala.concurrent.duration._
 import com.itv.scalapact.shared.typeclasses.{IPactReader, IScalaPactHttpClient}
-import com.itv.scalapactcore.verifier.Verifier.SetupProviderState
+import com.itv.scalapactcore.verifier.Verifier.{ProviderStateResult, SetupProviderState}
 
 object ScalaPactVerify {
   implicit def toOption[A](a: A): Option[A] = Option(a)
-  implicit def toSetupProviderState(bool: Boolean): (Boolean, InteractionRequest => InteractionRequest) = (bool, identity[InteractionRequest])
+  implicit def toProviderStateResult(bool: Boolean): ProviderStateResult = ProviderStateResult(bool)
 
   object verifyPact {
     def withPactSource(


### PR DESCRIPTION
Hi! 
We are starting to use scala-pact at work but we are missing some functionality offered in other pact libraries. 
This PR is to add the ability to modify the requests of our pacts. We want to mimic the current behaviour of our system, which will add headers to the requests (like authorization)  but they are not really part of the pact. 
I'm looking forwards to hear from your opinion.
Kind regards,
Samuel.