### PR TITLE
Fixed issue where if multiple params where specified only one would b…

### DIFF
--- a/scalapact-http4s-0-17/src/main/scala/com/itv/scalapact/http4s17/impl/PactStubService.scala
+++ b/scalapact-http4s-0-17/src/main/scala/com/itv/scalapact/http4s17/impl/PactStubService.scala
@@ -99,7 +99,7 @@ private object PactStubService {
             method = Option(req.method.name.toUpperCase),
             headers = req.headers,
             query =
-              if (req.params.isEmpty) None else Option(req.params.toList.map(p => p._1 + "=" + p._2).mkString("&")),
+              if (req.params.isEmpty) None else Option(req.multiParams.toList.flatMap { case (key, values) => values.map((key,_))}.map(p => p._1 + "=" + p._2).mkString("&")),
             path = Option(req.pathInfo),
             body = req.bodyAsText.runLog.map(body => Option(body.mkString)).unsafeRun(),
             matchingRules = None

--- a/scalapact-http4s-0-18/src/main/scala/com/itv/scalapact/http4s18/impl/PactStubService.scala
+++ b/scalapact-http4s-0-18/src/main/scala/com/itv/scalapact/http4s18/impl/PactStubService.scala
@@ -100,7 +100,7 @@ object PactStubService {
         InteractionRequest(
           method = Option(req.method.name.toUpperCase),
           headers = req.headers,
-          query = if (req.params.isEmpty) None else Option(req.params.toList.map(p => p._1 + "=" + p._2).mkString("&")),
+          query = if (req.params.isEmpty) None else Option(req.multiParams.toList.flatMap { case (key, values) => values.map((key,_))}.map(p => p._1 + "=" + p._2).mkString("&")),
           path = Option(req.pathInfo),
           body = req.attemptAs[String].fold(_ => None, Option.apply).unsafeRunSync(),
           matchingRules = None

--- a/scalapact-http4s-0-20/src/main/scala/com/itv/scalapact/http4s20/impl/PactStubService.scala
+++ b/scalapact-http4s-0-20/src/main/scala/com/itv/scalapact/http4s20/impl/PactStubService.scala
@@ -106,7 +106,7 @@ object PactStubService {
               h.name.toString -> h.value
             }.toMap),
             query =
-              if (req.params.isEmpty) None else Option(req.params.toList.map(p => p._1 + "=" + p._2).mkString("&")),
+              if (req.params.isEmpty) None else Option(req.multiParams.toList.flatMap { case (key, values) => values.map((key,_))}.map(p => p._1 + "=" + p._2).mkString("&")),
             path = Option(req.pathInfo),
             body = maybeBody,
             matchingRules = None


### PR DESCRIPTION
If multiple query params with the same key are provided (e.g. `/bar?foo=1&foo=2`), only one would be used meaning that a test with that url would fail. (the issue is associated with the usage of req.params which returns a `Map[String,String]` instead of `req.multiParams` which results in a `Map[String,List[String]]` 

All tests are green (including running `local-build-test.sh`)