### PR TITLE
Adds support for tagging pacts while publishing and verifying pacts with specified tags

### DIFF
--- a/sbt-scalapact-nodeps/src/main/scala/com/itv/scalapact/plugin/ScalaPactPlugin.scala
+++ b/sbt-scalapact-nodeps/src/main/scala/com/itv/scalapact/plugin/ScalaPactPlugin.scala
@@ -19,7 +19,8 @@ object ScalaPactPlugin extends AutoPlugin {
     implicit def toSetupProviderState(bool: Boolean): ProviderStateResult = ProviderStateResult(bool)
 
     val providerStateMatcher: SettingKey[PartialFunction[String, ProviderStateResult]] =
-      SettingKey[PartialFunction[String, ProviderStateResult]]("provider-state-matcher", "Alternative partial function for provider state setup")
+      SettingKey[PartialFunction[String, ProviderStateResult]]("provider-state-matcher",
+                                                               "Alternative partial function for provider state setup")
 
     val providerStates: SettingKey[Seq[(String, SetupProviderState)]] =
       SettingKey[Seq[(String, SetupProviderState)]]("provider-states", "A list of provider state setup functions")
@@ -45,10 +46,22 @@ object ScalaPactPlugin extends AutoPlugin {
         "The name and pact version numbers of the services that consume the service to verify"
       )
 
+    val taggedConsumerNames: SettingKey[Seq[(String, Seq[String])]] =
+      SettingKey[Seq[(String, Seq[String])]](
+        "taggedConsumerNames",
+        "The name and list of tags of the services that consume the service to verify"
+      )
+
     val pactContractVersion: SettingKey[String] =
       SettingKey[String](
         "pactContractVersion",
         "The version number the pact contract will be published under. If missing or empty, the project version will be used."
+      )
+
+    val pactContractTags: SettingKey[Seq[String]] =
+      SettingKey[Seq[String]](
+        "pactContractTags",
+        "The tags the pact contract will be published with. If missing or empty, the contract will be published without tags."
       )
 
     val allowSnapshotPublish: SettingKey[Boolean] =
@@ -84,17 +97,21 @@ object ScalaPactPlugin extends AutoPlugin {
     providerName := "",
     consumerNames := Seq.empty[String],
     versionedConsumerNames := Seq.empty[(String, String)],
+    taggedConsumerNames := Seq.empty[(String, Seq[String])],
     pactContractVersion := "",
+    pactContractTags := Seq.empty[String],
     allowSnapshotPublish := false,
     scalaPactEnv := ScalaPactEnv.empty
   )
 
   @SuppressWarnings(Array("org.wartremover.warts.Any"))
   override lazy val projectSettings: Seq[Def.Setting[
-    _ >: Seq[(String, SetupProviderState)] with Seq[(String, String)] with Boolean with ScalaPactEnv with Map[
+    _ >: Seq[(String, SetupProviderState)] with Seq[(String, String)] with Seq[(String, Seq[String])] with Boolean with ScalaPactEnv with Map[
       String,
       String
-    ] with String with Seq[String] with PartialFunction[String, ProviderStateResult] with Task[Unit] with InputTask[Unit]
+    ] with String with Seq[String] with PartialFunction[String, ProviderStateResult] with Task[Unit] with InputTask[
+      Unit
+    ]
   ]] = {
     pactSettings ++ Seq(
       // Tasks
@@ -125,7 +142,8 @@ object ScalaPactPlugin extends AutoPlugin {
         providerBrokerPublishMap.value,
         version.value,
         pactContractVersion.value,
-        allowSnapshotPublish.value
+        allowSnapshotPublish.value,
+        pactContractTags.value
       )
     }
 
@@ -140,7 +158,8 @@ object ScalaPactPlugin extends AutoPlugin {
         version.value,
         providerName.value,
         consumerNames.value,
-        versionedConsumerNames.value
+        versionedConsumerNames.value,
+        taggedConsumerNames.value
       )
     }
 

--- a/sbt-scalapact-shared/src/main/scala/com/itv/scalapact/plugin/shared/ScalaPactVerifyCommand.scala
+++ b/sbt-scalapact-shared/src/main/scala/com/itv/scalapact/plugin/shared/ScalaPactVerifyCommand.scala
@@ -17,9 +17,9 @@ object ScalaPactVerifyCommand {
       projectVersion: String,
       providerName: String,
       consumerNames: Seq[String],
-      versionedConsumerNames: Seq[(String, String)]
-  )(implicit pactReader: IPactReader, httpClient: IScalaPactHttpClient[F], publisher: IResultPublisher
-  ): Unit = {
+      versionedConsumerNames: Seq[(String, String)],
+      taggedConsumerNames: Seq[(String, Seq[String])]
+  )(implicit pactReader: IPactReader, httpClient: IScalaPactHttpClient[F], publisher: IResultPublisher): Unit = {
     PactLogger.message("*************************************".white.bold)
     PactLogger.message("** ScalaPact: Running Verifier     **".white.bold)
     PactLogger.message("*************************************".white.bold)
@@ -32,6 +32,8 @@ object ScalaPactVerifyCommand {
       projectVersion,
       providerName,
       consumerNames.toList,
+      taggedConsumerNames = taggedConsumerNames.toList
+        .map(t => TaggedConsumer(t._1, t._2.toList)),
       versionedConsumerNames = versionedConsumerNames.toList
         .map(t => VersionedConsumer(t._1, t._2))
     )

--- a/sbt-scalapact/src/main/scala/com/itv/scalapact/plugin/ScalaPactPlugin.scala
+++ b/sbt-scalapact/src/main/scala/com/itv/scalapact/plugin/ScalaPactPlugin.scala
@@ -50,10 +50,22 @@ object ScalaPactPlugin extends AutoPlugin {
         "The name and pact version numbers of the services that consume the service to verify"
       )
 
+    val taggedConsumerNames: SettingKey[Seq[(String, Seq[String])]] =
+      SettingKey[Seq[(String, Seq[String])]](
+        "taggedConsumerNames",
+        "The name and list of tags of the services that consume the service to verify"
+      )
+
     val pactContractVersion: SettingKey[String] =
       SettingKey[String](
         "pactContractVersion",
         "The version number the pact contract will be published under. If missing or empty, the project version will be used."
+      )
+
+    val pactContractTags: SettingKey[Seq[String]] =
+      SettingKey[Seq[String]](
+        "pactContractTags",
+        "The tags the pact contract will be published with. If missing or empty, the contract will be published without tags."
       )
 
     val allowSnapshotPublish: SettingKey[Boolean] =
@@ -89,14 +101,16 @@ object ScalaPactPlugin extends AutoPlugin {
     providerName := "",
     consumerNames := Seq.empty[String],
     versionedConsumerNames := Seq.empty[(String, String)],
+    taggedConsumerNames := Seq.empty[(String, Seq[String])],
     pactContractVersion := "",
+    pactContractTags := Seq.empty[String],
     allowSnapshotPublish := false,
     scalaPactEnv := ScalaPactEnv.empty
   )
 
   @SuppressWarnings(Array("org.wartremover.warts.Any"))
   override lazy val projectSettings: Seq[Def.Setting[
-    _ >: Seq[(String, SetupProviderState)] with Seq[(String, String)] with Boolean with ScalaPactEnv with Map[
+    _ >: Seq[(String, SetupProviderState)] with Seq[(String, String)] with Seq[(String, Seq[String])] with Boolean with ScalaPactEnv with Map[
       String,
       String
     ] with String with Seq[String] with PartialFunction[String, ProviderStateResult] with Task[Unit] with InputTask[
@@ -132,7 +146,8 @@ object ScalaPactPlugin extends AutoPlugin {
         providerBrokerPublishMap.value,
         version.value,
         pactContractVersion.value,
-        allowSnapshotPublish.value
+        allowSnapshotPublish.value,
+        pactContractTags.value
       )
     }
 
@@ -147,7 +162,8 @@ object ScalaPactPlugin extends AutoPlugin {
         version.value,
         providerName.value,
         consumerNames.value,
-        versionedConsumerNames.value
+        versionedConsumerNames.value,
+        taggedConsumerNames.value
       )
     }
 

--- a/scalapact-docs/src/main/paradox/basics/sbt-commands.md
+++ b/scalapact-docs/src/main/paradox/basics/sbt-commands.md
@@ -55,6 +55,11 @@ You can also specify the version you wish to publish under by adding:
 
 If you omit this variable or set it to an empty string, the main project version will be the version used to publish against.
 
+You can specify the tags of the contract by adding: 
+`pactContractTags := List("tag1", "tag2")`
+
+If you omit this variable or set it to an empty list, the contract will not be tagged under publishing. 
+
 You can then use the publish command to generate and upload your pact files to pact broker:
 
 `sbt pact-publish`

--- a/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactVerify.scala
+++ b/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactVerify.scala
@@ -130,6 +130,7 @@ object ScalaPactVerify {
                 projectVersion = "",
                 providerName = "",
                 consumerNames = Nil,
+                taggedConsumerNames = Nil,
                 versionedConsumerNames = Nil
               ),
               ScalaPactSettings(
@@ -152,6 +153,7 @@ object ScalaPactVerify {
                 projectVersion = "",
                 providerName = "",
                 consumerNames = Nil,
+                taggedConsumerNames = Nil,
                 versionedConsumerNames = Nil
               ),
               ScalaPactSettings(
@@ -174,6 +176,30 @@ object ScalaPactVerify {
                 projectVersion = "",
                 providerName = providerName,
                 consumerNames = consumerNames,
+                taggedConsumerNames = Nil,
+                versionedConsumerNames = Nil
+              ),
+              ScalaPactSettings(
+                host = host,
+                protocol = protocol,
+                port = port,
+                localPactFilePath = None,
+                strictMode = strict,
+                clientTimeout = Option(clientTimeout),
+                outputPath = None,
+                publishResultsEnabled = publishResultsEnabled
+              )
+            )
+
+          case pactBrokerWithTags(url, providerName, publishResultsEnabled, consumersWithTags) =>
+            (
+              PactVerifySettings(
+                providerStates = providerStateFunc,
+                pactBrokerAddress = url,
+                projectVersion = "",
+                providerName = providerName,
+                consumerNames = Nil,
+                taggedConsumerNames = consumersWithTags,
                 versionedConsumerNames = Nil
               ),
               ScalaPactSettings(
@@ -196,6 +222,7 @@ object ScalaPactVerify {
                 projectVersion = "",
                 providerName = providerName,
                 consumerNames = Nil,
+                taggedConsumerNames = Nil,
                 versionedConsumerNames = consumerNames.map(c => VersionedConsumer(c, version))
               ),
               ScalaPactSettings(
@@ -222,13 +249,25 @@ object ScalaPactVerify {
   sealed trait PactSourceType
   case class loadFromLocal(path: String) extends PactSourceType
   case class pactBroker(
-    url: String, provider: String, consumers: List[String], publishResultsEnabled: Option[BrokerPublishData]
+      url: String,
+      provider: String,
+      consumers: List[String],
+      publishResultsEnabled: Option[BrokerPublishData]
   ) extends PactSourceType {
     def withContractVersion(version: String): pactBrokerWithVersion =
       pactBrokerWithVersion(url, version, provider, consumers, publishResultsEnabled)
   }
+  case class pactBrokerWithTags(url: String,
+                                provider: String,
+                                publishResultsEnabled: Option[BrokerPublishData],
+                                consumerNamesWithTags: List[TaggedConsumer]
+   ) extends PactSourceType
   case class pactBrokerWithVersion(
-    url: String, contractVersion: String, provider: String, consumers: List[String], publishResultsEnabled: Option[BrokerPublishData]
+      url: String,
+      contractVersion: String,
+      provider: String,
+      consumers: List[String],
+      publishResultsEnabled: Option[BrokerPublishData]
   ) extends PactSourceType
   case class pactAsJsonString(json: String) extends PactSourceType
 

--- a/scalapact-shared/src/main/scala/com/itv/scalapact/shared/PactVerifySettings.scala
+++ b/scalapact-shared/src/main/scala/com/itv/scalapact/shared/PactVerifySettings.scala
@@ -7,4 +7,5 @@ case class PactVerifySettings(providerStates: SetupProviderState,
                               projectVersion: String,
                               providerName: String,
                               consumerNames: List[String],
+                              taggedConsumerNames: List[TaggedConsumer],
                               versionedConsumerNames: List[VersionedConsumer])

--- a/scalapact-shared/src/main/scala/com/itv/scalapact/shared/TaggedConsumer.scala
+++ b/scalapact-shared/src/main/scala/com/itv/scalapact/shared/TaggedConsumer.scala
@@ -1,0 +1,3 @@
+package com.itv.scalapact.shared
+
+case class TaggedConsumer(name: String, tags: List[String])


### PR DESCRIPTION
Fixes #107 

This allows one to tag their published contracts and to verify contracts with specified tags.

As recommended by pact-foundation: https://github.com/pact-foundation/pact_broker/wiki/Using-tags#1-automatically-tag-with-branch-name-when-pact-is-published-recommended