### PR TITLE
Versions / docs update following 2.3.9 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ A Consumer Driven Contract testing library for Scala and [ScalaTest](http://www.
 
 Scala-Pact is intended for Scala developers who are looking for a better way to manage the HTTP contracts between their services.
 
-## Latest version is 2.3.8
+## Latest version is 2.3.9
 
 Scala-Pact now has two branches based on SBT requirements.
 
-#### SBT 1.x compatible (Latest 2.3.8)
+#### SBT 1.x compatible (Latest 2.3.9)
 
-The all development going forward begins at `2.3.x` and resides on the `master` branch.
+All development going forward begins at `2.3.x` and resides on the `master` branch.
 For the sake of the maintainer's sanity, version 2.3.x and beyond will only support Scala 2.12 and SBT 1.x or greater.
 
 #### SBT 0.13.x compatible (Latest 2.2.5)
@@ -40,27 +40,27 @@ import com.itv.scalapact.plugin._
 enablePlugins(ScalaPactPlugin)
         
 libraryDependencies ++= Seq(
-  "com.itv"       %% "scalapact-circe-0-9"     % "2.3.8" % "test",
-  "com.itv"       %% "scalapact-http4s-0-18"   % "2.3.8" % "test",
-  "com.itv"       %% "scalapact-scalatest"     % "2.3.8" % "test",
+  "com.itv"       %% "scalapact-circe-0-9"     % "2.3.9" % "test",
+  "com.itv"       %% "scalapact-http4s-0-18"   % "2.3.9" % "test",
+  "com.itv"       %% "scalapact-scalatest"     % "2.3.9" % "test",
   "org.scalatest" %% "scalatest"               % "3.0.5" % "test"
 )
 ```
 
 Add this line to your `project/plugins.sbt` file to install the plugin:
 ```scala
-addSbtPlugin("com.itv" % "sbt-scalapact" % "2.3.8")
+addSbtPlugin("com.itv" % "sbt-scalapact" % "2.3.9")
 ```
 This version of the plugin comes pre-packaged with the latest JSON and Http libraries.
 Thanks to the way SBT works, that one plugin line will work in most cases, but if you're still having conflicts, you can also do this to use your preferred libraries:
 
 ```scala
  libraryDependencies ++= Seq(
-   "com.itv" %% "scalapact-argonaut-6-2" % "2.3.8",
-   "com.itv" %% "scalapact-http4s-0-16a" % "2.3.8"
+   "com.itv" %% "scalapact-argonaut-6-2" % "2.3.9",
+   "com.itv" %% "scalapact-http4s-0-16a" % "2.3.9"
  )
  
- addSbtPlugin("com.itv" % "sbt-scalapact-nodeps" % "2.3.8")
+ addSbtPlugin("com.itv" % "sbt-scalapact-nodeps" % "2.3.9")
 ```
 
 In your test suite, you will need the following imports:

--- a/build.sbt
+++ b/build.sbt
@@ -61,7 +61,7 @@ addCommandAlias(
 )
 
 lazy val commonSettings = Seq(
-  version := "2.3.9-SNAPSHOT",
+  version := "2.3.10-SNAPSHOT",
   organization := "com.itv",
   scalaVersion := scala212,
   libraryDependencies ++= Seq(

--- a/example/consumer/build.sbt
+++ b/example/consumer/build.sbt
@@ -12,9 +12,9 @@ enablePlugins(ScalaPactPlugin)
 
 libraryDependencies ++=
   Seq(
-    "com.itv"       %% "scalapact-circe-0-9"   % "2.3.9-SNAPSHOT" % "test",
-    "com.itv"       %% "scalapact-http4s-0-18" % "2.3.9-SNAPSHOT" % "test",
-    "com.itv"       %% "scalapact-scalatest"   % "2.3.9-SNAPSHOT" % "test",
+    "com.itv"       %% "scalapact-circe-0-9"   % "2.3.10-SNAPSHOT" % "test",
+    "com.itv"       %% "scalapact-http4s-0-18" % "2.3.10-SNAPSHOT" % "test",
+    "com.itv"       %% "scalapact-scalatest"   % "2.3.10-SNAPSHOT" % "test",
     "org.scalaj"    %% "scalaj-http"           % "2.3.0",
     "org.slf4j"     % "slf4j-simple"           % "1.6.4",
     "org.json4s"    %% "json4s-native"         % "3.5.0",

--- a/example/consumer/project/plugins.sbt
+++ b/example/consumer/project/plugins.sbt
@@ -1,2 +1,2 @@
 
-addSbtPlugin("com.itv" % "sbt-scalapact" % "2.3.9-SNAPSHOT")
+addSbtPlugin("com.itv" % "sbt-scalapact" % "2.3.10-SNAPSHOT")

--- a/example/provider/project/plugins.sbt
+++ b/example/provider/project/plugins.sbt
@@ -1,6 +1,6 @@
 libraryDependencies ++= Seq(
-  "com.itv" %% "scalapact-argonaut-6-2" % "2.3.9-SNAPSHOT",
-  "com.itv" %% "scalapact-http4s-0-16a" % "2.3.9-SNAPSHOT"
+  "com.itv" %% "scalapact-argonaut-6-2" % "2.3.10-SNAPSHOT",
+  "com.itv" %% "scalapact-http4s-0-16a" % "2.3.10-SNAPSHOT"
 )
 
-addSbtPlugin("com.itv" % "sbt-scalapact-nodeps" % "2.3.9-SNAPSHOT")
+addSbtPlugin("com.itv" % "sbt-scalapact-nodeps" % "2.3.10-SNAPSHOT")

--- a/example/provider_tests/build.sbt
+++ b/example/provider_tests/build.sbt
@@ -13,9 +13,9 @@ libraryDependencies ++=
     "org.http4s"    %% "http4s-circe"          % "0.18.9",
     "org.slf4j"     % "slf4j-simple"           % "1.6.4",
     "org.scalatest" %% "scalatest"             % "3.0.1" % "test",
-    "com.itv"       %% "scalapact-circe-0-9"   % "2.3.9-SNAPSHOT" % "test",
-    "com.itv"       %% "scalapact-http4s-0-18" % "2.3.9-SNAPSHOT" % "test",
-    "com.itv"       %% "scalapact-scalatest"   % "2.3.9-SNAPSHOT" % "test",
+    "com.itv"       %% "scalapact-circe-0-9"   % "2.3.10-SNAPSHOT" % "test",
+    "com.itv"       %% "scalapact-http4s-0-18" % "2.3.10-SNAPSHOT" % "test",
+    "com.itv"       %% "scalapact-scalatest"   % "2.3.10-SNAPSHOT" % "test",
     // Optional for auto-derivation of JSON codecs
     "io.circe" %% "circe-generic" % "0.9.0",
     // Optional for string interpolation to JSON model

--- a/scalapact-docs/src/main/paradox/change-log.md
+++ b/scalapact-docs/src/main/paradox/change-log.md
@@ -26,9 +26,39 @@ With thanks to all contributors!
 - [Paulymorph]
 - [jnatten]
 - [randbw]
+- [ShahOdin]
+- [aggenebbisj]
+- [mcarolan]
+- [cmcmteixeira]
+- [chrischivers]
+- [jacemale]
+- [dantb]
+- [razerno]
 - ...your name here? :-)
 
 Maintained by [davesmith00000].
+
+## 2.3.9 - 2019-06-27
+
+- Add pact metadata to generated contracts (Fixes [#84](https://github.com/ITV/scala-pact/issues/84)) ([davesmith00000])
+- Support finalising a `ScalaPactDescription` within the `ScalaPactForger` DSL (Fixes [#134](https://github.com/ITV/scala-pact/issues/134)) ([razerno])
+- Refactored squashPactFiles method in SBT plugin ([dantb])
+- Added support for token based Pact Broker authentication (Fixes [#140](https://github.com/ITV/scala-pact/issues/140)) ([dantb])
+
+## 2.3.8 - 2019-04-26
+- Added support for Http4s 0.20.0 ([jacemale])
+
+## 2.3.6 - 2019-04-13
+- Bugfix: Use correct `Headers` apply function in `Http4sRequestResponseFactory` ([davesmith00000])
+- Use recommended scalafix SBT JVM memory settings ([davesmith00000])
+- Added Http4s 0.20.0-M4 support ([chrischivers])
+- Fix handling of URL parameter lists in `PactStubService` ([cmcmteixeira])
+
+## 2.3.5 - 2019-02-15
+- Added support for Circe 0.11 ([mcarolan])
+- Fix typo in `ScalaPactVerify` ([aggenebbisj])
+- Documentation corrections ([ShahOdin])
+- Remove milestone version from package name ([randbw])
 
 ## 2.3.4 - 2018-12-31
 
@@ -206,3 +236,11 @@ Other improvements for contributors:
 [Paulymorph]: https://github.com/Paulymorph
 [jnatten]: https://github.com/jnatten
 [randbw]: https://github.com/randbw
+[ShahOdin]: https://github.com/ShahOdin
+[aggenebbisj]: https://github.com/aggenebbisj
+[mcarolan]: https://github.com/mcarolan
+[cmcmteixeira]: https://github.com/cmcmteixeira
+[chrischivers]: https://github.com/chrischivers
+[jacemale]: https://github.com/jacemale
+[dantb]: https://github.com/dantb
+[razerno]: https://github.com/razerno

--- a/scalapact-docs/src/main/paradox/setup.md
+++ b/scalapact-docs/src/main/paradox/setup.md
@@ -9,7 +9,7 @@ As of version 2.2.0, both the test framework and the plugin require you to speci
 
 Scala-Pact now has two branches based on SBT requirements.
 
-#### SBT 1.x compatible (Latest 2.3.4)
+#### SBT 1.x compatible (Latest 2.3.9)
 
 The all development going forward begins at `2.3.x` and resides on the `master` branch.
 For the sake of the maintainer's sanity, version 2.3.x and beyond will only support Scala 2.12 and SBT 1.x or greater.
@@ -36,27 +36,27 @@ import com.itv.scalapact.plugin._
 enablePlugins(ScalaPactPlugin)
         
 libraryDependencies ++= Seq(
-  "com.itv"       %% "scalapact-circe-0-9"     % "2.3.4" % "test",
-  "com.itv"       %% "scalapact-http4s-0-18"   % "2.3.4" % "test",
-  "com.itv"       %% "scalapact-scalatest"     % "2.3.4" % "test",
+  "com.itv"       %% "scalapact-circe-0-9"     % "2.3.9" % "test",
+  "com.itv"       %% "scalapact-http4s-0-18"   % "2.3.9" % "test",
+  "com.itv"       %% "scalapact-scalatest"     % "2.3.9" % "test",
   "org.scalatest" %% "scalatest"               % "3.0.5" % "test"
 )
 ```
 
 Add this line to your `project/plugins.sbt` file to install the plugin:
 ```
-addSbtPlugin("com.itv" % "sbt-scalapact" % "2.3.4")
+addSbtPlugin("com.itv" % "sbt-scalapact" % "2.3.9")
 ```
 This version of the plugin comes pre-packaged with the latest JSON and Http libraries.
 Thanks to the way SBT works, that one plugin line will work in most cases, but if you're still having conflicts, you can also do this to use your preferred libraries:
 
 ```
  libraryDependencies ++= Seq(
-   "com.itv" %% "scalapact-argonaut-6-2" % "2.3.4",
-   "com.itv" %% "scalapact-http4s-0-16a" % "2.3.4"
+   "com.itv" %% "scalapact-argonaut-6-2" % "2.3.9",
+   "com.itv" %% "scalapact-http4s-0-16a" % "2.3.9"
  )
  
- addSbtPlugin("com.itv" % "sbt-scalapact-nodeps" % "2.3.4")
+ addSbtPlugin("com.itv" % "sbt-scalapact-nodeps" % "2.3.9")
 ```
 
 In you're test suite, you will need the following imports:
@@ -86,17 +86,17 @@ Please check the @ref:[compatibility matrix](project-deps.md) before using.
 
 JSON Libraries
 ```
-"com.itv" %% "scalapact-argonaut-6-2"  % "2.3.4"
-"com.itv" %% "scalapact-circe-0-8"     % "2.3.4"
-"com.itv" %% "scalapact-circe-0-9"     % "2.3.4"
-"com.itv" %% "scalapact-circe-0-10"    % "2.3.4"
+"com.itv" %% "scalapact-argonaut-6-2"  % "2.3.9"
+"com.itv" %% "scalapact-circe-0-8"     % "2.3.9"
+"com.itv" %% "scalapact-circe-0-9"     % "2.3.9"
+"com.itv" %% "scalapact-circe-0-10"    % "2.3.9"
 ```
 
 HTTP Libraries
 ```
-"com.itv" %% "scalapact-http4s-0-16a"  % "2.3.4"
-"com.itv" %% "scalapact-http4s-0-17"   % "2.3.4"
-"com.itv" %% "scalapact-http4s-0-18"   % "2.3.4"
+"com.itv" %% "scalapact-http4s-0-16a"  % "2.3.9"
+"com.itv" %% "scalapact-http4s-0-17"   % "2.3.9"
+"com.itv" %% "scalapact-http4s-0-18"   % "2.3.9"
 ```
 
 ### You're using SBT 0.13.17 or lower:


### PR DESCRIPTION
Have to tried to fill in the changelog gaps where possible (by looking at https://repo1.maven.org/maven2/com/itv/). Let me know if anything is missing @davesmith00000 

Sticking to the current mechanism of a snapshot version so the example projects won't compile on master - looking into ways we can improve the versioning and multi-project management generally