### PR TITLE
Adds url escaping of tags to broker requests

### DIFF
--- a/sbt-scalapact-shared/src/main/scala/com/itv/scalapact/plugin/shared/Publisher.scala
+++ b/sbt-scalapact-shared/src/main/scala/com/itv/scalapact/plugin/shared/Publisher.scala
@@ -1,5 +1,7 @@
 package com.itv.scalapact.plugin.shared
 
+import java.net.URLEncoder
+
 import com.itv.scalapact.shared._
 import com.itv.scalapact.shared.ColourOutput._
 import com.itv.scalapact.shared.typeclasses.IPactWriter
@@ -33,7 +35,8 @@ object Publisher {
       case Right(v) =>
         val consumerVersion = versionToPublishAs.replace("-SNAPSHOT", ".x")
         val tagAddresses = tagsToPublishWith.map(
-          v.validatedAddress.address + "/pacticipants/" + v.consumerName + "/versions/" + consumerVersion + "/tags/" + _
+          v.validatedAddress.address + "/pacticipants/" + v.consumerName + "/versions/" + consumerVersion + "/tags/" + URLEncoder
+            .encode(_, "UTF-8")
         )
         val address = v.validatedAddress.address + "/pacts/provider/" + v.providerName + "/consumer/" + v.consumerName + "/version/" + consumerVersion
 

--- a/scalapact-core/src/main/scala/com/itv/scalapactcore/verifier/Verifier.scala
+++ b/scalapact-core/src/main/scala/com/itv/scalapactcore/verifier/Verifier.scala
@@ -1,5 +1,7 @@
 package com.itv.scalapactcore.verifier
 
+import java.net.URLEncoder
+
 import com.itv.scalapact.shared._
 import com.itv.scalapactcore.common.matching.InteractionMatchers._
 import com.itv.scalapact.shared.ColourOutput._
@@ -30,7 +32,7 @@ object Verifier {
       val versionConsumers = pactVerifySettings.consumerNames.map(c => VersionedConsumer(c, "/latest")) ++
         pactVerifySettings.versionedConsumerNames.map(vc => vc.copy(version = "/version/" + vc.version)) ++
         pactVerifySettings.taggedConsumerNames.flatMap(
-          tc => tc.tags.map(t => VersionedConsumer(tc.name, "/latest/" + t))
+          tc => tc.tags.map(t => VersionedConsumer(tc.name, "/latest/" + URLEncoder.encode(t, "UTF-8")))
         )
 
       val latestPacts: List[Pact] = versionConsumers


### PR DESCRIPTION
[Percent encodes](https://en.wikipedia.org/wiki/Percent-encoding) tags when publishing and requesting tags from pact-broker.

Allows to use reserved symbols in tag names (Ex: `/`, `#`). 