### PR TITLE
Support Circe 0.11 (v0.11.1)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -57,7 +57,7 @@ addCommandAlias(
 )
 addCommandAlias(
   "quickpublish",
-  ";shared/publishLocal;core/publishLocal;argonaut62/publishLocal;circe08/publishLocal;circe09/publishLocal;circe10/publishLocal;http4s016a/publishLocal;http4s017/publishLocal;http4s018/publishLocal;http4s020/publishLocal;pluginShared/publishLocal;plugin/publishLocal;pluginNoDeps/publishLocal;standalone/publishLocal;framework/publishLocal"
+  ";shared/publishLocal;core/publishLocal;argonaut62/publishLocal;circe08/publishLocal;circe09/publishLocal;circe10/publishLocal;circe11/publishLocal;http4s016a/publishLocal;http4s017/publishLocal;http4s018/publishLocal;http4s020/publishLocal;pluginShared/publishLocal;plugin/publishLocal;pluginNoDeps/publishLocal;standalone/publishLocal;framework/publishLocal"
 )
 
 lazy val commonSettings = Seq(
@@ -269,6 +269,22 @@ lazy val circe10 =
     .dependsOn(shared)
     .settings(compilerOptions212: _*)
 
+
+lazy val circe11 =
+  (project in file("scalapact-circe-0-11"))
+    .settings(commonSettings: _*)
+    .settings(publishSettings: _*)
+    .settings(
+      name := "scalapact-circe-0-11",
+      libraryDependencies ++= Seq(
+        "io.circe" %% "circe-core",
+        "io.circe" %% "circe-generic",
+        "io.circe" %% "circe-parser"
+      ).map(_ % "0.11.1")
+    )
+    .dependsOn(shared)
+    .settings(compilerOptions212: _*)
+
 lazy val pluginShared =
   (project in file("sbt-scalapact-shared"))
     .settings(commonSettings: _*)
@@ -382,6 +398,6 @@ lazy val scalaPactProject =
     .settings(commonSettings: _*)
     .aggregate(shared, core, pluginShared, plugin, pluginNoDeps, framework, standalone)
     .aggregate(http4s016a, http4s017, http4s018, http4s020)
-    .aggregate(argonaut62, circe08, circe09, circe10)
+    .aggregate(argonaut62, circe08, circe09, circe10, circe11)
     .aggregate(docs)
     .aggregate(pactSpec, testsWithDeps)

--- a/scalapact-circe-0-11/src/main/scala/com/itv/scalapact/circe11/JsonConversionFunctions.scala
+++ b/scalapact-circe-0-11/src/main/scala/com/itv/scalapact/circe11/JsonConversionFunctions.scala
@@ -1,0 +1,79 @@
+package com.itv.scalapact.circe11
+
+import io.circe._
+import io.circe.parser._
+import com.itv.scalapact.shared.IJsonConversionFunctions
+import com.itv.scalapact.shared.matchir._
+import com.itv.scalapact.shared.matchir.MatchIrConstants.{rootNodeLabel, unnamedNodeLabel}
+import com.itv.scalapact.shared.ColourOutput._
+import com.itv.scalapact.shared.PactLogger
+
+object JsonConversionFunctions extends IJsonConversionFunctions {
+
+  def fromJSON(jsonString: String): Option[IrNode] =
+    parse(jsonString).toOption.flatMap { json =>
+      jsonRootToIrNode(json, IrNodePathEmpty)
+    }
+
+  def jsonToIrNode(label: String, json: Json, pathToParent: IrNodePath): IrNode =
+    json match {
+      case j: Json if j.isArray =>
+        IrNode(label, jsonArrayToIrNodeList(label, j, pathToParent)).withPath(pathToParent).markAsArray
+
+      case j: Json if j.isObject =>
+        IrNode(label, jsonObjectToIrNodeList(j, pathToParent)).withPath(pathToParent)
+
+      case j: Json if j.isNull =>
+        IrNode(label, IrNullNode).withPath(pathToParent)
+
+      case j: Json if j.isNumber =>
+        IrNode(label, j.asNumber.map(_.toDouble).map(d => IrNumberNode(d))).withPath(pathToParent)
+
+      case j: Json if j.isBoolean =>
+        IrNode(label, j.asBoolean.map(IrBooleanNode)).withPath(pathToParent)
+
+      case j: Json if j.isString =>
+        IrNode(label, j.asString.map(IrStringNode)).withPath(pathToParent)
+    }
+
+  def jsonObjectToIrNodeList(json: Json, pathToParent: IrNodePath): List[IrNode] =
+    json.hcursor.keys
+      .map(_.toSet)
+      .map(_.toList)
+      .getOrElse(Nil)
+      .map(l => if (l.isEmpty) unnamedNodeLabel else l)
+      .map { l =>
+        json.hcursor.downField(l).focus.map { q =>
+          jsonToIrNode(l, q, pathToParent <~ l)
+        }
+      }
+      .collect { case Some(s) => s }
+
+  def jsonArrayToIrNodeList(parentLabel: String, json: Json, pathToParent: IrNodePath): List[IrNode] =
+    json.asArray
+      .map(_.toList)
+      .getOrElse(Nil)
+      .zipWithIndex
+      .map(j => jsonToIrNode(parentLabel, j._1, pathToParent <~ j._2))
+
+  def jsonRootToIrNode(json: Json, initialPath: IrNodePath): Option[IrNode] =
+    json match {
+      case j: Json if j.isArray =>
+        Option(
+          IrNode(rootNodeLabel, jsonArrayToIrNodeList(unnamedNodeLabel, j, initialPath))
+            .withPath(initialPath)
+            .markAsArray
+        )
+
+      case j: Json if j.isObject =>
+        Option(
+          IrNode(rootNodeLabel, jsonObjectToIrNodeList(j, initialPath))
+            .withPath(initialPath)
+        )
+
+      case _ =>
+        PactLogger.error("JSON was not an object or an array".red)
+        None
+    }
+
+}

--- a/scalapact-circe-0-11/src/main/scala/com/itv/scalapact/circe11/PactReader.scala
+++ b/scalapact-circe-0-11/src/main/scala/com/itv/scalapact/circe11/PactReader.scala
@@ -1,0 +1,120 @@
+package com.itv.scalapact.circe11
+
+import com.itv.scalapact.shared.Pact.Links
+import io.circe._
+import io.circe.parser._
+import io.circe.generic.auto._
+import com.itv.scalapact.shared._
+import com.itv.scalapact.shared.matchir.IrNode
+import com.itv.scalapact.shared.typeclasses.IPactReader
+
+class PactReader extends IPactReader {
+
+  def fromJSON(jsonString: String): Option[IrNode] =
+    JsonConversionFunctions.fromJSON(jsonString)
+
+  def jsonStringToPact(json: String): Either[String, Pact] = {
+    val brokenPact: Option[(PactActor, PactActor, List[(Option[Interaction], Option[String], Option[String])], Option[Links])] = for {
+      provider     <- JsonBodySpecialCaseHelper.extractPactActor("provider")(json)
+      consumer     <- JsonBodySpecialCaseHelper.extractPactActor("consumer")(json)
+      interactions <- JsonBodySpecialCaseHelper.extractInteractions(json)
+    } yield (provider, consumer, interactions, JsonBodySpecialCaseHelper.extractLinks(json))
+
+    brokenPact.map { bp =>
+      val interactions = bp._3.collect {
+        case (Some(i), r1, r2) =>
+          i.copy(
+            request = i.request.copy(body = r1),
+            response = i.response.copy(body = r2)
+          )
+      }
+
+      Pact(
+        provider = bp._1,
+        consumer = bp._2,
+        interactions = interactions
+          .map(i => i.copy(providerState = i.providerState.orElse(i.provider_state)))
+          .map(i => i.copy(provider_state = None)),
+        _links = bp._4
+      )
+
+    } match {
+      case Some(pact) => Right(pact)
+      case None       => Left(s"Could not read pact from json: $json")
+    }
+  }
+
+}
+
+object JsonBodySpecialCaseHelper {
+
+  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+  val extractPactActor: String => String => Option[PactActor] = field =>
+    json => {
+      parse(json).toOption.flatMap(_.hcursor.downField(field).focus.flatMap(_.as[PactActor].toOption))
+  }
+
+  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+  val extractInteractions: String => Option[List[(Option[Interaction], Option[String], Option[String])]] = json => {
+
+    val interactions =
+      parse(json).toOption
+        .flatMap { j =>
+          j.hcursor.downField("interactions").focus.flatMap(p => p.asArray.map(_.toList))
+        }
+
+    val makeOptionalBody: Json => Option[String] = {
+      case body: Json if body.isString =>
+        body.asString
+
+      case body =>
+        Option(body.pretty(Printer.spaces2.copy(dropNullValues = true)))
+    }
+
+    interactions.map { is =>
+      is.map { i =>
+        val minusRequestBody =
+          i.hcursor.downField("request").downField("body").delete.top match {
+            case ok @ Some(_) => ok
+            case None         => Option(i)
+          }
+
+        val minusResponseBody = minusRequestBody.flatMap { ii =>
+          ii.hcursor.downField("response").downField("body").delete.top match {
+            case ok @ Some(_) => ok
+            case None         => minusRequestBody // There wasn't a body, but there was still an interaction.
+          }
+        }
+
+        val requestBody = i.hcursor
+          .downField("request")
+          .downField("body")
+          .focus
+          .flatMap { makeOptionalBody }
+
+        val responseBody = i.hcursor
+          .downField("response")
+          .downField("body")
+          .focus
+          .flatMap { makeOptionalBody }
+
+        (minusResponseBody.flatMap(p => p.as[Interaction].toOption), requestBody, responseBody)
+      }
+    }
+  }
+
+  @SuppressWarnings(Array("org.wartremover.warts.PublicInference", "org.wartremover.warts.Any"))
+  val extractLinks: String => Option[Links] = json => {
+    parse(json).toOption.flatMap { j =>
+      (j.hcursor.downField("_links")).focus
+    }.flatMap { j =>
+      val withoutCuries = j.hcursor.downField("curies").delete.top match {
+        case ok @ Some(_) => ok
+        case None => Option(j)
+      }
+
+      withoutCuries.flatMap(_.as[Links].toOption)
+    }
+  }
+
+}

--- a/scalapact-circe-0-11/src/main/scala/com/itv/scalapact/circe11/PactWriter.scala
+++ b/scalapact-circe-0-11/src/main/scala/com/itv/scalapact/circe11/PactWriter.scala
@@ -1,0 +1,79 @@
+package com.itv.scalapact.circe11
+
+import com.itv.scalapact.shared.Pact
+import com.itv.scalapact.shared.typeclasses.IPactWriter
+import io.circe._
+import io.circe.parser._
+import io.circe.syntax._
+import io.circe.generic.auto._
+
+class PactWriter extends IPactWriter {
+
+  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+  def pactToJsonString(pact: Pact): String = {
+
+    val interactions: Vector[Json] =
+      pact.interactions.toVector
+        .map { i =>
+          val maybeRequestBody: Option[Json] = i.request.body.flatMap { rb =>
+            parse(rb).toOption.orElse(Option(Json.fromString(rb)))
+          }
+
+          val maybeResponseBody: Option[Json] = i.response.body.flatMap { rb =>
+            parse(rb).toOption.orElse(Option(Json.fromString(rb)))
+          }
+
+          val bodilessInteraction: Json = i
+            .copy(
+              request = i.request.copy(body = None),
+              response = i.response.copy(body = None)
+            )
+            .asJson
+
+          val withRequestBody: Option[Json] = {
+            for {
+              requestBody <- maybeRequestBody
+              bodyField = bodilessInteraction.hcursor.downField("request").downField("body")
+              updated <- Option(bodyField.set(requestBody))
+            } yield updated.top
+          } match {
+            case ok @ Some(_) => ok.flatten
+            case None         => Option(bodilessInteraction) // There wasn't a body, but there was still an interaction.
+          }
+
+          val withResponseBody: Option[Json] = {
+            maybeResponseBody.map { responseBody =>
+              withRequestBody
+                .flatMap { j =>
+                  j.hcursor.downField("response").downField("body").set(responseBody).top
+                }
+            }
+          } match {
+            case ok @ Some(_) => ok.flatten
+            case None         => withRequestBody // There wasn't a body, but there was still an interaction.
+          }
+
+          withResponseBody
+        }
+        .collect { case Some(s) => s }
+
+    val json: Option[Json] =
+      pact
+        .copy(interactions = Nil)
+        .asJson
+        .hcursor
+        .downField("interactions")
+        .withFocus(_.withArray(_ => interactions.asJson))
+        .top
+
+    // I don't believe you can ever see this exception.
+    json
+      .getOrElse(
+        throw new Exception(
+          "Something went really wrong serialising the following pact into json: " + pact.renderAsString
+        )
+      )
+      .pretty(Printer.spaces2.copy(dropNullValues = true))
+  }
+
+}

--- a/scalapact-circe-0-11/src/main/scala/com/itv/scalapact/circe11/package.scala
+++ b/scalapact-circe-0-11/src/main/scala/com/itv/scalapact/circe11/package.scala
@@ -1,0 +1,12 @@
+package com.itv.scalapact
+
+import com.itv.scalapact.shared.typeclasses.{IPactReader, IPactWriter}
+
+package object circe11 {
+
+  implicit val pactReaderInstance: IPactReader =
+    new PactReader
+
+  implicit val pactWriterInstance: IPactWriter =
+    new PactWriter
+}

--- a/scalapact-circe-0-11/src/main/scala/com/itv/scalapact/json/package.scala
+++ b/scalapact-circe-0-11/src/main/scala/com/itv/scalapact/json/package.scala
@@ -1,0 +1,10 @@
+package com.itv.scalapact
+
+import com.itv.scalapact.circe11.{PactReader, PactWriter}
+import com.itv.scalapact.shared.typeclasses.{IPactReader, IPactWriter}
+
+package object json {
+  implicit val pactReaderInstance: IPactReader = new PactReader
+
+  implicit val pactWriterInstance: IPactWriter = new PactWriter
+}

--- a/scalapact-circe-0-11/src/test/scala/com/itv/scalapact/circe11/PactFileExamples.scala
+++ b/scalapact-circe-0-11/src/test/scala/com/itv/scalapact/circe11/PactFileExamples.scala
@@ -1,0 +1,474 @@
+package com.itv.scalapact.circe11
+
+import com.itv.scalapact.shared._
+
+object PactFileExamples {
+
+  val anotherExample: String =
+    """{
+      |  "provider" : {
+      |    "name" : "Their Provider Service"
+      |  },
+      |  "consumer" : {
+      |    "name" : "My Consumer"
+      |  },
+      |  "interactions" : [
+      |    {
+      |      "description" : "a simple get example with a header matcher",
+      |      "request" : {
+      |        "method" : "GET",
+      |        "path" : "/header-match",
+      |        "headers" : {
+      |          "fish" : "chips",
+      |          "sauce" : "ketchup"
+      |        },
+      |        "matchingRules" : {
+      |          "$.headers.fish" : {
+      |            "match" : "regex",
+      |            "regex" : "\\w+"
+      |          },
+      |          "$.headers.sauce" : {
+      |            "match" : "regex",
+      |            "regex" : "\\w+"
+      |          }
+      |        }
+      |      },
+      |      "response" : {
+      |        "status" : 200,
+      |        "headers" : {
+      |          "fish" : "chips",
+      |          "sauce" : "ketchup"
+      |        },
+      |        "body" : "Hello there!",
+      |        "matchingRules" : {
+      |          "$.headers.fish" : {
+      |            "match" : "regex",
+      |            "regex" : "\\w+"
+      |          },
+      |          "$.headers.sauce" : {
+      |            "match" : "regex",
+      |            "regex" : "\\w+"
+      |          }
+      |        }
+      |      }
+      |    }
+      |  ]
+      |}""".stripMargin
+
+  val verySimple = Pact(
+    consumer = PactActor("consumer"),
+    provider = PactActor("provider"),
+    interactions = List(
+      Interaction(
+        provider_state = None,
+        providerState = None,
+        description = "a simple request",
+        request = InteractionRequest(
+          method = Option("GET"),
+          path = Option("/"),
+          query = None,
+          headers = None,
+          body = None,
+          matchingRules = None
+        ),
+        response = InteractionResponse(
+          status = Option(200),
+          headers = None,
+          body = Option("""Hello"""),
+          None
+        )
+      )
+    ),
+    _links = None
+  )
+
+  val verySimpleAsString: String =
+    """{
+      |  "provider" : {
+      |    "name" : "provider"
+      |  },
+      |  "consumer" : {
+      |    "name" : "consumer"
+      |  },
+      |  "interactions" : [
+      |    {
+      |      "description" : "a simple request",
+      |      "request" : {
+      |        "method" : "GET",
+      |        "path" : "/"
+      |      },
+      |      "response" : {
+      |        "status" : 200,
+      |        "body" : "Hello"
+      |      }
+      |    }
+      |  ]
+      |}""".stripMargin
+
+  val simple = Pact(
+    consumer = PactActor("consumer"),
+    provider = PactActor("provider"),
+    interactions = List(
+      Interaction(
+        provider_state = None,
+        providerState = Option("a simple state"),
+        description = "a simple request",
+        request = InteractionRequest(
+          method = Option("GET"),
+          path = Option("/fetch-json"),
+          query = Option("fish=chips"),
+          headers = Option(Map("Content-Type" -> "text/plain")),
+          body = Option("""fish"""),
+          matchingRules = Option(
+            Map(
+              "$.headers.Accept"         -> MatchingRule(`match` = Option("regex"), regex = Option("\\w+"), min = None),
+              "$.headers.Content-Length" -> MatchingRule(`match` = Option("type"), regex = None, min = None)
+            )
+          )
+        ),
+        response = InteractionResponse(
+          status = Option(200),
+          headers = Option(Map("Content-Type" -> "application/json")),
+          body = Option("""{
+              |  "fish" : [
+              |    "cod",
+              |    "haddock",
+              |    "flying"
+              |  ]
+              |}""".stripMargin),
+          matchingRules = Option(
+            Map(
+              "$.headers.Accept"         -> MatchingRule(`match` = Option("regex"), regex = Option("\\w+"), min = None),
+              "$.headers.Content-Length" -> MatchingRule(`match` = Option("type"), regex = None, min = None)
+            )
+          )
+        )
+      ),
+      Interaction(
+        provider_state = None,
+        providerState = Option("a simple state 2"),
+        description = "a simple request 2",
+        request = InteractionRequest(
+          method = Option("GET"),
+          path = Option("/fetch-json2"),
+          query = None,
+          headers = Option(Map("Content-Type" -> "text/plain")),
+          body = Option("""fish"""),
+          matchingRules = None
+        ),
+        response = InteractionResponse(
+          status = Option(200),
+          headers = Option(Map("Content-Type" -> "application/json")),
+          body = Option("""{
+              |  "chips" : true,
+              |  "fish" : [
+              |    "cod",
+              |    "haddock"
+              |  ]
+              |}""".stripMargin),
+          matchingRules = None
+        )
+      )
+    ),
+    _links = None
+  )
+
+  val _links = Map(
+    "self" -> LinkValues(
+      title = Option("Pact"),
+      name = Option("Pact between consumer (v1.0.0) and provider"),
+      href = "http://localhost/pacts/provider/provider/consumer/consumer/version/1.0.0",
+      templated = None
+    ),
+    "pb:consumer" -> LinkValues(
+      title = Option("Consumer"),
+      name = Option("consumer"),
+      href = "http://localhost/pacticipants/consumer",
+      templated = None
+    ),
+    "pb:provider" -> LinkValues(
+      title = Option("Provider"),
+      name = Option("provider"),
+      href = "http://localhost/pacticipants/provider",
+      templated = None
+    ),
+    "pb:latest-tagged-pact-version" -> LinkValues(
+      title = Option("Latest tagged version of this pact"),
+      name = None,
+      href = "http://localhost/pacts/provider/provider-service/consumer/consumer-service/latest/{tag}",
+      templated = Option(true)
+    )
+  )
+
+  val simpleWithLinks = simple.copy(_links = Option(_links))
+
+  val simpleAsString: String = """{
+                         |  "provider" : {
+                         |    "name" : "provider"
+                         |  },
+                         |  "consumer" : {
+                         |    "name" : "consumer"
+                         |  },
+                         |  "interactions" : [
+                         |    {
+                         |      "providerState" : "a simple state",
+                         |      "description" : "a simple request",
+                         |      "request" : {
+                         |        "method" : "GET",
+                         |        "path" : "/fetch-json",
+                         |        "query" : "fish=chips",
+                         |        "headers" : {
+                         |          "Content-Type" : "text/plain"
+                         |        },
+                         |        "body" : "fish",
+                         |        "matchingRules" : {
+                         |          "$.headers.Accept" : {
+                         |            "match" : "regex",
+                         |            "regex" : "\\w+"
+                         |          },
+                         |          "$.headers.Content-Length" : {
+                         |            "match" : "type"
+                         |          }
+                         |        }
+                         |      },
+                         |      "response" : {
+                         |        "status" : 200,
+                         |        "headers" : {
+                         |          "Content-Type" : "application/json"
+                         |        },
+                         |        "body" : {
+                         |          "fish" : [
+                         |            "cod",
+                         |            "haddock",
+                         |            "flying"
+                         |          ]
+                         |        },
+                         |        "matchingRules" : {
+                         |          "$.headers.Accept" : {
+                         |            "match" : "regex",
+                         |            "regex" : "\\w+"
+                         |          },
+                         |          "$.headers.Content-Length" : {
+                         |            "match" : "type"
+                         |          }
+                         |        }
+                         |      }
+                         |    },
+                         |    {
+                         |      "providerState" : "a simple state 2",
+                         |      "description" : "a simple request 2",
+                         |      "request" : {
+                         |        "method" : "GET",
+                         |        "path" : "/fetch-json2",
+                         |        "headers" : {
+                         |          "Content-Type" : "text/plain"
+                         |        },
+                         |        "body" : "fish"
+                         |      },
+                         |      "response" : {
+                         |        "status" : 200,
+                         |        "headers" : {
+                         |          "Content-Type" : "application/json"
+                         |        },
+                         |        "body" : {
+                         |          "chips" : true,
+                         |          "fish" : [
+                         |            "cod",
+                         |            "haddock"
+                         |          ]
+                         |        }
+                         |      }
+                         |    }
+                         |  ]
+                         |}""".stripMargin
+
+  val simpleOldProviderStateAsString: String = """{
+                                 |  "provider" : {
+                                 |    "name" : "provider"
+                                 |  },
+                                 |  "consumer" : {
+                                 |    "name" : "consumer"
+                                 |  },
+                                 |  "interactions" : [
+                                 |    {
+                                 |      "provider_state" : "a simple state",
+                                 |      "description" : "a simple request",
+                                 |      "request" : {
+                                 |        "method" : "GET",
+                                 |        "path" : "/fetch-json",
+                                 |        "body" : "fish",
+                                 |        "query" : "fish=chips",
+                                 |        "headers" : {
+                                 |          "Content-Type" : "text/plain"
+                                 |        },
+                                 |        "matchingRules" : {
+                                 |          "$.headers.Accept" : {
+                                 |            "match" : "regex",
+                                 |            "regex" : "\\w+"
+                                 |          },
+                                 |          "$.headers.Content-Length" : {
+                                 |            "match" : "type"
+                                 |          }
+                                 |        }
+                                 |      },
+                                 |      "response" : {
+                                 |        "status" : 200,
+                                 |        "headers" : {
+                                 |          "Content-Type" : "application/json"
+                                 |        },
+                                 |        "body" : {
+                                 |          "fish" : [
+                                 |            "cod",
+                                 |            "haddock",
+                                 |            "flying"
+                                 |          ]
+                                 |        },
+                                 |        "matchingRules" : {
+                                 |          "$.headers.Accept" : {
+                                 |            "match" : "regex",
+                                 |            "regex" : "\\w+"
+                                 |          },
+                                 |          "$.headers.Content-Length" : {
+                                 |            "match" : "type"
+                                 |          }
+                                 |        }
+                                 |      }
+                                 |    },
+                                 |    {
+                                 |      "provider_state" : "a simple state 2",
+                                 |      "description" : "a simple request 2",
+                                 |      "request" : {
+                                 |        "method" : "GET",
+                                 |        "path" : "/fetch-json2",
+                                 |        "body" : "fish",
+                                 |        "headers" : {
+                                 |          "Content-Type" : "text/plain"
+                                 |        }
+                                 |      },
+                                 |      "response" : {
+                                 |        "status" : 200,
+                                 |        "headers" : {
+                                 |          "Content-Type" : "application/json"
+                                 |        },
+                                 |        "body" : {
+                                 |          "chips" : true,
+                                 |          "fish" : [
+                                 |            "cod",
+                                 |            "haddock"
+                                 |          ]
+                                 |        }
+                                 |      }
+                                 |    }
+                                 |  ]
+                                 |}""".stripMargin
+
+  val simpleWithLinksAsString: String = """{
+                                          |  "provider" : {
+                                          |    "name" : "provider"
+                                          |  },
+                                          |  "consumer" : {
+                                          |    "name" : "consumer"
+                                          |  },
+                                          |  "interactions" : [
+                                          |    {
+                                          |      "request" : {
+                                          |        "method" : "GET",
+                                          |        "body" : "fish",
+                                          |        "path" : "/fetch-json",
+                                          |        "matchingRules" : {
+                                          |          "$.headers.Accept" : {
+                                          |            "match" : "regex",
+                                          |            "regex" : "\\w+"
+                                          |          },
+                                          |          "$.headers.Content-Length" : {
+                                          |            "match" : "type"
+                                          |          }
+                                          |        },
+                                          |        "query" : "fish=chips",
+                                          |        "headers" : {
+                                          |          "Content-Type" : "text/plain"
+                                          |        }
+                                          |      },
+                                          |      "description" : "a simple request",
+                                          |      "response" : {
+                                          |        "status" : 200,
+                                          |        "headers" : {
+                                          |          "Content-Type" : "application/json"
+                                          |        },
+                                          |        "body" : {
+                                          |          "fish" : [
+                                          |            "cod",
+                                          |            "haddock",
+                                          |            "flying"
+                                          |          ]
+                                          |        },
+                                          |        "matchingRules" : {
+                                          |          "$.headers.Accept" : {
+                                          |            "match" : "regex",
+                                          |            "regex" : "\\w+"
+                                          |          },
+                                          |          "$.headers.Content-Length" : {
+                                          |            "match" : "type"
+                                          |          }
+                                          |        }
+                                          |      },
+                                          |      "providerState" : "a simple state"
+                                          |    },
+                                          |    {
+                                          |      "request" : {
+                                          |        "method" : "GET",
+                                          |        "body" : "fish",
+                                          |        "path" : "/fetch-json2",
+                                          |        "headers" : {
+                                          |          "Content-Type" : "text/plain"
+                                          |        }
+                                          |      },
+                                          |      "description" : "a simple request 2",
+                                          |      "response" : {
+                                          |        "status" : 200,
+                                          |        "headers" : {
+                                          |          "Content-Type" : "application/json"
+                                          |        },
+                                          |        "body" : {
+                                          |          "chips" : true,
+                                          |          "fish" : [
+                                          |            "cod",
+                                          |            "haddock"
+                                          |          ]
+                                          |        }
+                                          |      },
+                                          |      "providerState" : "a simple state 2"
+                                          |    }
+                                          |  ],
+                                          |  "_links": {
+                                          |    "self": {
+                                          |      "title": "Pact",
+                                          |      "name": "Pact between consumer (v1.0.0) and provider",
+                                          |      "href": "http://localhost/pacts/provider/provider/consumer/consumer/version/1.0.0"
+                                          |    },
+                                          |    "pb:consumer": {
+                                          |      "title": "Consumer",
+                                          |      "name": "consumer",
+                                          |      "href": "http://localhost/pacticipants/consumer"
+                                          |    },
+                                          |    "pb:provider": {
+                                          |      "title": "Provider",
+                                          |      "name": "provider",
+                                          |      "href": "http://localhost/pacticipants/provider"
+                                          |    },
+                                          |    "pb:latest-tagged-pact-version": {
+                                          |      "title": "Latest tagged version of this pact",
+                                          |      "href": "http://localhost/pacts/provider/provider-service/consumer/consumer-service/latest/{tag}",
+                                          |      "templated": true
+                                          |    },
+                                          |    "curies": [
+                                          |      {
+                                          |        "name": "pb",
+                                          |        "href": "http://localhost/doc/{rel}",
+                                          |        "templated": true
+                                          |      }
+                                          |    ]
+                                          |  }
+                                          |}""".stripMargin
+
+}

--- a/scalapact-circe-0-11/src/test/scala/com/itv/scalapact/circe11/RubyJsonHelperSpec.scala
+++ b/scalapact-circe-0-11/src/test/scala/com/itv/scalapact/circe11/RubyJsonHelperSpec.scala
@@ -1,0 +1,103 @@
+package com.itv.scalapact.circe11
+
+import com.itv.scalapact.shared._
+import org.scalatest.{FunSpec, Matchers}
+
+class RubyJsonHelperSpec extends FunSpec with Matchers {
+
+  describe("Handling ruby json") {
+
+    it("should be able to extract the provider") {
+
+      JsonBodySpecialCaseHelper.extractPactActor("provider")(PactFileExamples.simpleAsString) shouldEqual Some(
+        PactActor("provider")
+      )
+
+    }
+
+    it("should be able to extract the consumer") {
+
+      JsonBodySpecialCaseHelper.extractPactActor("consumer")(PactFileExamples.simpleAsString) shouldEqual Some(
+        PactActor("consumer")
+      )
+
+    }
+
+    it("should be able to extract a list of interactions paired with their bodies") {
+
+      val interaction1 = Interaction(
+        provider_state = None,
+        providerState = Option("a simple state"),
+        description = "a simple request",
+        request = InteractionRequest(
+          method = Option("GET"),
+          path = Option("/fetch-json"),
+          query = Option("fish=chips"),
+          headers = Option(Map("Content-Type" -> "text/plain")),
+          body = None,
+          matchingRules = Option(
+            Map(
+              "$.headers.Accept"         -> MatchingRule(`match` = Option("regex"), regex = Option("\\w+"), min = None),
+              "$.headers.Content-Length" -> MatchingRule(`match` = Option("type"), regex = None, min = None)
+            )
+          )
+        ),
+        response = InteractionResponse(
+          status = Option(200),
+          headers = Option(Map("Content-Type" -> "application/json")),
+          body = None,
+          matchingRules = Option(
+            Map(
+              "$.headers.Accept"         -> MatchingRule(`match` = Option("regex"), regex = Option("\\w+"), min = None),
+              "$.headers.Content-Length" -> MatchingRule(`match` = Option("type"), regex = None, min = None)
+            )
+          )
+        )
+      )
+      val interaction1RequestBody  = Option("fish")
+      val interaction1ResponseBody = Option("""{
+          |  "fish" : [
+          |    "cod",
+          |    "haddock",
+          |    "flying"
+          |  ]
+          |}""".stripMargin)
+
+      val interaction2 = Interaction(
+        provider_state = None,
+        providerState = Option("a simple state 2"),
+        description = "a simple request 2",
+        request = InteractionRequest(
+          method = Option("GET"),
+          path = Option("/fetch-json2"),
+          query = None,
+          headers = Option(Map("Content-Type" -> "text/plain")),
+          body = None,
+          matchingRules = None
+        ),
+        response = InteractionResponse(
+          status = Option(200),
+          headers = Option(Map("Content-Type" -> "application/json")),
+          body = None,
+          matchingRules = None
+        )
+      )
+      val interaction2RequestBody  = Option("fish")
+      val interaction2ResponseBody = Option("""{
+          |  "chips" : true,
+          |  "fish" : [
+          |    "cod",
+          |    "haddock"
+          |  ]
+          |}""".stripMargin)
+
+      val list = List(
+        (Some(interaction1), interaction1RequestBody, interaction1ResponseBody),
+        (Some(interaction2), interaction2RequestBody, interaction2ResponseBody)
+      )
+
+      JsonBodySpecialCaseHelper.extractInteractions(PactFileExamples.simpleAsString) shouldEqual Some(list)
+
+    }
+  }
+}

--- a/scalapact-circe-0-11/src/test/scala/com/itv/scalapact/circe11/ScalaPactReaderWriterSpec.scala
+++ b/scalapact-circe-0-11/src/test/scala/com/itv/scalapact/circe11/ScalaPactReaderWriterSpec.scala
@@ -1,0 +1,113 @@
+package com.itv.scalapact.circe11
+
+import io.circe.parser._
+import org.scalatest.{FunSpec, Matchers}
+
+class ScalaPactReaderWriterSpec extends FunSpec with Matchers {
+
+  val pactReader = new PactReader
+  val pactWriter = new PactWriter
+
+  describe("Reading and writing a homogeneous Pact files") {
+
+    it("should be able to read Pact files") {
+      val pactEither = pactReader.jsonStringToPact(PactFileExamples.simpleAsString)
+
+      pactEither.right.get shouldEqual PactFileExamples.simple
+    }
+
+    it("should be able to read Pact files using the old provider state key") {
+      val pactEither = pactReader.jsonStringToPact(PactFileExamples.simpleOldProviderStateAsString)
+
+      pactEither.right.get shouldEqual PactFileExamples.simple
+    }
+
+    it("should be able to write Pact files") {
+
+      val written = pactWriter.pactToJsonString(PactFileExamples.simple)
+
+      val expected = PactFileExamples.simpleAsString
+
+      parse(written).toOption.get shouldEqual parse(expected).toOption.get
+    }
+
+    it("should be able to eat it's own dog food") {
+
+      val json = pactWriter.pactToJsonString(PactFileExamples.simple)
+
+      val pact = pactReader.jsonStringToPact(json).right.get
+
+      val `reJson'd` = parse(pactWriter.pactToJsonString(pact)).toOption.get
+
+      `reJson'd` shouldEqual parse(PactFileExamples.simpleAsString).toOption.get
+
+      pact shouldEqual PactFileExamples.simple
+
+    }
+
+    it("should be able to read ruby format json") {
+      val pactEither = pactReader.jsonStringToPact(PactFileExamples.simpleAsString)
+
+      pactEither.right.get shouldEqual PactFileExamples.simple
+    }
+
+    it("should be able to write a pact file in ruby format") {
+
+      val written = pactWriter.pactToJsonString(PactFileExamples.simple)
+
+      val expected = PactFileExamples.simpleAsString
+
+      written shouldEqual expected
+
+    }
+
+    it("should be able to eat it's own dog food with no body") {
+
+      val json = pactWriter.pactToJsonString(PactFileExamples.verySimple)
+
+      val pact = pactReader.jsonStringToPact(json).right.get
+
+      val `reJson'd` = parse(pactWriter.pactToJsonString(pact)).toOption.get
+
+      `reJson'd` shouldEqual parse(PactFileExamples.verySimpleAsString).toOption.get
+
+      pact shouldEqual PactFileExamples.verySimple
+
+    }
+
+    it("should be able to read ruby format json with no body") {
+      val pactEither = pactReader.jsonStringToPact(PactFileExamples.verySimpleAsString)
+
+      pactEither.right.get shouldEqual PactFileExamples.verySimple
+    }
+
+    it("should be able to write a pact file in ruby format with no body") {
+
+      val written = pactWriter.pactToJsonString(PactFileExamples.verySimple)
+
+      val expected = PactFileExamples.verySimpleAsString
+
+      parse(written).toOption.get shouldEqual parse(expected).toOption.get
+    }
+
+    it("should be able to parse another example") {
+
+      pactReader.jsonStringToPact(PactFileExamples.anotherExample) match {
+        case Left(e) =>
+          fail(e)
+
+        case Right(pact) =>
+          pact.consumer.name shouldEqual "My Consumer"
+          pact.provider.name shouldEqual "Their Provider Service"
+          pact.interactions.head.response.body.get shouldEqual "Hello there!"
+      }
+
+    }
+
+    it("should parse _links") {
+      val pactEither = pactReader.jsonStringToPact(PactFileExamples.simpleWithLinksAsString)
+
+      pactEither.right.get shouldEqual PactFileExamples.simpleWithLinks
+    }
+  }
+}


### PR DESCRIPTION
No difference in IPactReader/Writer implementation between Circe 0.10 and 0.11 - only a `libraryDependencies` change needed