### PR TITLE
Cache http clients used in tests

### DIFF
--- a/scalapact-http4s-0-21/src/main/scala/com/itv/scalapact/http4s21/impl/Http4sClientHelper.scala
+++ b/scalapact-http4s-0-21/src/main/scala/com/itv/scalapact/http4s21/impl/Http4sClientHelper.scala
@@ -26,7 +26,7 @@ object Http4sClientHelper {
       .withRequestTimeout(clientTimeout)
       .withUserAgentOption(Option(`User-Agent`(AgentProduct("scala-pact", Option(BuildInfo.version)))))
 
-    PactLogger.message(
+    PactLogger.debug(
       s"Creating http4s client: connections $maxTotalConnections, timeout $clientTimeout, sslContextName: $sslContextName, sslContextMap: $sslContextMap"
     )
 

--- a/scalapact-http4s-0-21/src/main/scala/com/itv/scalapact/http4s21/impl/Http4sClientHelper.scala
+++ b/scalapact-http4s-0-21/src/main/scala/com/itv/scalapact/http4s21/impl/Http4sClientHelper.scala
@@ -2,6 +2,7 @@ package com.itv.scalapact.http4s21.impl
 
 import cats.effect.{ContextShift, IO, Resource}
 import com.itv.scalapact.shared.http.{SimpleRequest, SimpleResponse, SslContextMap}
+import com.itv.scalapact.shared.utils.PactLogger
 import org.http4s._
 import org.http4s.client.Client
 import org.http4s.client.blaze.BlazeClientBuilder
@@ -25,12 +26,17 @@ object Http4sClientHelper {
       .withRequestTimeout(clientTimeout)
       .withUserAgentOption(Option(`User-Agent`(AgentProduct("scala-pact", Option(BuildInfo.version)))))
 
+    PactLogger.message(
+      s"Creating http4s client: connections $maxTotalConnections, timeout $clientTimeout, sslContextName: $sslContextName, sslContextMap: $sslContextMap"
+    )
+
     sslContext.fold(builder)(s => builder.withSslContext(s)).resource
   }
 
   def doRequest(request: SimpleRequest, httpClient: Resource[IO, Client[IO]]): IO[SimpleResponse] =
     for {
       request <- Http4sRequestResponseFactory.buildRequest(request)
+      _       <- IO(PactLogger.message(s"cURL for request: ${request.asCurl()}"))
       response <- httpClient.use { c =>
         c.run(request).use { r: Response[IO] =>
           r.bodyText.compile.toVector

--- a/scalapact-http4s-0-21/src/main/scala/com/itv/scalapact/http4s21/impl/HttpInstances.scala
+++ b/scalapact-http4s-0-21/src/main/scala/com/itv/scalapact/http4s21/impl/HttpInstances.scala
@@ -20,14 +20,12 @@ trait HttpInstances {
 
   implicit def httpClientBuilder(implicit sslContextMap: SslContextMap): IScalaPactHttpClientBuilder = {
     (clientTimeout: Duration, sslContextName: Option[String], maxTotalConnections: Int) =>
-      {
-        val clientConfig = ClientConfig(clientTimeout, sslContextName, maxTotalConnections, sslContextMap)
-        PactLogger.message(s"Checking client cache for config $clientConfig, cache size is ${clients.size}")
-        clients.computeIfAbsent(
-          clientConfig,
-          _ => ScalaPactHttpClient(clientTimeout, sslContextName, maxTotalConnections)
-        )
-      }
+      val clientConfig = ClientConfig(clientTimeout, sslContextName, maxTotalConnections, sslContextMap)
+      PactLogger.message(s"Checking client cache for config $clientConfig, cache size is ${clients.size}")
+      clients.computeIfAbsent(
+        clientConfig,
+        _ => ScalaPactHttpClient(clientTimeout, sslContextName, maxTotalConnections)
+      )
   }
 }
 

--- a/scalapact-http4s-0-21/src/main/scala/com/itv/scalapact/http4s21/impl/HttpInstances.scala
+++ b/scalapact-http4s-0-21/src/main/scala/com/itv/scalapact/http4s21/impl/HttpInstances.scala
@@ -21,7 +21,7 @@ trait HttpInstances {
   implicit def httpClientBuilder(implicit sslContextMap: SslContextMap): IScalaPactHttpClientBuilder = {
     (clientTimeout: Duration, sslContextName: Option[String], maxTotalConnections: Int) =>
       val clientConfig = ClientConfig(clientTimeout, sslContextName, maxTotalConnections, sslContextMap)
-      PactLogger.message(s"Checking client cache for config $clientConfig, cache size is ${clients.size}")
+      PactLogger.debug(s"Checking client cache for config $clientConfig, cache size is ${clients.size}")
       clients.computeIfAbsent(
         clientConfig,
         _ => ScalaPactHttpClient(clientTimeout, sslContextName, maxTotalConnections)


### PR DESCRIPTION
Fixes the client part of https://github.com/ITV/scala-pact/issues/190 by caching clients with the same config. Not sure about the `PactStubber`, that seems more complicated as it depends on the interactions defined? Maybe it's possible to do though