### PR TITLE
Fixes #207: tagging provider verifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ credentials.sbt
 *.html
 
 # IDE
+.bsp
 .idea
 .idea_modules
 *.iml

--- a/scalapact-core/src/main/scala/com/itv/scalapactcore/verifier/PactsForVerificationVerifier.scala
+++ b/scalapact-core/src/main/scala/com/itv/scalapactcore/verifier/PactsForVerificationVerifier.scala
@@ -42,6 +42,7 @@ private[verifier] class PactsForVerificationVerifier(
       pactBrokerClient.publishVerificationResults(
         resultsAndProperties.map(_._1),
         publishData,
+        verificationSettings.providerVersionTags,
         verificationSettings.pactBrokerAuthorization,
         verificationSettings.pactBrokerClientTimeout,
         verificationSettings.sslContextName

--- a/scalapact-core/src/main/scala/com/itv/scalapactcore/verifier/PrePactsForVerificationVerifier.scala
+++ b/scalapact-core/src/main/scala/com/itv/scalapactcore/verifier/PrePactsForVerificationVerifier.scala
@@ -57,11 +57,12 @@ private[verifier] class PrePactsForVerificationVerifier(
 
     scalaPactSettings.publishResultsEnabled.foreach { publishData =>
       brokerClient.publishVerificationResults(
-        pactVerifyResults,
-        publishData,
-        pactVerifySettings.pactBrokerAuthorization,
-        pactVerifySettings.pactBrokerClientTimeout,
-        pactVerifySettings.sslContextName
+        pactVerifyResults = pactVerifyResults,
+        brokerPublishData = publishData,
+        providerVersionTags = Nil,
+        pactBrokerAuthorization = pactVerifySettings.pactBrokerAuthorization,
+        brokerClientTimeout = pactVerifySettings.pactBrokerClientTimeout,
+        sslContextName = pactVerifySettings.sslContextName
       )
     }
 


### PR DESCRIPTION
See #207 -- adds tags to the provider version prior to verifying results. The `pb:provider` link should be defined here, according to https://github.com/pact-foundation/pact_broker/blob/master/spec/lib/pact_broker/api/decorators/pact_decorator_spec.rb#L81