### PR TITLE
Wip pacts

### DIFF
--- a/example/provider_pact-for-verification/src/test/scala/com/example/provider/VerifyContractsSpec.scala
+++ b/example/provider_pact-for-verification/src/test/scala/com/example/provider/VerifyContractsSpec.scala
@@ -2,7 +2,7 @@ package com.example.provider
 
 import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
 import com.itv.scalapact.PactVerifySuite
-import com.itv.scalapact.shared.{ConsumerVersionSelector, PactBrokerAuthorization, ProviderStateResult}
+import com.itv.scalapact.shared.{ConsumerVersionSelector, PactBrokerAuthorization, ProviderStateResult, PendingPactSettings}
 
 import scala.concurrent.duration._
 
@@ -30,7 +30,7 @@ class VerifyContractsSpec extends FunSpec with Matchers with BeforeAndAfterAll w
             "scala-pact-provider",
             List(consumer),
             List(),
-            None,
+            PendingPactSettings.PendingDisabled,
             None,
             //again, these are publicly known creds for a test pact-broker
             PactBrokerAuthorization(pactBrokerCredentials = ("dXfltyFMgNOFZAxr8io9wJ37iUpY42M", "O5AIZWxelWbLvqMd8PkAVycBJh2Psyg1"), ""),

--- a/example/provider_pact-for-verification/src/test/scala/com/example/provider/VerifyContractsSpec.scala
+++ b/example/provider_pact-for-verification/src/test/scala/com/example/provider/VerifyContractsSpec.scala
@@ -30,7 +30,7 @@ class VerifyContractsSpec extends FunSpec with Matchers with BeforeAndAfterAll w
             "scala-pact-provider",
             List(consumer),
             List(),
-            includePendingStatus = false,
+            None,
             None,
             //again, these are publicly known creds for a test pact-broker
             PactBrokerAuthorization(pactBrokerCredentials = ("dXfltyFMgNOFZAxr8io9wJ37iUpY42M", "O5AIZWxelWbLvqMd8PkAVycBJh2Psyg1"), ""),

--- a/pending-pact-tests/provider/pact.sbt
+++ b/pending-pact-tests/provider/pact.sbt
@@ -1,0 +1,8 @@
+import com.itv.scalapact.shared.ConsumerVersionSelector
+
+pactBrokerAddress := "https://test.pact.dius.com.au"
+//For publishing to pact-broker test server (these credentials are public knowledge)
+pactBrokerCredentials := ("dXfltyFMgNOFZAxr8io9wJ37iUpY42M", "O5AIZWxelWbLvqMd8PkAVycBJh2Psyg1")
+consumerVersionSelectors := Seq(ConsumerVersionSelector("test", latest = true))
+providerVersionTags := List("master")
+providerName := "scala-pact-pending-test-provider"

--- a/pending-pact-tests/provider/pact.sbt
+++ b/pending-pact-tests/provider/pact.sbt
@@ -1,4 +1,5 @@
 import com.itv.scalapact.shared.ConsumerVersionSelector
+import scala.concurrent.duration._
 
 pactBrokerAddress := "https://test.pact.dius.com.au"
 //For publishing to pact-broker test server (these credentials are public knowledge)
