### PR TITLE
Log pactbroker error bodies

### DIFF
--- a/scalapact-core/src/main/scala/com/itv/scalapactcore/common/PactBrokerClient.scala
+++ b/scalapact-core/src/main/scala/com/itv/scalapactcore/common/PactBrokerClient.scala
@@ -110,7 +110,8 @@ class PactBrokerClient(implicit
               throw new Exception("HAL index missing from Pact Broker response")
           }
         case Right(r) =>
-          val message = prettifyBrokerError(s"Failed to load HAL index from: ${pactVerifySettings.pactBrokerAddress}.", r)
+          val message =
+            prettifyBrokerError(s"Failed to load HAL index from: ${pactVerifySettings.pactBrokerAddress}.", r)
           PactLogger.error(message)
           throw new Exception(message)
         case Left(e) =>

--- a/scalapact-core/src/main/scala/com/itv/scalapactcore/common/PactBrokerClient.scala
+++ b/scalapact-core/src/main/scala/com/itv/scalapactcore/common/PactBrokerClient.scala
@@ -72,9 +72,10 @@ class PactBrokerClient(implicit
                 PactLogger.error("Pact data missing from Pact Broker response")
                 throw new Exception("Pact data missing from Pact Broker response")
               }
-          case Right(_) =>
-            PactLogger.error(s"Failed to load pacts for verification from: $address".red)
-            throw new Exception(s"Failed to load pacts for verification from: $address")
+          case Right(r) =>
+            val message = prettifyBrokerError(s"Failed to load pacts for verification from: $address.", r)
+            PactLogger.error(message)
+            throw new Exception(message)
           case Left(e) =>
             PactLogger.error(s"Error: ${e.getMessage}".red)
             throw e
@@ -108,9 +109,10 @@ class PactBrokerClient(implicit
               PactLogger.error(s"HAL index missing from Pact Broker response".red)
               throw new Exception("HAL index missing from Pact Broker response")
           }
-        case Right(_) =>
-          PactLogger.error(s"Failed to load HAL index from: ${pactVerifySettings.pactBrokerAddress}".red)
-          throw new Exception(s"Failed to load HAL index from: ${pactVerifySettings.pactBrokerAddress}")
+        case Right(r) =>
+          val message = prettifyBrokerError(s"Failed to load HAL index from: ${pactVerifySettings.pactBrokerAddress}.", r)
+          PactLogger.error(message)
+          throw new Exception(message)
         case Left(e) =>
           PactLogger.error(s"Error: ${e.getMessage}".red)
           throw e
@@ -191,9 +193,10 @@ class PactBrokerClient(implicit
             Left(new Exception("Pact data missing from Pact Broker response"))
           }
 
-      case Right(_) =>
-        PactLogger.error(s"Failed to load consumer pact from: $address".red)
-        Left(new Exception(s"Failed to load consumer pact from: $address"))
+      case Right(r) =>
+        val message = prettifyBrokerError(s"Failed to load consumer pact from: $address", r)
+        PactLogger.error(message)
+        Left(new Exception(message))
 
       case Left(e) =>
         PactLogger.error(s"Error: ${e.getMessage}".red)
@@ -229,7 +232,7 @@ class PactBrokerClient(implicit
                   s"Verification results published for provider '${result.pact.provider.name}' and consumer '${result.pact.consumer.name}'"
                 )
               } else {
-                PactLogger.error(s"Publish verification results failed with ${response.statusCode}".red)
+                PactLogger.error(prettifyBrokerError("Publish verification results failed.", response))
               }
             case Left(err) => PactLogger.error(s"Unable to publish verification results: $err".red)
           }
@@ -330,7 +333,7 @@ class PactBrokerClient(implicit
             case Left(e) =>
               PublishFailed(context, s"Failed with error: ${e.getMessage}".red)
             case Right(r) if !r.is2xx =>
-              PublishFailed(context, s"$r\nFailed: ${r.statusCode}, ${r.body}".red)
+              PublishFailed(context, prettifyResponse(r))
           }
           .getOrElse {
             httpClient.doRequest(
@@ -347,7 +350,7 @@ class PactBrokerClient(implicit
                 PublishSuccess(context)
 
               case Right(r) =>
-                PublishFailed(context, s"$r\nFailed: ${r.statusCode}, ${r.body}".red)
+                PublishFailed(context, prettifyResponse(r))
 
               case Left(e) =>
                 PublishFailed(context, s"Failed with error: ${e.getMessage}".red)
@@ -356,6 +359,12 @@ class PactBrokerClient(implicit
 
     }
   }
+
+  private def prettifyBrokerError(context: String, simpleResponse: SimpleResponse): String =
+    s"$context ${prettifyResponse(simpleResponse)}".red
+
+  private def prettifyResponse(response: SimpleResponse): String =
+    s"Failed with ${response.statusCode}${response.body.collect { case b if b.nonEmpty => s", $b" }.getOrElse("")}".red
 
 }
 


### PR DESCRIPTION
Fixes https://github.com/ITV/scala-pact/issues/196

The specific 400 error mentioned here https://github.com/ITV/scala-pact/issues/71#issuecomment-723306849 can be reproduced with this curl
```bash
curl --location --request POST 'https://test.pact.dius.com.au/pacts/provider/scala-pact-provider/consumer/scala-pact-consumer/pact-version/56cd913906efe69e3f8b9fe9c62e69aac2b31aa8/verification-results' \
--header 'Accept: application/hal+json' \
--header 'Content-Type: application/json' \
--header 'Authorization: Basic ZFhmbHR5Rk1nTk9GWkF4cjhpbzl3SjM3aVVwWTQyTTpPNUFJWld4ZWxXYkx2cU1kOFBrQVZ5Y0JKaDJQc3lnMQ==' \
--data-raw '{
  "success": true,
  "providerApplicationVersion": "",
  "buildUrl": "http://my-ci.org/build/3456"
}'
```

This now prints
```
Publish verification results failed. Failed with 400, {"errors":{"provider_version":["can't be blank","Version number '' cannot be parsed to a version number. The expected format (unless this configuration has been overridden) is a semantic version. eg. 1.3.0 or 2.0.4.rc1"]}}
```