### PR TITLE
Fixes #212: ensure pact path is consistent

### DIFF
--- a/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactContractWriter.scala
+++ b/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactContractWriter.scala
@@ -2,11 +2,12 @@ package com.itv.scalapact
 
 import java.io.{File, PrintWriter}
 import java.nio.charset.StandardCharsets
-
 import com.itv.scalapact.model.ScalaPactMatchingRule._
 import com.itv.scalapact.model.{ScalaPactDescriptionFinal, ScalaPactInteractionFinal, ScalaPactMatchingRule}
 import com.itv.scalapact.shared._
 import com.itv.scalapact.shared.json.IPactWriter
+
+import java.nio.file.Paths
 
 private[scalapact] object ScalaPactContractWriter {
   def writePactContracts(outputPath: String)(implicit pactWriter: IPactWriter): ScalaPactDescriptionFinal => Unit =
@@ -29,10 +30,13 @@ private[scalapact] object ScalaPactContractWriter {
         .map("%02x".format(_))
         .mkString
 
-      val relativePath = outputPath + "/" + simplifyName(pactDescription.consumer) + "_" + simplifyName(
-        pactDescription.provider
-      ) + "_" + sha1 + "_tmp.json"
-      val file = new File(relativePath)
+      val path = Paths.get(
+        // #212: ensure a consistent path is used between projects and sub-projects
+        dirFile.getAbsolutePath,
+        simplifyName(pactDescription.consumer) + "_" +
+          simplifyName(pactDescription.provider) + "_" + sha1 + "_tmp.json"
+      )
+      val file = new File(path.toUri)
 
       if (file.exists()) {
         file.delete()
@@ -40,7 +44,7 @@ private[scalapact] object ScalaPactContractWriter {
 
       file.createNewFile()
 
-      new PrintWriter(relativePath) {
+      new PrintWriter(file) {
         write(producePactJson(pactDescription))
         close()
       }


### PR DESCRIPTION
See #212 -- it seems that when given a `new File(relativePath)`, `file.createNewFile()` will create a file in a different place for SBT sub-projects and root-projects. Using `new File(absolutePath)` instead resolves this issue.

I'm not sure the best way to add test coverage for this, but it can be reproduced by:
- creating an SBT project that has a sub-project and a root project both with `.enablePlugins(ScalaPactPlugin)`.
- creating a consumer pact in both projects and and running tests against them (`sbt pactTest`, assuming you `.aggregate` the sub-project in the root project)
- you should see pact files get generated in the root `target/pacts` folder, as well as in `subProject/target/pacts` prior to this fix, and after this fix they should both be in the root `target/pacts` folder.