### PR TITLE
Fixes #204: require explicitly enabling ScalaPactPlugin on projects.

### DIFF
--- a/broker-integration-tests/provider/build.sbt
+++ b/broker-integration-tests/provider/build.sbt
@@ -1,8 +1,11 @@
 import java.io.File
+import com.itv.scalapact.plugin._
 
 name := "provider"
 
 scalaVersion := "2.13.3"
+
+enablePlugins(ScalaPactPlugin)
 
 lazy val pactVersionFile: SettingKey[File] = settingKey[File]("location of scala-pact version for these tests")
 pactVersionFile := baseDirectory.value.getParentFile.getParentFile / "version.sbt"

--- a/broker-integration-tests/provider/build.sbt
+++ b/broker-integration-tests/provider/build.sbt
@@ -1,5 +1,4 @@
 import java.io.File
-import com.itv.scalapact.plugin._
 
 name := "provider"
 

--- a/example/provider/delivered_pacts/scala-pact-consumer_scala-pact-provider.json
+++ b/example/provider/delivered_pacts/scala-pact-consumer_scala-pact-provider.json
@@ -66,7 +66,7 @@
       "version" : "2.0.0"
     },
     "scala-pact" : {
-      "version" : "2.4.1-SNAPSHOT"
+      "version" : "3.0.2-SNAPSHOT"
     }
   }
 }

--- a/example/provider/pact.sbt
+++ b/example/provider/pact.sbt
@@ -7,6 +7,8 @@ import com.itv.scalapact.shared.ProviderStateResult
 
 import scala.concurrent.duration._
 
+enablePlugins(ScalaPactPlugin)
+
 scalaPactEnv :=
   ScalaPactEnv.defaults
     .withPort(8080)

--- a/example/provider_pact-for-verification/build.sbt
+++ b/example/provider_pact-for-verification/build.sbt
@@ -1,11 +1,13 @@
 import java.io.File
+import com.itv.scalapact.plugin._
 
 organization := "com.example"
 
 name := "provider_pacts-for-verification"
 
-
 scalaVersion := "2.13.3"
+
+enablePlugins(ScalaPactPlugin)
 
 lazy val pactVersionFile: SettingKey[File] = settingKey[File]("location of scala-pact version for examples")
 pactVersionFile := baseDirectory.value.getParentFile.getParentFile / "version.sbt"

--- a/example/provider_pact-for-verification/build.sbt
+++ b/example/provider_pact-for-verification/build.sbt
@@ -1,5 +1,4 @@
 import java.io.File
-import com.itv.scalapact.plugin._
 
 organization := "com.example"
 

--- a/example/provider_tests/build.sbt
+++ b/example/provider_tests/build.sbt
@@ -4,7 +4,6 @@ organization := "com.example"
 
 name := "provider_tests"
 
-
 scalaVersion := "2.13.3"
 
 lazy val pactVersionFile: SettingKey[File] = settingKey[File]("location of scala-pact version for examples")

--- a/example/provider_tests/delivered_pacts/scala-pact-consumer_scala-pact-provider.json
+++ b/example/provider_tests/delivered_pacts/scala-pact-consumer_scala-pact-provider.json
@@ -66,7 +66,7 @@
       "version" : "2.0.0"
     },
     "scala-pact" : {
-      "version" : "2.4.1-SNAPSHOT"
+      "version" : "3.0.2-SNAPSHOT"
     }
   }
 }

--- a/sbt-scalapact/src/main/scala/com/itv/scalapact/plugin/ScalaPactPlugin.scala
+++ b/sbt-scalapact/src/main/scala/com/itv/scalapact/plugin/ScalaPactPlugin.scala
@@ -15,7 +15,7 @@ import scala.language.implicitConversions
 
 object ScalaPactPlugin extends AutoPlugin {
   override def requires: JvmPlugin.type = plugins.JvmPlugin
-  override def trigger: PluginTrigger   = allRequirements
+  override def trigger: PluginTrigger   = noTrigger
 
   @SuppressWarnings(Array("org.wartremover.warts.ImplicitConversion"))
   implicit def booleanToProviderStateResult(bool: Boolean): ProviderStateResult = ProviderStateResult(bool)

--- a/scripts/test-verifier.sh
+++ b/scripts/test-verifier.sh
@@ -15,6 +15,8 @@ echo "addSbtPlugin(\"com.itv\" % \"sbt-scalapact\" % \"$CORE_VERSION\")" >> $PLU
 cat > $PACT_CONFIG_FILE <<EOL
 import com.itv.scalapact.plugin.ScalaPactPlugin._
 
+enablePlugins(ScalaPactPlugin)
+
 providerStates := Seq(
 ("Resource with ID 1234 exists", (_: String) => {
  println("Injecting key 1234 into the database...")


### PR DESCRIPTION
Using `allRequirements` means that the plugin is automatically applied to every project in a multi-project build, which can be problematic for projects which don't need the plugin. Using `noTrigger` means you must explicitly enable the plugin on each project with `.enablePlugins(ScalaPactPlugin)`.

Note: this should be considered a breaking change, even though it matches the documented use of the plugin, so at the very least it should be released as a minor version update.