@@ -6,3 +7,4 @@ pactBrokerCredentials := ("dXfltyFMgNOFZAxr8io9wJ37iUpY42M", "O5AIZWxelWbLvqMd8P
 consumerVersionSelectors := Seq(ConsumerVersionSelector("test", latest = true))
 providerVersionTags := List("master")
 providerName := "scala-pact-pending-test-provider"
+pactBrokerClientTimeout := 5.seconds

--- a/pending-pact-tests/provider/src/test/scala/provider/VerifyContractsSpec.scala
+++ b/pending-pact-tests/provider/src/test/scala/provider/VerifyContractsSpec.scala
@@ -2,7 +2,7 @@ package provider
 
 import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
 import com.itv.scalapact.PactVerifySuite
-import com.itv.scalapact.shared.{ConsumerVersionSelector, PactBrokerAuthorization, ProviderStateResult, PendingPactSetttings}
+import com.itv.scalapact.shared.{ConsumerVersionSelector, PactBrokerAuthorization, PendingPactSettings}
 
 import scala.concurrent.duration._
 

--- a/pending-pact-tests/provider/src/test/scala/provider/VerifyContractsSpec.scala
+++ b/pending-pact-tests/provider/src/test/scala/provider/VerifyContractsSpec.scala
@@ -2,7 +2,7 @@ package provider
 
 import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
 import com.itv.scalapact.PactVerifySuite
-import com.itv.scalapact.shared.{ConsumerVersionSelector, PactBrokerAuthorization, ProviderStateResult}
+import com.itv.scalapact.shared.{ConsumerVersionSelector, PactBrokerAuthorization, ProviderStateResult, PendingPactSetttings}
 
 import scala.concurrent.duration._
 
@@ -32,7 +32,7 @@ class VerifyContractsSpec extends FunSpec with Matchers with BeforeAndAfterAll w
             "scala-pact-pending-test-provider",
             consumers,
             List("master"),
-            includePendingStatus = true,
+            pendingPactSettings = PendingPactSettings.PendingEnabled,
             None,
             //again, these are publicly known creds for a test pact-broker
             PactBrokerAuthorization(pactBrokerCredentials = ("dXfltyFMgNOFZAxr8io9wJ37iUpY42M", "O5AIZWxelWbLvqMd8PkAVycBJh2Psyg1"), ""),

--- a/sbt-scalapact-shared/src/main/scala/com/itv/scalapact/plugin/ScalaPactEnv.scala
+++ b/sbt-scalapact-shared/src/main/scala/com/itv/scalapact/plugin/ScalaPactEnv.scala
@@ -45,7 +45,8 @@ case class ScalaPactEnv(
   def enablePublishResults(providerVersion: String, buildUrl: Option[String]): ScalaPactEnv =
     this.copy(publishResultsEnabled = Option(BrokerPublishData(providerVersion, buildUrl)))
 
-  def withPendingPactSettings(settings: PendingPactSettings): ScalaPactEnv = this.copy(pendingPactSettings = Some(settings))
+  def withPendingPactSettings(settings: PendingPactSettings): ScalaPactEnv =
+    this.copy(pendingPactSettings = Some(settings))
 
   def toSettings: ScalaPactSettings =
     ScalaPactSettings(

--- a/sbt-scalapact-shared/src/main/scala/com/itv/scalapact/plugin/ScalaPactEnv.scala
+++ b/sbt-scalapact-shared/src/main/scala/com/itv/scalapact/plugin/ScalaPactEnv.scala
@@ -1,7 +1,5 @@
 package com.itv.scalapact.plugin
 
-import java.time.OffsetDateTime
-
 import com.itv.scalapact.shared.{BrokerPublishData, PendingPactSettings, ScalaPactSettings}
 
 import scala.concurrent.duration._
@@ -15,8 +13,7 @@ case class ScalaPactEnv(
     clientTimeout: Option[Duration],
     outputPath: Option[String],
     publishResultsEnabled: Option[BrokerPublishData],
-    enablePending: Option[Boolean],
-    includeWipPactsSince: Option[OffsetDateTime]
+    pendingPactSettings: Option[PendingPactSettings]
 ) {
   def +(other: ScalaPactEnv): ScalaPactEnv =
     ScalaPactEnv.append(this, other)
@@ -48,7 +45,7 @@ case class ScalaPactEnv(
   def enablePublishResults(providerVersion: String, buildUrl: Option[String]): ScalaPactEnv =
     this.copy(publishResultsEnabled = Option(BrokerPublishData(providerVersion, buildUrl)))
 
-  def enablePendingStatus: ScalaPactEnv = this.copy(enablePending = Some(true))
+  def withPendingPactSettings(settings: PendingPactSettings): ScalaPactEnv = this.copy(pendingPactSettings = Some(settings))
 
   def toSettings: ScalaPactSettings =
     ScalaPactSettings(
@@ -60,7 +57,7 @@ case class ScalaPactEnv(
       clientTimeout,
       outputPath,
       publishResultsEnabled,
-      PendingPactSettings(enablePending, includeWipPactsSince)
+      pendingPactSettings
     )
 
 }
@@ -79,14 +76,13 @@ object ScalaPactEnv {
       Option(Duration(1, SECONDS)),
       None, // "target/pacts"
       None, // false
-      None, // false
       None
     )
 
   def defaults: ScalaPactEnv =
     ScalaPactEnv("http", "localhost", 1234)
 
-  def empty: ScalaPactEnv = ScalaPactEnv(None, None, None, None, None, None, None, None, None, None)
+  def empty: ScalaPactEnv = ScalaPactEnv(None, None, None, None, None, None, None, None, None)
 
   def append(a: ScalaPactEnv, b: ScalaPactEnv): ScalaPactEnv =
     ScalaPactEnv(
@@ -98,7 +94,6 @@ object ScalaPactEnv {
       clientTimeout = b.clientTimeout.orElse(a.clientTimeout),
       outputPath = b.outputPath.orElse(a.outputPath),
       publishResultsEnabled = b.publishResultsEnabled.orElse(a.publishResultsEnabled),
-      enablePending = b.enablePending.orElse(a.enablePending),
-      includeWipPactsSince = b.includeWipPactsSince.orElse(a.includeWipPactsSince)
+      pendingPactSettings = b.pendingPactSettings.orElse(a.pendingPactSettings)
     )
 }

--- a/sbt-scalapact-shared/src/main/scala/com/itv/scalapact/plugin/ScalaPactEnv.scala
+++ b/sbt-scalapact-shared/src/main/scala/com/itv/scalapact/plugin/ScalaPactEnv.scala
@@ -2,7 +2,7 @@ package com.itv.scalapact.plugin
 
 import java.time.OffsetDateTime
 
-import com.itv.scalapact.shared.{BrokerPublishData, ScalaPactSettings}
+import com.itv.scalapact.shared.{BrokerPublishData, PendingPactSettings, ScalaPactSettings}
 
 import scala.concurrent.duration._
 
@@ -60,8 +60,7 @@ case class ScalaPactEnv(
       clientTimeout,
       outputPath,
       publishResultsEnabled,
-      enablePending,
-      includeWipPactsSince
+      PendingPactSettings(enablePending, includeWipPactsSince)
     )
 
 }

--- a/sbt-scalapact-shared/src/main/scala/com/itv/scalapact/plugin/ScalaPactEnv.scala
+++ b/sbt-scalapact-shared/src/main/scala/com/itv/scalapact/plugin/ScalaPactEnv.scala
@@ -80,7 +80,7 @@ object ScalaPactEnv {
       Option(Duration(1, SECONDS)),
       None, // "target/pacts"
       None, // false
-      None,  // false
+      None, // false
       None
     )
 

--- a/sbt-scalapact-shared/src/main/scala/com/itv/scalapact/plugin/ScalaPactEnv.scala
+++ b/sbt-scalapact-shared/src/main/scala/com/itv/scalapact/plugin/ScalaPactEnv.scala
@@ -1,5 +1,7 @@
 package com.itv.scalapact.plugin
 
+import java.time.OffsetDateTime
+
 import com.itv.scalapact.shared.{BrokerPublishData, ScalaPactSettings}
 
 import scala.concurrent.duration._
@@ -13,7 +15,8 @@ case class ScalaPactEnv(
     clientTimeout: Option[Duration],
     outputPath: Option[String],
     publishResultsEnabled: Option[BrokerPublishData],
-    enablePending: Option[Boolean]
+    enablePending: Option[Boolean],
+    includeWipPactsSince: Option[OffsetDateTime]
 ) {
   def +(other: ScalaPactEnv): ScalaPactEnv =
     ScalaPactEnv.append(this, other)
@@ -57,7 +60,8 @@ case class ScalaPactEnv(
       clientTimeout,
       outputPath,
       publishResultsEnabled,
-      enablePending
+      enablePending,
+      includeWipPactsSince
     )
 
 }
@@ -76,13 +80,14 @@ object ScalaPactEnv {
       Option(Duration(1, SECONDS)),
       None, // "target/pacts"
       None, // false
-      None  // false
+      None,  // false
+      None
     )
 
   def defaults: ScalaPactEnv =
     ScalaPactEnv("http", "localhost", 1234)
 
-  def empty: ScalaPactEnv = ScalaPactEnv(None, None, None, None, None, None, None, None, None)
+  def empty: ScalaPactEnv = ScalaPactEnv(None, None, None, None, None, None, None, None, None, None)
 
   def append(a: ScalaPactEnv, b: ScalaPactEnv): ScalaPactEnv =
     ScalaPactEnv(
@@ -94,6 +99,7 @@ object ScalaPactEnv {
       clientTimeout = b.clientTimeout.orElse(a.clientTimeout),
       outputPath = b.outputPath.orElse(a.outputPath),
       publishResultsEnabled = b.publishResultsEnabled.orElse(a.publishResultsEnabled),
-      enablePending = b.enablePending.orElse(a.enablePending)
+      enablePending = b.enablePending.orElse(a.enablePending),
+      includeWipPactsSince = b.includeWipPactsSince.orElse(a.includeWipPactsSince)
     )
 }

--- a/sbt-scalapact-shared/src/main/scala/com/itv/scalapact/plugin/shared/ScalaPactVerifyCommand.scala
+++ b/sbt-scalapact-shared/src/main/scala/com/itv/scalapact/plugin/shared/ScalaPactVerifyCommand.scala
@@ -44,8 +44,8 @@ object ScalaPactVerifyCommand {
           providerName,
           consumerVersionSelectors.toList,
           providerVersionTags.toList,
-          scalaPactSettings.enablePending.getOrElse(includePendingStatus),
-          scalaPactSettings.includeWipPactsSince,
+          scalaPactSettings.pendingPactSettings.enablePending.getOrElse(includePendingStatus),
+          scalaPactSettings.pendingPactSettings.includeWipPactsSince,
           pactBrokerAuthorization,
           Some(pactBrokerClientTimeout),
           sslContextName

--- a/sbt-scalapact-shared/src/main/scala/com/itv/scalapact/plugin/shared/ScalaPactVerifyCommand.scala
+++ b/sbt-scalapact-shared/src/main/scala/com/itv/scalapact/plugin/shared/ScalaPactVerifyCommand.scala
@@ -40,7 +40,7 @@ object ScalaPactVerifyCommand {
       else if (consumerVersionSelectors.nonEmpty) {
         val pendingPactSettings = scalaPactSettings.pendingPactSettings.getOrElse {
           includePendingStatus match {
-            case true => PendingPactSettings.PendingEnabled
+            case true  => PendingPactSettings.PendingEnabled
             case false => PendingPactSettings.PendingDisabled
           }
         }

--- a/sbt-scalapact-shared/src/main/scala/com/itv/scalapact/plugin/shared/ScalaPactVerifyCommand.scala
+++ b/sbt-scalapact-shared/src/main/scala/com/itv/scalapact/plugin/shared/ScalaPactVerifyCommand.scala
@@ -37,20 +37,25 @@ object ScalaPactVerifyCommand {
     val pactVerifySettings = {
       if (scalaPactSettings.localPactFilePath.isDefined)
         LocalPactVerifySettings(combinedPactStates)
-      else if (consumerVersionSelectors.nonEmpty)
+      else if (consumerVersionSelectors.nonEmpty) {
+        val pendingPactSettings = scalaPactSettings.pendingPactSettings.getOrElse {
+          includePendingStatus match {
+            case true => PendingPactSettings.PendingEnabled
+            case false => PendingPactSettings.PendingDisabled
+          }
+        }
         PactsForVerificationSettings(
           combinedPactStates,
           pactBrokerAddress,
           providerName,
           consumerVersionSelectors.toList,
           providerVersionTags.toList,
-          scalaPactSettings.pendingPactSettings.enablePending.getOrElse(includePendingStatus),
-          scalaPactSettings.pendingPactSettings.includeWipPactsSince,
+          pendingPactSettings,
           pactBrokerAuthorization,
           Some(pactBrokerClientTimeout),
           sslContextName
         )
-      else {
+      } else {
         val versionedConsumers =
           consumerNames.map(VersionedConsumer.fromName) ++
             versionedConsumerNames.map(v => VersionedConsumer(v._1, v._2)) ++

--- a/sbt-scalapact-shared/src/main/scala/com/itv/scalapact/plugin/shared/ScalaPactVerifyCommand.scala
+++ b/sbt-scalapact-shared/src/main/scala/com/itv/scalapact/plugin/shared/ScalaPactVerifyCommand.scala
@@ -45,6 +45,7 @@ object ScalaPactVerifyCommand {
           consumerVersionSelectors.toList,
           providerVersionTags.toList,
           scalaPactSettings.enablePending.getOrElse(includePendingStatus),
+          scalaPactSettings.includeWipPactsSince,
           pactBrokerAuthorization,
           Some(pactBrokerClientTimeout),
           sslContextName

--- a/scalapact-argonaut-6-2/src/main/scala/com/itv/scalapact/argonaut62/PactImplicits.scala
+++ b/scalapact-argonaut-6-2/src/main/scala/com/itv/scalapact/argonaut62/PactImplicits.scala
@@ -115,10 +115,11 @@ object PactImplicits {
     for {
       providerState  <- cur.get[Option[String]]("providerState")
       provider_state <- cur.get[Option[String]]("provider_state")
+      ps = providerState.orElse(provider_state).filterNot(_.isEmpty)
       description    <- cur.get[String]("description")
       request        <- cur.get[InteractionRequest]("request")
       response       <- cur.get[InteractionResponse]("response")
-    } yield Interaction(providerState.orElse(provider_state), description, request, response)
+    } yield Interaction(ps, description, request, response)
   }
 
   implicit lazy val InteractionCodecJson: EncodeJson[Interaction] = EncodeJson[Interaction] { i =>

--- a/scalapact-argonaut-6-2/src/main/scala/com/itv/scalapact/argonaut62/PactImplicits.scala
+++ b/scalapact-argonaut-6-2/src/main/scala/com/itv/scalapact/argonaut62/PactImplicits.scala
@@ -116,9 +116,9 @@ object PactImplicits {
       providerState  <- cur.get[Option[String]]("providerState")
       provider_state <- cur.get[Option[String]]("provider_state")
       ps = providerState.orElse(provider_state).filterNot(_.isEmpty)
-      description    <- cur.get[String]("description")
-      request        <- cur.get[InteractionRequest]("request")
-      response       <- cur.get[InteractionResponse]("response")
+      description <- cur.get[String]("description")
+      request     <- cur.get[InteractionRequest]("request")
+      response    <- cur.get[InteractionResponse]("response")
     } yield Interaction(ps, description, request, response)
   }
 

--- a/scalapact-argonaut-6-2/src/main/scala/com/itv/scalapact/argonaut62/PactImplicits.scala
+++ b/scalapact-argonaut-6-2/src/main/scala/com/itv/scalapact/argonaut62/PactImplicits.scala
@@ -1,5 +1,7 @@
 package com.itv.scalapact.argonaut62
 
+import java.time.format.DateTimeFormatter
+
 import argonaut.Argonaut._
 import argonaut.{Parse, _}
 import com.itv.scalapact.shared.Notice._
@@ -185,10 +187,12 @@ object PactImplicits {
 
   implicit lazy val pactsForVerificationRequestEncoder: EncodeJson[PactsForVerificationRequest] =
     EncodeJson[PactsForVerificationRequest] { r =>
+      val wipPactString = r.includeWipPactsSince.map(DateTimeFormatter.ISO_OFFSET_DATE_TIME.format)
       Json.obj(
         "consumerVersionSelectors" -> r.consumerVersionSelectors.asJson,
         "providerVersionTags"      -> r.providerVersionTags.asJson,
-        "includePendingStatus"     -> r.includePendingStatus.asJson
+        "includePendingStatus"     -> r.includePendingStatus.asJson,
+        "includeWipPactsSince"     -> wipPactString.asJson
       )
     }
 

--- a/scalapact-circe-0-13/src/main/scala/com/itv/scalapact/circe13/PactImplicits.scala
+++ b/scalapact-circe-0-13/src/main/scala/com/itv/scalapact/circe13/PactImplicits.scala
@@ -66,10 +66,11 @@ object PactImplicits {
     for {
       providerState  <- cur.get[Option[String]]("providerState")
       provider_state <- cur.get[Option[String]]("provider_state")
+      ps = providerState.orElse(provider_state).filterNot(_.isEmpty)
       description    <- cur.get[String]("description")
       request        <- cur.get[InteractionRequest]("request")
       response       <- cur.get[InteractionResponse]("response")
-    } yield Interaction(providerState.orElse(provider_state), description, request, response)
+    } yield Interaction(ps, description, request, response)
   }
 
   implicit val interactionEncoder: Encoder[Interaction] = deriveEncoder

--- a/scalapact-circe-0-13/src/main/scala/com/itv/scalapact/circe13/PactImplicits.scala
+++ b/scalapact-circe-0-13/src/main/scala/com/itv/scalapact/circe13/PactImplicits.scala
@@ -67,9 +67,9 @@ object PactImplicits {
       providerState  <- cur.get[Option[String]]("providerState")
       provider_state <- cur.get[Option[String]]("provider_state")
       ps = providerState.orElse(provider_state).filterNot(_.isEmpty)
-      description    <- cur.get[String]("description")
-      request        <- cur.get[InteractionRequest]("request")
-      response       <- cur.get[InteractionResponse]("response")
+      description <- cur.get[String]("description")
+      request     <- cur.get[InteractionRequest]("request")
+      response    <- cur.get[InteractionResponse]("response")
     } yield Interaction(ps, description, request, response)
   }
 

--- a/scalapact-core/src/main/scala/com/itv/scalapactcore/common/PactBrokerClient.scala
+++ b/scalapact-core/src/main/scala/com/itv/scalapactcore/common/PactBrokerClient.scala
@@ -31,8 +31,8 @@ class PactBrokerClient(implicit
           PactsForVerificationRequest(
             pactVerifySettings.consumerVersionSelectors,
             pactVerifySettings.providerVersionTags,
-            pactVerifySettings.includePendingStatus,
-            pactVerifySettings.includeWipPactsSince
+            pactVerifySettings.pendingPactSettings.enablePending,
+            pactVerifySettings.pendingPactSettings.includeWipPactsSince
           )
         )
         val request = SimpleRequest(

--- a/scalapact-core/src/main/scala/com/itv/scalapactcore/common/PactBrokerClient.scala
+++ b/scalapact-core/src/main/scala/com/itv/scalapactcore/common/PactBrokerClient.scala
@@ -31,7 +31,8 @@ class PactBrokerClient(implicit
           PactsForVerificationRequest(
             pactVerifySettings.consumerVersionSelectors,
             pactVerifySettings.providerVersionTags,
-            pactVerifySettings.includePendingStatus
+            pactVerifySettings.includePendingStatus,
+            pactVerifySettings.includeWipPactsSince
           )
         )
         val request = SimpleRequest(

--- a/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactMock.scala
+++ b/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactMock.scala
@@ -44,7 +44,8 @@ private[scalapact] object ScalaPactMock {
       clientTimeout = None,
       outputPath = Option(outputPath),
       publishResultsEnabled = None, // Nothing to publish
-      enablePending = None          //This is determined by the pact broker
+      enablePending = None,          //This is determined by the pact broker
+      includeWipPactsSince = None
     )
     val pacts = List(ScalaPactContractWriter.producePactFromDescription(pactDescription))
 

--- a/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactMock.scala
+++ b/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactMock.scala
@@ -4,7 +4,7 @@ import com.itv.scalapact.model.ScalaPactDescriptionFinal
 import com.itv.scalapact.shared.http.{HttpMethod, IScalaPactHttpClient, SimpleRequest, SslContextMap}
 import com.itv.scalapact.shared.json.{IPactReader, IPactWriter}
 import com.itv.scalapact.shared.utils.PactLogger
-import com.itv.scalapact.shared.{IPactStubber, PendingPactSettings, ScalaPactSettings}
+import com.itv.scalapact.shared.{IPactStubber, ScalaPactSettings}
 import com.itv.scalapactcore.common.stubber.InteractionManager
 
 private[scalapact] object ScalaPactMock {
@@ -44,7 +44,7 @@ private[scalapact] object ScalaPactMock {
       clientTimeout = None,
       outputPath = Option(outputPath),
       publishResultsEnabled = None, // Nothing to publish
-      pendingPactSettings = PendingPactSettings.empty
+      pendingPactSettings = None
     )
     val pacts = List(ScalaPactContractWriter.producePactFromDescription(pactDescription))
 

--- a/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactMock.scala
+++ b/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactMock.scala
@@ -44,7 +44,7 @@ private[scalapact] object ScalaPactMock {
       clientTimeout = None,
       outputPath = Option(outputPath),
       publishResultsEnabled = None, // Nothing to publish
-      enablePending = None,          //This is determined by the pact broker
+      enablePending = None,         //This is determined by the pact broker
       includeWipPactsSince = None
     )
     val pacts = List(ScalaPactContractWriter.producePactFromDescription(pactDescription))

--- a/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactMock.scala
+++ b/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactMock.scala
@@ -4,7 +4,7 @@ import com.itv.scalapact.model.ScalaPactDescriptionFinal
 import com.itv.scalapact.shared.http.{HttpMethod, IScalaPactHttpClient, SimpleRequest, SslContextMap}
 import com.itv.scalapact.shared.json.{IPactReader, IPactWriter}
 import com.itv.scalapact.shared.utils.PactLogger
-import com.itv.scalapact.shared.{IPactStubber, ScalaPactSettings}
+import com.itv.scalapact.shared.{IPactStubber, PendingPactSettings, ScalaPactSettings}
 import com.itv.scalapactcore.common.stubber.InteractionManager
 
 private[scalapact] object ScalaPactMock {
@@ -44,8 +44,7 @@ private[scalapact] object ScalaPactMock {
       clientTimeout = None,
       outputPath = Option(outputPath),
       publishResultsEnabled = None, // Nothing to publish
-      enablePending = None,         //This is determined by the pact broker
-      includeWipPactsSince = None
+      pendingPactSettings = PendingPactSettings.empty
     )
     val pacts = List(ScalaPactContractWriter.producePactFromDescription(pactDescription))
 

--- a/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactVerify.scala
+++ b/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactVerify.scala
@@ -290,7 +290,8 @@ trait ScalaPactVerifyDsl {
 
   sealed trait PactSourceType
 
-  case class loadFromLocal(path: String) extends PactSourceType
+  case class loadFromLocal(path: String)    extends PactSourceType
+  case class pactAsJsonString(json: String) extends PactSourceType
 
   case class pactBrokerUseLatest(
       url: String,
@@ -378,7 +379,7 @@ trait ScalaPactVerifyDsl {
       this.copy(pactBrokerClientTimeout = Some(duration))
     def withPactBrokerAuth(auth: PactBrokerAuthorization): pactBrokerWithVersionSelectors =
       this.copy(pactBrokerAuthorization = Some(auth))
-    def withPublishDate(data: BrokerPublishData): pactBrokerWithVersionSelectors =
+    def withPublishData(data: BrokerPublishData): pactBrokerWithVersionSelectors =
       this.copy(publishResultsEnabled = Some(data))
   }
 
@@ -400,6 +401,28 @@ trait ScalaPactVerifyDsl {
         None,
         None,
         None
+      ) {}
+
+    def apply(
+        url: String,
+        provider: String,
+        consumerVersionSelectors: List[ConsumerVersionSelector],
+        providerVersionTags: List[String],
+        includePendingStatus: Boolean,
+        publishResultsEnabled: Option[BrokerPublishData],
+        pactBrokerAuthorization: Option[PactBrokerAuthorization],
+        pactBrokerClientTimeout: Option[Duration]
+    ): pactBrokerWithVersionSelectors =
+      new pactBrokerWithVersionSelectors(
+        url,
+        provider,
+        consumerVersionSelectors,
+        providerVersionTags,
+        includePendingStatus,
+        None,
+        publishResultsEnabled,
+        pactBrokerAuthorization,
+        pactBrokerClientTimeout
       ) {}
 
     def apply(
@@ -444,8 +467,6 @@ trait ScalaPactVerifyDsl {
       ) {}
 
   }
-
-  case class pactAsJsonString(json: String) extends PactSourceType
 
   class ScalaPactVerifyFailed extends Exception
 

--- a/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactVerify.scala
+++ b/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactVerify.scala
@@ -1,6 +1,7 @@
 package com.itv.scalapact
 
 import java.io.{BufferedWriter, File, FileWriter}
+import java.time.OffsetDateTime
 
 import com.itv.scalapact.shared.ProviderStateResult.SetupProviderState
 import com.itv.scalapact.shared._
@@ -171,7 +172,8 @@ trait ScalaPactVerifyDsl {
           clientTimeout = Some(clientTimeout),
           outputPath = None,
           publishResultsEnabled = publishResultsEnabled,
-          enablePending = None
+          enablePending = None,
+          includeWipPactsSince = None
         )
 
         val (verifySettings, scalaPactSettings) = sourceType match {
@@ -253,6 +255,7 @@ trait ScalaPactVerifyDsl {
                 consumerVersionSelectors,
                 providerVersionTags,
                 includePendingStatus,
+                includeWipPactsSince,
                 publishResultsEnabled,
                 pactBrokerAuthorization,
                 pactBrokerClientTimeout
@@ -262,6 +265,7 @@ trait ScalaPactVerifyDsl {
               pactBrokerAddress = url,
               providerName = providerName,
               includePendingStatus = includePendingStatus,
+              includeWipPactsSince = includeWipPactsSince,
               consumerVersionSelectors = consumerVersionSelectors,
               providerVersionTags = providerVersionTags,
               pactBrokerAuthorization = pactBrokerAuthorization,
@@ -349,6 +353,7 @@ trait ScalaPactVerifyDsl {
       consumerVersionSelectors: List[ConsumerVersionSelector],
       providerVersionTags: List[String],
       includePendingStatus: Boolean,
+      includeWipPactsSince: Option[OffsetDateTime],
       publishResultsEnabled: Option[BrokerPublishData],
       pactBrokerAuthorization: Option[PactBrokerAuthorization],
       pactBrokerClientTimeout: Option[Duration]

--- a/scalapact-shared/src/main/scala/com/itv/scalapact/shared/PactVerifySettings.scala
+++ b/scalapact-shared/src/main/scala/com/itv/scalapact/shared/PactVerifySettings.scala
@@ -1,7 +1,5 @@
 package com.itv.scalapact.shared
 
-import java.time.OffsetDateTime
-
 import com.itv.scalapact.shared.ProviderStateResult.SetupProviderState
 
 import scala.concurrent.duration.Duration
@@ -26,8 +24,7 @@ final case class PactsForVerificationSettings(
     providerName: String,
     consumerVersionSelectors: List[ConsumerVersionSelector],
     providerVersionTags: List[String],
-    includePendingStatus: Boolean,
-    includeWipPactsSince: Option[OffsetDateTime],
+    pendingPactSettings: PendingPactSettings,
     pactBrokerAuthorization: Option[PactBrokerAuthorization],
     pactBrokerClientTimeout: Option[Duration],
     sslContextName: Option[String]

--- a/scalapact-shared/src/main/scala/com/itv/scalapact/shared/PactVerifySettings.scala
+++ b/scalapact-shared/src/main/scala/com/itv/scalapact/shared/PactVerifySettings.scala
@@ -1,5 +1,7 @@
 package com.itv.scalapact.shared
 
+import java.time.OffsetDateTime
+
 import com.itv.scalapact.shared.ProviderStateResult.SetupProviderState
 
 import scala.concurrent.duration.Duration
@@ -25,6 +27,7 @@ final case class PactsForVerificationSettings(
     consumerVersionSelectors: List[ConsumerVersionSelector],
     providerVersionTags: List[String],
     includePendingStatus: Boolean,
+    includeWipPactsSince: Option[OffsetDateTime],
     pactBrokerAuthorization: Option[PactBrokerAuthorization],
     pactBrokerClientTimeout: Option[Duration],
     sslContextName: Option[String]

--- a/scalapact-shared/src/main/scala/com/itv/scalapact/shared/PactsForVerificationRequest.scala
+++ b/scalapact-shared/src/main/scala/com/itv/scalapact/shared/PactsForVerificationRequest.scala
@@ -1,7 +1,10 @@
 package com.itv.scalapact.shared
 
+import java.time.OffsetDateTime
+
 final case class PactsForVerificationRequest(
     consumerVersionSelectors: List[ConsumerVersionSelector],
     providerVersionTags: List[String],
-    includePendingStatus: Boolean
+    includePendingStatus: Boolean,
+    includeWipPactsSince: Option[OffsetDateTime]
 )

--- a/scalapact-shared/src/main/scala/com/itv/scalapact/shared/PendingPactSettings.scala
+++ b/scalapact-shared/src/main/scala/com/itv/scalapact/shared/PendingPactSettings.scala
@@ -1,0 +1,25 @@
+package com.itv.scalapact.shared
+
+import java.time.OffsetDateTime
+
+sealed abstract case class PendingPactSettings(
+    enablePending: Option[Boolean],
+    includeWipPactsSince: Option[OffsetDateTime]
+) {
+  def append(that: PendingPactSettings): PendingPactSettings = that match {
+    case PendingPactSettings(_, Some(wip))   => new PendingPactSettings(Some(true), Some(wip)) {}
+    case PendingPactSettings(Some(false), _) => PendingPactSettings(Some(false))
+    case PendingPactSettings(ep, wip) =>
+      new PendingPactSettings(ep.orElse(this.enablePending), wip.orElse(this.includeWipPactsSince)) {}
+  }
+}
+
+object PendingPactSettings {
+  def empty: PendingPactSettings = new PendingPactSettings(None, None) {}
+  def apply(enablePending: Option[Boolean], includeWipPactsSince: Option[OffsetDateTime]): PendingPactSettings = includeWipPactsSince match {
+    case Some(wipSince) => apply(wipSince)
+    case None           => apply(enablePending: Option[Boolean])
+  }
+  def apply(enablePending: Option[Boolean]): PendingPactSettings = new PendingPactSettings(enablePending, None) {}
+  def apply(wipPactsSince: OffsetDateTime): PendingPactSettings  = new PendingPactSettings(Some(true), Some(wipPactsSince)) {}
+}

--- a/scalapact-shared/src/main/scala/com/itv/scalapact/shared/PendingPactSettings.scala
+++ b/scalapact-shared/src/main/scala/com/itv/scalapact/shared/PendingPactSettings.scala
@@ -16,10 +16,12 @@ sealed abstract case class PendingPactSettings(
 
 object PendingPactSettings {
   def empty: PendingPactSettings = new PendingPactSettings(None, None) {}
-  def apply(enablePending: Option[Boolean], includeWipPactsSince: Option[OffsetDateTime]): PendingPactSettings = includeWipPactsSince match {
-    case Some(wipSince) => apply(wipSince)
-    case None           => apply(enablePending: Option[Boolean])
-  }
+  def apply(enablePending: Option[Boolean], includeWipPactsSince: Option[OffsetDateTime]): PendingPactSettings =
+    includeWipPactsSince match {
+      case Some(wipSince) => apply(wipSince)
+      case None           => apply(enablePending: Option[Boolean])
+    }
   def apply(enablePending: Option[Boolean]): PendingPactSettings = new PendingPactSettings(enablePending, None) {}
-  def apply(wipPactsSince: OffsetDateTime): PendingPactSettings  = new PendingPactSettings(Some(true), Some(wipPactsSince)) {}
+  def apply(wipPactsSince: OffsetDateTime): PendingPactSettings =
+    new PendingPactSettings(Some(true), Some(wipPactsSince)) {}
 }

--- a/scalapact-shared/src/main/scala/com/itv/scalapact/shared/PendingPactSettings.scala
+++ b/scalapact-shared/src/main/scala/com/itv/scalapact/shared/PendingPactSettings.scala
@@ -2,26 +2,25 @@ package com.itv.scalapact.shared
 
 import java.time.OffsetDateTime
 
-sealed abstract case class PendingPactSettings(
-    enablePending: Option[Boolean],
-    includeWipPactsSince: Option[OffsetDateTime]
-) {
-  def append(that: PendingPactSettings): PendingPactSettings = that match {
-    case PendingPactSettings(_, Some(wip))   => new PendingPactSettings(Some(true), Some(wip)) {}
-    case PendingPactSettings(Some(false), _) => PendingPactSettings(Some(false))
-    case PendingPactSettings(ep, wip) =>
-      new PendingPactSettings(ep.orElse(this.enablePending), wip.orElse(this.includeWipPactsSince)) {}
-  }
+sealed trait PendingPactSettings {
+  def enablePending: Boolean
+  def includeWipPactsSince: Option[OffsetDateTime]
 }
 
 object PendingPactSettings {
-  def empty: PendingPactSettings = new PendingPactSettings(None, None) {}
-  def apply(enablePending: Option[Boolean], includeWipPactsSince: Option[OffsetDateTime]): PendingPactSettings =
-    includeWipPactsSince match {
-      case Some(wipSince) => apply(wipSince)
-      case None           => apply(enablePending: Option[Boolean])
-    }
-  def apply(enablePending: Option[Boolean]): PendingPactSettings = new PendingPactSettings(enablePending, None) {}
-  def apply(wipPactsSince: OffsetDateTime): PendingPactSettings =
-    new PendingPactSettings(Some(true), Some(wipPactsSince)) {}
+
+  case object PendingDisabled extends PendingPactSettings {
+    val enablePending: Boolean = false
+    val includeWipPactsSince: Option[OffsetDateTime] = None
+  }
+
+  case object PendingEnabled extends PendingPactSettings {
+    val enablePending: Boolean = true
+    val includeWipPactsSince: Option[OffsetDateTime] = None
+  }
+
+  case class IncludeWipPacts(wipPactsSince: OffsetDateTime) extends PendingPactSettings {
+    val enablePending: Boolean = true
+    val includeWipPactsSince: Option[OffsetDateTime] = Some(wipPactsSince)
+  }
 }

--- a/scalapact-shared/src/main/scala/com/itv/scalapact/shared/PendingPactSettings.scala
+++ b/scalapact-shared/src/main/scala/com/itv/scalapact/shared/PendingPactSettings.scala
@@ -10,17 +10,17 @@ sealed trait PendingPactSettings {
 object PendingPactSettings {
 
   case object PendingDisabled extends PendingPactSettings {
-    val enablePending: Boolean = false
+    val enablePending: Boolean                       = false
     val includeWipPactsSince: Option[OffsetDateTime] = None
   }
 
   case object PendingEnabled extends PendingPactSettings {
-    val enablePending: Boolean = true
+    val enablePending: Boolean                       = true
     val includeWipPactsSince: Option[OffsetDateTime] = None
   }
 
   case class IncludeWipPacts(wipPactsSince: OffsetDateTime) extends PendingPactSettings {
-    val enablePending: Boolean = true
+    val enablePending: Boolean                       = true
     val includeWipPactsSince: Option[OffsetDateTime] = Some(wipPactsSince)
   }
 }

--- a/scalapact-shared/src/main/scala/com/itv/scalapact/shared/ScalaPactSettings.scala
+++ b/scalapact-shared/src/main/scala/com/itv/scalapact/shared/ScalaPactSettings.scala
@@ -1,5 +1,7 @@
 package com.itv.scalapact.shared
 
+import java.time.OffsetDateTime
+
 import com.itv.scalapact.shared.utils.Helpers
 
 import scala.concurrent.duration.{Duration, SECONDS}
@@ -14,7 +16,8 @@ case class ScalaPactSettings(
     clientTimeout: Option[Duration],
     outputPath: Option[String],
     publishResultsEnabled: Option[BrokerPublishData],
-    enablePending: Option[Boolean]
+    enablePending: Option[Boolean],
+    includeWipPactsSince: Option[OffsetDateTime]
 ) {
   val giveHost: String            = host.getOrElse("localhost")
   val giveProtocol: String        = protocol.getOrElse("http")
@@ -73,7 +76,7 @@ object ScalaPactSettings {
 
   def apply: ScalaPactSettings = default
 
-  def default: ScalaPactSettings = ScalaPactSettings(None, None, None, None, None, None, None, None, None)
+  def default: ScalaPactSettings = ScalaPactSettings(None, None, None, None, None, None, None, None, None, None)
 
   val parseArguments: Seq[String] => ScalaPactSettings = args => (Helpers.pair andThen convertToArguments)(args.toList)
 
@@ -87,7 +90,8 @@ object ScalaPactSettings {
       clientTimeout = b.clientTimeout.orElse(a.clientTimeout),
       outputPath = b.outputPath.orElse(a.outputPath),
       publishResultsEnabled = b.publishResultsEnabled.orElse(a.publishResultsEnabled),
-      enablePending = b.enablePending.orElse(a.enablePending)
+      enablePending = b.enablePending.orElse(a.enablePending),
+      includeWipPactsSince = b.includeWipPactsSince.orElse(a.includeWipPactsSince)
     )
 
   private lazy val convertToArguments: Map[String, String] => ScalaPactSettings = argMap =>
@@ -101,7 +105,8 @@ object ScalaPactSettings {
         argMap.get("--clientTimeout").flatMap(Helpers.safeStringToLong).flatMap(i => Option(Duration(i, SECONDS))),
       outputPath = argMap.get("--out"),
       publishResultsEnabled = calculateBrokerPublishData(argMap),
-      enablePending = argMap.get("--enablePending").flatMap(Helpers.safeStringToBoolean)
+      enablePending = argMap.get("--enablePending").flatMap(Helpers.safeStringToBoolean),
+      includeWipPactsSince = argMap.get("--includeWipPactsSince").flatMap(Helpers.safeStringToDateTime)
     )
 
   private def calculateBrokerPublishData(argMap: Map[String, String]): Option[BrokerPublishData] = {

--- a/scalapact-shared/src/main/scala/com/itv/scalapact/shared/ScalaPactSettings.scala
+++ b/scalapact-shared/src/main/scala/com/itv/scalapact/shared/ScalaPactSettings.scala
@@ -1,12 +1,11 @@
 package com.itv.scalapact.shared
 
-import java.time.OffsetDateTime
-
-import com.itv.scalapact.shared.utils.Helpers
+import com.itv.scalapact.shared.utils.{Helpers, PactLogger}
 
 import scala.concurrent.duration.{Duration, SECONDS}
 import scala.util.Properties
 
+//Command line settings - these should override any corresponding sbt settings
 case class ScalaPactSettings(
     protocol: Option[String],
     host: Option[String],
@@ -16,8 +15,7 @@ case class ScalaPactSettings(
     clientTimeout: Option[Duration],
     outputPath: Option[String],
     publishResultsEnabled: Option[BrokerPublishData],
-    enablePending: Option[Boolean],
-    includeWipPactsSince: Option[OffsetDateTime]
+    pendingPactSettings: PendingPactSettings
 ) {
   val giveHost: String            = host.getOrElse("localhost")
   val giveProtocol: String        = protocol.getOrElse("http")
@@ -25,7 +23,6 @@ case class ScalaPactSettings(
   val giveStrictMode: Boolean     = strictMode.getOrElse(false)
   val giveClientTimeout: Duration = clientTimeout.getOrElse(Duration(1, SECONDS))
   val giveOutputPath: String      = outputPath.getOrElse(Properties.envOrElse("pact.rootDir", "target/pacts"))
-  val giveEnablePending: Boolean  = enablePending.getOrElse(false)
 
   def +(other: ScalaPactSettings): ScalaPactSettings =
     ScalaPactSettings.append(this, other)
@@ -76,7 +73,8 @@ object ScalaPactSettings {
 
   def apply: ScalaPactSettings = default
 
-  def default: ScalaPactSettings = ScalaPactSettings(None, None, None, None, None, None, None, None, None, None)
+  def default: ScalaPactSettings =
+    ScalaPactSettings(None, None, None, None, None, None, None, None, PendingPactSettings.empty)
 
   val parseArguments: Seq[String] => ScalaPactSettings = args => (Helpers.pair andThen convertToArguments)(args.toList)
 
@@ -90,8 +88,7 @@ object ScalaPactSettings {
       clientTimeout = b.clientTimeout.orElse(a.clientTimeout),
       outputPath = b.outputPath.orElse(a.outputPath),
       publishResultsEnabled = b.publishResultsEnabled.orElse(a.publishResultsEnabled),
-      enablePending = b.enablePending.orElse(a.enablePending),
-      includeWipPactsSince = b.includeWipPactsSince.orElse(a.includeWipPactsSince)
+      pendingPactSettings = b.pendingPactSettings.append(a.pendingPactSettings)
     )
 
   private lazy val convertToArguments: Map[String, String] => ScalaPactSettings = argMap =>
@@ -105,12 +102,27 @@ object ScalaPactSettings {
         argMap.get("--clientTimeout").flatMap(Helpers.safeStringToLong).flatMap(i => Option(Duration(i, SECONDS))),
       outputPath = argMap.get("--out"),
       publishResultsEnabled = calculateBrokerPublishData(argMap),
-      enablePending = argMap.get("--enablePending").flatMap(Helpers.safeStringToBoolean),
-      includeWipPactsSince = argMap.get("--includeWipPactsSince").flatMap(Helpers.safeStringToDateTime)
+      pendingPactSettings = calculatePendingPactSettings(argMap)
     )
 
   private def calculateBrokerPublishData(argMap: Map[String, String]): Option[BrokerPublishData] = {
     val buildUrl = argMap.get("--publishResultsBuildUrl")
     argMap.get("--publishResultsVersion").map(BrokerPublishData(_, buildUrl))
+  }
+
+  private def calculatePendingPactSettings(argMap: Map[String, String]): PendingPactSettings = {
+    val wipSince      = argMap.get("--includeWipPactsSince").flatMap(Helpers.safeStringToDateTime)
+    val enablePending = argMap.get("--enablePending").flatMap(Helpers.safeStringToBoolean)
+    (wipSince, enablePending) match {
+      case (Some(wipSince), Some(false)) =>
+        PactLogger.warn(
+          "WIP pacts cannot be retrieved if --enablePending is set to false. Setting --enablePending to true."
+        )
+        PendingPactSettings(wipSince)
+      case (Some(wipSince), _) =>
+        PendingPactSettings(wipSince)
+      case (_, ep) =>
+        PendingPactSettings(ep)
+    }
   }
 }

--- a/scalapact-shared/src/main/scala/com/itv/scalapact/shared/ScalaPactSettings.scala
+++ b/scalapact-shared/src/main/scala/com/itv/scalapact/shared/ScalaPactSettings.scala
@@ -78,7 +78,7 @@ object ScalaPactSettings {
 
   val parseArguments: Seq[String] => ScalaPactSettings = args => (Helpers.pair andThen convertToArguments)(args.toList)
 
-  def append(a: ScalaPactSettings, b: ScalaPactSettings): ScalaPactSettings = {
+  def append(a: ScalaPactSettings, b: ScalaPactSettings): ScalaPactSettings =
     ScalaPactSettings(
       host = b.host.orElse(a.host),
       protocol = b.protocol.orElse(a.protocol),
@@ -90,7 +90,6 @@ object ScalaPactSettings {
       publishResultsEnabled = b.publishResultsEnabled.orElse(a.publishResultsEnabled),
       pendingPactSettings = a.pendingPactSettings.orElse(b.pendingPactSettings)
     )
-  }
 
   private lazy val convertToArguments: Map[String, String] => ScalaPactSettings = argMap =>
     ScalaPactSettings(
@@ -125,7 +124,7 @@ object ScalaPactSettings {
       case (_, Some(true)) =>
         Some(PendingPactSettings.PendingEnabled)
       case (_, Some(false)) => Some(PendingPactSettings.PendingDisabled)
-      case (_, _) => None
+      case (_, _)           => None
     }
   }
 }

--- a/scalapact-shared/src/main/scala/com/itv/scalapact/shared/utils/Helpers.scala
+++ b/scalapact-shared/src/main/scala/com/itv/scalapact/shared/utils/Helpers.scala
@@ -2,6 +2,7 @@ package com.itv.scalapact.shared.utils
 
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
+import java.time.OffsetDateTime
 
 import com.itv.scalapact.shared.utils.ColourOutput.ColouredString
 
@@ -11,7 +12,7 @@ import scala.util.control.NonFatal
 
 object Helpers {
 
-  implicit class OptionOps[A](val value: Option[A]) extends AnyVal {
+  implicit class TryOps[A](val value: Option[A]) extends AnyVal {
     def whenEmpty(todo: => Unit): Option[A] = value match {
       case None =>
         todo
@@ -51,6 +52,10 @@ object Helpers {
   )
   def safeStringToDouble(str: String): Option[Double] = Try(str.toDouble).toOption.whenEmpty(
     PactLogger.error(s"Failed to convert string '$str' to number (double)".red)
+  )
+
+  def safeStringToDateTime(str: String): Option[OffsetDateTime] = Try(OffsetDateTime.parse(str)).toOption.whenEmpty(
+    PactLogger.error(s"Failed to convert string '$str' to date (OffsetDateTime).".red)
   )
 
   val urlEncode: String => Either[String, String] = str => {

--- a/scalapact-shared/src/main/scala/com/itv/scalapact/shared/utils/Helpers.scala
+++ b/scalapact-shared/src/main/scala/com/itv/scalapact/shared/utils/Helpers.scala
@@ -2,7 +2,7 @@ package com.itv.scalapact.shared.utils
 
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
-import java.time.OffsetDateTime
+import java.time.{LocalDate, LocalDateTime, OffsetDateTime, OffsetTime, ZoneOffset}
 
 import com.itv.scalapact.shared.utils.ColourOutput.ColouredString
 
@@ -54,9 +54,14 @@ object Helpers {
     PactLogger.error(s"Failed to convert string '$str' to number (double)".red)
   )
 
-  def safeStringToDateTime(str: String): Option[OffsetDateTime] = Try(OffsetDateTime.parse(str)).toOption.whenEmpty(
-    PactLogger.error(s"Failed to convert string '$str' to date (OffsetDateTime).".red)
-  )
+  def safeStringToDateTime(str: String): Option[OffsetDateTime] =
+    (Try(OffsetDateTime.parse(str)) orElse
+      Try(LocalDate.parse(str).atTime(OffsetTime.parse("00:00Z"))) orElse
+      Try(LocalDateTime.parse(str).atOffset(ZoneOffset.UTC))).toOption.whenEmpty(
+      PactLogger.error(
+        s"Failed to convert string '$str' to date. Should be one of OffsetDateTime, LocalDateTime, LocalDate.".red
+      )
+    )
 
   val urlEncode: String => Either[String, String] = str => {
     try Right(

--- a/scalapact-shared/src/main/scala/com/itv/scalapact/shared/utils/Helpers.scala
+++ b/scalapact-shared/src/main/scala/com/itv/scalapact/shared/utils/Helpers.scala
@@ -12,7 +12,7 @@ import scala.util.control.NonFatal
 
 object Helpers {
 
-  implicit class TryOps[A](val value: Option[A]) extends AnyVal {
+  implicit class OptionOps[A](val value: Option[A]) extends AnyVal {
     def whenEmpty(todo: => Unit): Option[A] = value match {
       case None =>
         todo

--- a/scalapact-shared/src/test/scala/com/itv/scalapact/shared/utils/HelpersSpec.scala
+++ b/scalapact-shared/src/test/scala/com/itv/scalapact/shared/utils/HelpersSpec.scala
@@ -1,5 +1,7 @@
 package com.itv.scalapact.shared.utils
 
+import java.time.{OffsetDateTime, ZoneOffset}
+
 import org.scalatest.{FunSpec, Matchers}
 
 class HelpersSpec extends FunSpec with Matchers {
@@ -20,9 +22,12 @@ class HelpersSpec extends FunSpec with Matchers {
     }
 
     it("should parse various date strings") {
-      Helpers.safeStringToDateTime("2020-08-06").isDefined shouldBe true
-      Helpers.safeStringToDateTime("2020-08-06T10:30:30").isDefined shouldBe true
-      Helpers.safeStringToDateTime("2020-08-06T10:30:30+01:00").isDefined shouldBe true
+      Helpers.safeStringToDateTime("2020-08-06") shouldBe
+        Some(OffsetDateTime.of(2020, 8, 6, 0, 0, 0, 0, ZoneOffset.UTC))
+      Helpers.safeStringToDateTime("2020-08-06T10:30:30") shouldBe
+        Some(OffsetDateTime.of(2020, 8, 6, 10, 30, 30, 0, ZoneOffset.UTC))
+      Helpers.safeStringToDateTime("2020-08-06T10:30:30+01:00") shouldBe
+        Some(OffsetDateTime.of(2020, 8, 6, 10, 30, 30, 0, ZoneOffset.ofHours(1)))
     }
 
   }

--- a/scalapact-shared/src/test/scala/com/itv/scalapact/shared/utils/HelpersSpec.scala
+++ b/scalapact-shared/src/test/scala/com/itv/scalapact/shared/utils/HelpersSpec.scala
@@ -22,7 +22,7 @@ class HelpersSpec extends FunSpec with Matchers {
     it("should parse various date strings") {
       Helpers.safeStringToDateTime("2020-08-06").isDefined shouldBe true
       Helpers.safeStringToDateTime("2020-08-06T10:30:30").isDefined shouldBe true
-      Helpers.safeStringToDateTime("2020-08-06T10:30:30.001+1:00").isDefined shouldBe true
+      Helpers.safeStringToDateTime("2020-08-06T10:30:30+01:00").isDefined shouldBe true
     }
 
   }

--- a/scalapact-shared/src/test/scala/com/itv/scalapact/shared/utils/HelpersSpec.scala
+++ b/scalapact-shared/src/test/scala/com/itv/scalapact/shared/utils/HelpersSpec.scala
@@ -19,6 +19,12 @@ class HelpersSpec extends FunSpec with Matchers {
 
     }
 
+    it("should parse various date strings") {
+      Helpers.safeStringToDateTime("2020-08-06").isDefined shouldBe true
+      Helpers.safeStringToDateTime("2020-08-06T10:30:30").isDefined shouldBe true
+      Helpers.safeStringToDateTime("2020-08-06T10:30:30.001+1:00").isDefined shouldBe true
+    }
+
   }
 
 }

--- a/scripts/test-pending-pacts.sh
+++ b/scripts/test-pending-pacts.sh
@@ -18,6 +18,6 @@ sbt clean update test
 echo "Testing using the CLI with --includeWipPactsSince"
 sbt run &
 echo "warming things up..."
-simple_countdown 30
-sbt "pactVerify --enablePending true --includeWipPactsSince 2020-11-11T00:42Z --port 8080"
+simple_countdown 10
+sbt "pactVerify --enablePending true --includeWipPactsSince 2020-11-11T00:42Z --host localhost --port 8080 --clientTimeout 5"
 cd ../..

--- a/scripts/test-pending-pacts.sh
+++ b/scripts/test-pending-pacts.sh
@@ -21,3 +21,5 @@ echo "warming things up..."
 simple_countdown 10
 sbt "pactVerify --enablePending true --includeWipPactsSince 2020-11-11T00:42Z --host localhost --port 8080 --clientTimeout 5"
 cd ../..
+
+pkill -1 -f sbt-launch.jar

--- a/scripts/test-pending-pacts.sh
+++ b/scripts/test-pending-pacts.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+source scripts/test-header.sh
+
 echo "Checking pending pacts tests"
 echo "***********************"
 
@@ -12,4 +14,10 @@ cd ..
 
 cd provider
 sbt clean update test
+
+echo "Testing using the CLI with --includeWipPactsSince"
+sbt run &
+echo "warming things up..."
+simple_countdown 30
+sbt "pactVerify --enablePending true --includeWipPactsSince 2020-11-11T00:42Z --port 8080"
 cd ../..


### PR DESCRIPTION
https://github.com/ITV/scala-pact/issues/161

Adds a CLI setting `--includeWipPactsSince` that is passed to the pact broker when verifying pacts from the provider, which (as the name suggests) fetched pacts that the broker determined are "WIP". See the original issue for more details https://github.com/pact-foundation/pact_broker/issues/338. This accepts dates in the following formats: `2020-10-23`, `2020-10-23T22:00` and `2020-10-23T22:00+01:00` i.e. java LocalDate, LocalDateTime and OffsetDateTime. Default values for the hour/minute are 00:00, and the default timezone is UTC. 

In the verification test suite, the field `includePendingStatus` is replaced with a field `pendingPactSettings`, which encompasses settings for fetching pending pacts, and the finer-grained WIP pacts. `PendingPactSettings` is an ADT with 3 possible values: `PendingDisabled`, `PendingEnabled`, and `IncludeWipPacts(wipPactsSince: OffsetDateTime)`. 

As the date for WIP pacts to be fetched from is in most cases going to be dynamic based on the current date, I have not included an sbt setting key for it, as I would recommend it being set using the CLI arguments. If there is demand, we can add it there too though. 