### PR TITLE
uncomplicate the verification properties model

### DIFF
--- a/scalapact-circe-0-13/src/main/scala/com/itv/scalapact/circe13/PactImplicits.scala
+++ b/scalapact-circe-0-13/src/main/scala/com/itv/scalapact/circe13/PactImplicits.scala
@@ -1,7 +1,6 @@
 package com.itv.scalapact.circe13
 
 import com.itv.scalapact.shared.Notice._
-import com.itv.scalapact.shared.VerificationProperties._
 import com.itv.scalapact.shared._
 import io.circe.{Codec, Decoder, DecodingFailure, Encoder, Json, parser}
 import io.circe.generic.semiauto.{deriveCodec, deriveDecoder, deriveEncoder}
@@ -101,12 +100,12 @@ object PactImplicits {
   implicit val embeddedPactForVerificationDecoder: Decoder[PactForVerification]           = deriveDecoder
 
   implicit val simpleNoticeDecoder: Decoder[SimpleNotice] = deriveDecoder
-  implicit val pendingStateNoticeDecoder: Decoder[PendingStateNotice] = Decoder.instance { cur =>
+  implicit val pendingStateNoticeDecoder: Decoder[Notice] = Decoder.instance { cur =>
     lazy val pattern = "after_verification:success_(true|false)_published_(true|false)".r
     cur.get[String](s"text").flatMap { text =>
-      cur.get[String]("when").flatMap {
-        case "before_verification" => Right(BeforeVerificationNotice(text))
-        case pattern(success, published) =>
+      cur.get[Option[String]]("when").flatMap {
+        case Some("before_verification") => Right(BeforeVerificationNotice(text))
+        case Some(pattern(success, published)) =>
           (for {
             suc <- Try(success.toBoolean)
             pub <- Try(published.toBoolean)
@@ -114,17 +113,16 @@ object PactImplicits {
             case Failure(err)   => Left(DecodingFailure.fromThrowable(err, cur.history))
             case Success(value) => Right(value)
           }
-        case other => Left(DecodingFailure(s"$other is not a valid value for field 'when' of the notice.", cur.history))
+        case _ => Right(SimpleNotice(text))
       }
     }
   }
 
   implicit val verificationPropertiesDecoder: Decoder[VerificationProperties] = Decoder.instance { cur =>
-    cur.get[Option[Boolean]]("pending").flatMap {
-      case Some(pending) =>
-        cur.get[List[PendingStateNotice]]("notices").map(PendingStateVerificationProperties(pending, _))
-      case None => cur.get[List[SimpleNotice]]("notices").map(SimpleVerificationProperties)
-    }
+    for {
+      pending <- cur.getOrElse[Boolean]("pending")(false)
+      notices <- cur.get[List[Notice]]("notices")
+    } yield VerificationProperties(pending, notices)
   }
 
   implicit val pactsForVerificationDecoder: Decoder[PactsForVerificationResponse] = deriveDecoder

--- a/scalapact-circe-0-13/src/main/scala/com/itv/scalapact/circe13/PactImplicits.scala
+++ b/scalapact-circe-0-13/src/main/scala/com/itv/scalapact/circe13/PactImplicits.scala
@@ -99,7 +99,6 @@ object PactImplicits {
   implicit val embeddedPactsForVerificationDecoder: Decoder[EmbeddedPactsForVerification] = deriveDecoder
   implicit val embeddedPactForVerificationDecoder: Decoder[PactForVerification]           = deriveDecoder
 
-  implicit val simpleNoticeDecoder: Decoder[SimpleNotice] = deriveDecoder
   implicit val pendingStateNoticeDecoder: Decoder[Notice] = Decoder.instance { cur =>
     lazy val pattern = "after_verification:success_(true|false)_published_(true|false)".r
     cur.get[String](s"text").flatMap { text =>

--- a/scalapact-shared/src/main/scala/com/itv/scalapact/shared/PactsForVerificationResponse.scala
+++ b/scalapact-shared/src/main/scala/com/itv/scalapact/shared/PactsForVerificationResponse.scala
@@ -40,14 +40,14 @@ final case class PactForVerification(verificationProperties: VerificationPropert
   def href: Option[String] = _links.get("self").map(_.href)
 }
 
-final case class  VerificationProperties(pending: Boolean, notices: List[Notice])
+final case class VerificationProperties(pending: Boolean, notices: List[Notice])
 
 sealed trait Notice {
   def text: String
 }
 
 object Notice {
-  final case class SimpleNotice(text: String)             extends Notice
-  final case class BeforeVerificationNotice(text: String) extends Notice
+  final case class SimpleNotice(text: String)                                                  extends Notice
+  final case class BeforeVerificationNotice(text: String)                                      extends Notice
   final case class AfterVerificationNotice(text: String, success: Boolean, published: Boolean) extends Notice
 }

--- a/scalapact-shared/src/main/scala/com/itv/scalapact/shared/PactsForVerificationResponse.scala
+++ b/scalapact-shared/src/main/scala/com/itv/scalapact/shared/PactsForVerificationResponse.scala
@@ -1,7 +1,5 @@
 package com.itv.scalapact.shared
 
-import com.itv.scalapact.shared.Notice.{PendingStateNotice, SimpleNotice}
-
 /*
 {
   "_embedded": {
@@ -42,24 +40,7 @@ final case class PactForVerification(verificationProperties: VerificationPropert
   def href: Option[String] = _links.get("self").map(_.href)
 }
 
-sealed trait VerificationProperties {
-  type A <: Notice
-  def pending: Boolean
-  def notices: List[A]
-}
-
-object VerificationProperties {
-  sealed trait VerificationPropertiesAux[A0 <: Notice] extends VerificationProperties { type A = A0 }
-
-  final case class SimpleVerificationProperties(notices: List[SimpleNotice])
-      extends VerificationPropertiesAux[SimpleNotice] {
-    val pending = false
-  }
-
-  final case class PendingStateVerificationProperties(pending: Boolean, notices: List[PendingStateNotice])
-      extends VerificationPropertiesAux[PendingStateNotice]
-
-}
+final case class  VerificationProperties(pending: Boolean, notices: List[Notice])
 
 sealed trait Notice {
   def text: String
@@ -67,8 +48,6 @@ sealed trait Notice {
 
 object Notice {
   final case class SimpleNotice(text: String)             extends Notice
-  sealed trait PendingStateNotice                         extends Notice
-  final case class BeforeVerificationNotice(text: String) extends PendingStateNotice
-  final case class AfterVerificationNotice(text: String, success: Boolean, published: Boolean)
-      extends PendingStateNotice
+  final case class BeforeVerificationNotice(text: String) extends Notice
+  final case class AfterVerificationNotice(text: String, success: Boolean, published: Boolean) extends Notice
 }


### PR DESCRIPTION
I way over complicated the model, and the naming of the notices was too specific.

Related to comments on #188 