### PR TITLE
Fix results publisher request format

### DIFF
--- a/scalapact-http4s-0-16a/src/main/scala/com/itv/scalapact/http4s16a/impl/ResultPublisher.scala
+++ b/scalapact-http4s-0-16a/src/main/scala/com/itv/scalapact/http4s16a/impl/ResultPublisher.scala
@@ -53,6 +53,6 @@ class ResultPublisher(fetcher: (SimpleRequest, Client) => Task[SimpleResponse]) 
 
   private def body(brokerPublishData: BrokerPublishData, success: Boolean) = {
     val buildUrl = brokerPublishData.buildUrl.fold("")(u => s""", "buildUrl": "$u"""")
-    Option(s"""{ "success": "$success", "providerApplicationVersion": "${brokerPublishData.providerVersion}"$buildUrl }""")
+    Option(s"""{ "success": $success, "providerApplicationVersion": "${brokerPublishData.providerVersion}"$buildUrl }""")
   }
 }

--- a/scalapact-http4s-0-16a/src/test/scala/com/itv/scalapact/http4s16a/impl/ResultPublisherSpec.scala
+++ b/scalapact-http4s-0-16a/src/test/scala/com/itv/scalapact/http4s16a/impl/ResultPublisherSpec.scala
@@ -81,7 +81,7 @@ class ResultPublisherSpec extends FunSpec with Matchers with BeforeAndAfter {
         "",
         HttpMethod.POST,
         Map("Content-Type" -> "application/json; charset=UTF-8"),
-        Option("""{ "success": "true", "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""),
+        Option("""{ "success": true, "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""),
         None
       )
       requests shouldBe ArrayBuffer(successfulRequest)
@@ -98,7 +98,7 @@ class ResultPublisherSpec extends FunSpec with Matchers with BeforeAndAfter {
         "",
         HttpMethod.POST,
         Map("Content-Type" -> "application/json; charset=UTF-8"),
-        Option("""{ "success": "true", "providerApplicationVersion": "1.0.0" }"""),
+        Option("""{ "success": true, "providerApplicationVersion": "1.0.0" }"""),
         None
       )
       requests shouldBe ArrayBuffer(successfulRequest)
@@ -114,7 +114,7 @@ class ResultPublisherSpec extends FunSpec with Matchers with BeforeAndAfter {
         "",
         HttpMethod.POST,
         Map("Content-Type" -> "application/json; charset=UTF-8"),
-        Option("""{ "success": "false", "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""),
+        Option("""{ "success": false, "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""),
         None
       )
       requests shouldBe ArrayBuffer(failedRequest)
@@ -137,7 +137,7 @@ class ResultPublisherSpec extends FunSpec with Matchers with BeforeAndAfter {
       resultPublisher.publishResults(pactVerifyResults, brokerPublishData, PactBrokerAuthorization(("username", "password"), ""))
 
       val successfulRequest = SimpleRequest(
-        publishUrl, "", HttpMethod.POST, Map("Content-Type" -> "application/json; charset=UTF-8") + expectedHeader, Option("""{ "success": "true", "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""), None
+        publishUrl, "", HttpMethod.POST, Map("Content-Type" -> "application/json; charset=UTF-8") + expectedHeader, Option("""{ "success": true, "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""), None
       )
       requests shouldBe ArrayBuffer(successfulRequest)
     }
@@ -149,7 +149,7 @@ class ResultPublisherSpec extends FunSpec with Matchers with BeforeAndAfter {
       resultPublisher.publishResults(pactVerifyResults, brokerPublishData, PactBrokerAuthorization(("", ""), token))
 
       val successfulRequest = SimpleRequest(
-        publishUrl, "", HttpMethod.POST, Map("Content-Type" -> "application/json; charset=UTF-8") + expectedHeader, Option("""{ "success": "true", "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""), None
+        publishUrl, "", HttpMethod.POST, Map("Content-Type" -> "application/json; charset=UTF-8") + expectedHeader, Option("""{ "success": true, "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""), None
       )
       requests shouldBe ArrayBuffer(successfulRequest)
     }
@@ -158,7 +158,7 @@ class ResultPublisherSpec extends FunSpec with Matchers with BeforeAndAfter {
       resultPublisher.publishResults(pactVerifyResults, brokerPublishData, None)
 
       val successfulRequest = SimpleRequest(
-        publishUrl, "", HttpMethod.POST, Map("Content-Type" -> "application/json; charset=UTF-8"), Option("""{ "success": "true", "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""), None
+        publishUrl, "", HttpMethod.POST, Map("Content-Type" -> "application/json; charset=UTF-8"), Option("""{ "success": true, "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""), None
       )
       requests shouldBe ArrayBuffer(successfulRequest)
     }

--- a/scalapact-http4s-0-17/src/main/scala/com/itv/scalapact/http4s17/impl/ResultPublisher.scala
+++ b/scalapact-http4s-0-17/src/main/scala/com/itv/scalapact/http4s17/impl/ResultPublisher.scala
@@ -48,6 +48,6 @@ class ResultPublisher(fetcher: (SimpleRequest, Client) => Task[SimpleResponse]) 
 
   private def body(brokerPublishData: BrokerPublishData, success: Boolean) = {
     val buildUrl = brokerPublishData.buildUrl.fold("")(u => s""", "buildUrl": "$u"""")
-    Option(s"""{ "success": "$success", "providerApplicationVersion": "${brokerPublishData.providerVersion}"$buildUrl }""")
+    Option(s"""{ "success": $success, "providerApplicationVersion": "${brokerPublishData.providerVersion}"$buildUrl }""")
   }
 }

--- a/scalapact-http4s-0-17/src/test/scala/com/itv/scalapact/http4s17/impl/ResultPublisherSpec.scala
+++ b/scalapact-http4s-0-17/src/test/scala/com/itv/scalapact/http4s17/impl/ResultPublisherSpec.scala
@@ -81,7 +81,7 @@ class ResultPublisherSpec extends FunSpec with Matchers with BeforeAndAfter {
         "",
         HttpMethod.POST,
         Map("Content-Type" -> "application/json; charset=UTF-8"),
-        Option("""{ "success": "true", "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""),
+        Option("""{ "success": true, "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""),
         None
       )
       requests shouldBe ArrayBuffer(successfulRequest)
@@ -98,7 +98,7 @@ class ResultPublisherSpec extends FunSpec with Matchers with BeforeAndAfter {
         "",
         HttpMethod.POST,
         Map("Content-Type" -> "application/json; charset=UTF-8"),
-        Option("""{ "success": "true", "providerApplicationVersion": "1.0.0" }"""),
+        Option("""{ "success": true, "providerApplicationVersion": "1.0.0" }"""),
         None
       )
       requests shouldBe ArrayBuffer(successfulRequest)
@@ -114,7 +114,7 @@ class ResultPublisherSpec extends FunSpec with Matchers with BeforeAndAfter {
         "",
         HttpMethod.POST,
         Map("Content-Type" -> "application/json; charset=UTF-8"),
-        Option("""{ "success": "false", "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""),
+        Option("""{ "success": false, "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""),
         None
       )
       requests shouldBe ArrayBuffer(failedRequest)
@@ -135,7 +135,7 @@ class ResultPublisherSpec extends FunSpec with Matchers with BeforeAndAfter {
       resultPublisher.publishResults(pactVerifyResults, brokerPublishData, PactBrokerAuthorization(("username", "password"), ""))
 
       val successfulRequest = SimpleRequest(
-        publishUrl, "", HttpMethod.POST, Map("Content-Type" -> "application/json; charset=UTF-8") + expectedHeader, Option("""{ "success": "true", "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""), None
+        publishUrl, "", HttpMethod.POST, Map("Content-Type" -> "application/json; charset=UTF-8") + expectedHeader, Option("""{ "success": true, "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""), None
       )
       requests shouldBe ArrayBuffer(successfulRequest)
     }
@@ -147,7 +147,7 @@ class ResultPublisherSpec extends FunSpec with Matchers with BeforeAndAfter {
       resultPublisher.publishResults(pactVerifyResults, brokerPublishData, PactBrokerAuthorization(("", ""), token))
 
       val successfulRequest = SimpleRequest(
-        publishUrl, "", HttpMethod.POST, Map("Content-Type" -> "application/json; charset=UTF-8") + expectedHeader, Option("""{ "success": "true", "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""), None
+        publishUrl, "", HttpMethod.POST, Map("Content-Type" -> "application/json; charset=UTF-8") + expectedHeader, Option("""{ "success": true, "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""), None
       )
       requests shouldBe ArrayBuffer(successfulRequest)
     }
@@ -156,7 +156,7 @@ class ResultPublisherSpec extends FunSpec with Matchers with BeforeAndAfter {
       resultPublisher.publishResults(pactVerifyResults, brokerPublishData, None)
 
       val successfulRequest = SimpleRequest(
-        publishUrl, "", HttpMethod.POST, Map("Content-Type" -> "application/json; charset=UTF-8"), Option("""{ "success": "true", "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""), None
+        publishUrl, "", HttpMethod.POST, Map("Content-Type" -> "application/json; charset=UTF-8"), Option("""{ "success": true, "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""), None
       )
       requests shouldBe ArrayBuffer(successfulRequest)
     }

--- a/scalapact-http4s-0-18/src/main/scala/com/itv/scalapact/http4s18/impl/ResultPublisher.scala
+++ b/scalapact-http4s-0-18/src/main/scala/com/itv/scalapact/http4s18/impl/ResultPublisher.scala
@@ -60,7 +60,7 @@ class ResultPublisher(fetcher: (SimpleRequest, IO[Client[IO]]) => IO[SimpleRespo
   }
   private def body(brokerPublishData: BrokerPublishData, success: Boolean) = {
     val buildUrl = brokerPublishData.buildUrl.fold("")(u => s""", "buildUrl": "$u"""")
-    Option(s"""{ "success": "$success", "providerApplicationVersion": "${brokerPublishData.providerVersion}"$buildUrl }""")
+    Option(s"""{ "success": $success, "providerApplicationVersion": "${brokerPublishData.providerVersion}"$buildUrl }""")
   }
 
 }

--- a/scalapact-http4s-0-18/src/test/scala/com/itv/scalapact/http4s18/impl/ResultPublisherSpec.scala
+++ b/scalapact-http4s-0-18/src/test/scala/com/itv/scalapact/http4s18/impl/ResultPublisherSpec.scala
@@ -81,7 +81,7 @@ class ResultPublisherSpec extends FunSpec with Matchers with BeforeAndAfter {
         "",
         HttpMethod.POST,
         Map("Content-Type" -> "application/json; charset=UTF-8"),
-        Option("""{ "success": "true", "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""),
+        Option("""{ "success": true, "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""),
         None
       )
       requests shouldBe ArrayBuffer(successfulRequest)
@@ -98,7 +98,7 @@ class ResultPublisherSpec extends FunSpec with Matchers with BeforeAndAfter {
         "",
         HttpMethod.POST,
         Map("Content-Type" -> "application/json; charset=UTF-8"),
-        Option("""{ "success": "true", "providerApplicationVersion": "1.0.0" }"""),
+        Option("""{ "success": true, "providerApplicationVersion": "1.0.0" }"""),
         None
       )
       requests shouldBe ArrayBuffer(successfulRequest)
@@ -114,7 +114,7 @@ class ResultPublisherSpec extends FunSpec with Matchers with BeforeAndAfter {
         "",
         HttpMethod.POST,
         Map("Content-Type" -> "application/json; charset=UTF-8"),
-        Option("""{ "success": "false", "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""),
+        Option("""{ "success": false, "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""),
         None
       )
       requests shouldBe ArrayBuffer(failedRequest)
@@ -137,7 +137,7 @@ class ResultPublisherSpec extends FunSpec with Matchers with BeforeAndAfter {
       resultPublisher.publishResults(pactVerifyResults, brokerPublishData, PactBrokerAuthorization(("username", "password"), ""))
 
       val successfulRequest = SimpleRequest(
-        publishUrl, "", HttpMethod.POST, Map("Content-Type" -> "application/json; charset=UTF-8") + expectedHeader, Option("""{ "success": "true", "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""), None
+        publishUrl, "", HttpMethod.POST, Map("Content-Type" -> "application/json; charset=UTF-8") + expectedHeader, Option("""{ "success": true, "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""), None
       )
       requests shouldBe ArrayBuffer(successfulRequest)
     }
@@ -149,7 +149,7 @@ class ResultPublisherSpec extends FunSpec with Matchers with BeforeAndAfter {
       resultPublisher.publishResults(pactVerifyResults, brokerPublishData, PactBrokerAuthorization(("", ""), token))
 
       val successfulRequest = SimpleRequest(
-        publishUrl, "", HttpMethod.POST, Map("Content-Type" -> "application/json; charset=UTF-8") + expectedHeader, Option("""{ "success": "true", "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""), None
+        publishUrl, "", HttpMethod.POST, Map("Content-Type" -> "application/json; charset=UTF-8") + expectedHeader, Option("""{ "success": true, "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""), None
       )
       requests shouldBe ArrayBuffer(successfulRequest)
     }
@@ -158,7 +158,7 @@ class ResultPublisherSpec extends FunSpec with Matchers with BeforeAndAfter {
       resultPublisher.publishResults(pactVerifyResults, brokerPublishData, None)
 
       val successfulRequest = SimpleRequest(
-        publishUrl, "", HttpMethod.POST, Map("Content-Type" -> "application/json; charset=UTF-8"), Option("""{ "success": "true", "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""), None
+        publishUrl, "", HttpMethod.POST, Map("Content-Type" -> "application/json; charset=UTF-8"), Option("""{ "success": true, "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""), None
       )
       requests shouldBe ArrayBuffer(successfulRequest)
     }

--- a/scalapact-http4s-0-20/src/main/scala/com/itv/scalapact/http4s20/impl/ResultPublisher.scala
+++ b/scalapact-http4s-0-20/src/main/scala/com/itv/scalapact/http4s20/impl/ResultPublisher.scala
@@ -71,7 +71,7 @@ class ResultPublisher(fetcher: (SimpleRequest, Resource[IO, Client[IO]]) => IO[S
   private def body(brokerPublishData: BrokerPublishData, success: Boolean): Option[String] = {
     val buildUrl = brokerPublishData.buildUrl.fold("")(u => s""", "buildUrl": "$u"""")
     Option(
-      s"""{ "success": "$success", "providerApplicationVersion": "${brokerPublishData.providerVersion}"$buildUrl }"""
+      s"""{ "success": $success, "providerApplicationVersion": "${brokerPublishData.providerVersion}"$buildUrl }"""
     )
   }
 }

--- a/scalapact-http4s-0-20/src/test/scala/com/itv/scalapact/http4s/http4s20/impl/ResultPublisherSpec.scala
+++ b/scalapact-http4s-0-20/src/test/scala/com/itv/scalapact/http4s/http4s20/impl/ResultPublisherSpec.scala
@@ -83,7 +83,7 @@ class ResultPublisherSpec extends FunSpec with Matchers with BeforeAndAfter {
         "",
         HttpMethod.POST,
         Map("Content-Type" -> "application/json; charset=UTF-8"),
-        Option("""{ "success": "true", "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""),
+        Option("""{ "success": true, "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""),
         None
       )
       requests shouldBe ArrayBuffer(successfulRequest)
@@ -100,7 +100,7 @@ class ResultPublisherSpec extends FunSpec with Matchers with BeforeAndAfter {
         "",
         HttpMethod.POST,
         Map("Content-Type" -> "application/json; charset=UTF-8"),
-        Option("""{ "success": "true", "providerApplicationVersion": "1.0.0" }"""),
+        Option("""{ "success": true, "providerApplicationVersion": "1.0.0" }"""),
         None
       )
       requests shouldBe ArrayBuffer(successfulRequest)
@@ -116,7 +116,7 @@ class ResultPublisherSpec extends FunSpec with Matchers with BeforeAndAfter {
         "",
         HttpMethod.POST,
         Map("Content-Type" -> "application/json; charset=UTF-8"),
-        Option("""{ "success": "false", "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""),
+        Option("""{ "success": false, "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""),
         None
       )
       requests shouldBe ArrayBuffer(failedRequest)
@@ -139,7 +139,7 @@ class ResultPublisherSpec extends FunSpec with Matchers with BeforeAndAfter {
       resultPublisher.publishResults(pactVerifyResults, brokerPublishData, PactBrokerAuthorization(("username", "password"), ""))
 
       val successfulRequest = SimpleRequest(
-        publishUrl, "", HttpMethod.POST, Map("Content-Type" -> "application/json; charset=UTF-8") + expectedHeader, Option("""{ "success": "true", "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""), None
+        publishUrl, "", HttpMethod.POST, Map("Content-Type" -> "application/json; charset=UTF-8") + expectedHeader, Option("""{ "success": true, "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""), None
       )
       requests shouldBe ArrayBuffer(successfulRequest)
     }
@@ -151,7 +151,7 @@ class ResultPublisherSpec extends FunSpec with Matchers with BeforeAndAfter {
       resultPublisher.publishResults(pactVerifyResults, brokerPublishData, PactBrokerAuthorization(("", ""), token))
 
       val successfulRequest = SimpleRequest(
-        publishUrl, "", HttpMethod.POST, Map("Content-Type" -> "application/json; charset=UTF-8") + expectedHeader, Option("""{ "success": "true", "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""), None
+        publishUrl, "", HttpMethod.POST, Map("Content-Type" -> "application/json; charset=UTF-8") + expectedHeader, Option("""{ "success": true, "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""), None
       )
       requests shouldBe ArrayBuffer(successfulRequest)
     }
@@ -160,7 +160,7 @@ class ResultPublisherSpec extends FunSpec with Matchers with BeforeAndAfter {
       resultPublisher.publishResults(pactVerifyResults, brokerPublishData, None)
 
       val successfulRequest = SimpleRequest(
-        publishUrl, "", HttpMethod.POST, Map("Content-Type" -> "application/json; charset=UTF-8"), Option("""{ "success": "true", "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""), None
+        publishUrl, "", HttpMethod.POST, Map("Content-Type" -> "application/json; charset=UTF-8"), Option("""{ "success": true, "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""), None
       )
       requests shouldBe ArrayBuffer(successfulRequest)
     }

--- a/scalapact-http4s-0-21/src/main/scala/com/itv/scalapact/http4s21/impl/ResultPublisher.scala
+++ b/scalapact-http4s-0-21/src/main/scala/com/itv/scalapact/http4s21/impl/ResultPublisher.scala
@@ -71,7 +71,7 @@ class ResultPublisher(fetcher: (SimpleRequest, Resource[IO, Client[IO]]) => IO[S
   private def body(brokerPublishData: BrokerPublishData, success: Boolean): Option[String] = {
     val buildUrl = brokerPublishData.buildUrl.fold("")(u => s""", "buildUrl": "$u"""")
     Option(
-      s"""{ "success": "$success", "providerApplicationVersion": "${brokerPublishData.providerVersion}"$buildUrl }"""
+      s"""{ "success": $success, "providerApplicationVersion": "${brokerPublishData.providerVersion}"$buildUrl }"""
     )
   }
 }

--- a/scalapact-http4s-0-21/src/test/scala/com/itv/scalapact/http4s/http4s21/impl/ResultPublisherSpec.scala
+++ b/scalapact-http4s-0-21/src/test/scala/com/itv/scalapact/http4s/http4s21/impl/ResultPublisherSpec.scala
@@ -83,7 +83,7 @@ class ResultPublisherSpec extends FunSpec with Matchers with BeforeAndAfter {
         "",
         HttpMethod.POST,
         Map("Content-Type" -> "application/json; charset=UTF-8"),
-        Option("""{ "success": "true", "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""),
+        Option("""{ "success": true, "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""),
         None
       )
       requests shouldBe ArrayBuffer(successfulRequest)
@@ -100,7 +100,7 @@ class ResultPublisherSpec extends FunSpec with Matchers with BeforeAndAfter {
         "",
         HttpMethod.POST,
         Map("Content-Type" -> "application/json; charset=UTF-8"),
-        Option("""{ "success": "true", "providerApplicationVersion": "1.0.0" }"""),
+        Option("""{ "success": true, "providerApplicationVersion": "1.0.0" }"""),
         None
       )
       requests shouldBe ArrayBuffer(successfulRequest)
@@ -116,7 +116,7 @@ class ResultPublisherSpec extends FunSpec with Matchers with BeforeAndAfter {
         "",
         HttpMethod.POST,
         Map("Content-Type" -> "application/json; charset=UTF-8"),
-        Option("""{ "success": "false", "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""),
+        Option("""{ "success": false, "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""),
         None
       )
       requests shouldBe ArrayBuffer(failedRequest)
@@ -139,7 +139,7 @@ class ResultPublisherSpec extends FunSpec with Matchers with BeforeAndAfter {
       resultPublisher.publishResults(pactVerifyResults, brokerPublishData, PactBrokerAuthorization(("username", "password"), ""))
 
       val successfulRequest = SimpleRequest(
-        publishUrl, "", HttpMethod.POST, Map("Content-Type" -> "application/json; charset=UTF-8") + expectedHeader, Option("""{ "success": "true", "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""), None
+        publishUrl, "", HttpMethod.POST, Map("Content-Type" -> "application/json; charset=UTF-8") + expectedHeader, Option("""{ "success": true, "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""), None
       )
       requests shouldBe ArrayBuffer(successfulRequest)
     }
@@ -151,7 +151,7 @@ class ResultPublisherSpec extends FunSpec with Matchers with BeforeAndAfter {
       resultPublisher.publishResults(pactVerifyResults, brokerPublishData, PactBrokerAuthorization(("", ""), token))
 
       val successfulRequest = SimpleRequest(
-        publishUrl, "", HttpMethod.POST, Map("Content-Type" -> "application/json; charset=UTF-8") + expectedHeader, Option("""{ "success": "true", "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""), None
+        publishUrl, "", HttpMethod.POST, Map("Content-Type" -> "application/json; charset=UTF-8") + expectedHeader, Option("""{ "success": true, "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""), None
       )
       requests shouldBe ArrayBuffer(successfulRequest)
     }
@@ -160,7 +160,7 @@ class ResultPublisherSpec extends FunSpec with Matchers with BeforeAndAfter {
       resultPublisher.publishResults(pactVerifyResults, brokerPublishData, None)
 
       val successfulRequest = SimpleRequest(
-        publishUrl, "", HttpMethod.POST, Map("Content-Type" -> "application/json; charset=UTF-8"), Option("""{ "success": "true", "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""), None
+        publishUrl, "", HttpMethod.POST, Map("Content-Type" -> "application/json; charset=UTF-8"), Option("""{ "success": true, "providerApplicationVersion": "1.0.0", "buildUrl": "http://buildUrl.com" }"""), None
       )
       requests shouldBe ArrayBuffer(successfulRequest)
     }


### PR DESCRIPTION
On broker version 2.58.0 (only tested against this version), the `success` field is expected to be a proper JSON boolean instead of a string. Posting a `"true"` or `"false"` JSON string in the request body results in HTTP 400 broker response:
```
{
  "errors": {
    "success": [
      "must be boolean"
    ]
  }
}