### PR TITLE
Fixes #216: only sys.exit from SBT tasks on failure

### DIFF
--- a/sbt-scalapact-shared/src/main/scala/com/itv/scalapact/plugin/shared/ScalaPactPublishCommand.scala
+++ b/sbt-scalapact-shared/src/main/scala/com/itv/scalapact/plugin/shared/ScalaPactPublishCommand.scala
@@ -58,11 +58,8 @@ object ScalaPactPublishCommand {
       case result: PublishFailed  => PactLogger.error(result.renderAsString)
     }
 
-    if (publishResults.forall(_.isSuccess)) exitSuccess()
-    else exitFailure()
+    if (!publishResults.forall(_.isSuccess)) exitFailure()
   }
-
-  private def exitSuccess(): Unit = sys.exit(0)
 
   private def exitFailure(): Unit = sys.exit(1)
 }

--- a/sbt-scalapact-shared/src/main/scala/com/itv/scalapact/plugin/shared/ScalaPactVerifyCommand.scala
+++ b/sbt-scalapact-shared/src/main/scala/com/itv/scalapact/plugin/shared/ScalaPactVerifyCommand.scala
@@ -73,9 +73,7 @@ object ScalaPactVerifyCommand {
     }
 
     val successfullyVerified = Verifier.apply.verify(pactVerifySettings, scalaPactSettings)
-
-    if (successfullyVerified) sys.exit(0) else sys.exit(1)
-
+    if (!successfullyVerified) sys.exit(1)
   }
 
   def combineProviderStatesIntoTotalFunction(


### PR DESCRIPTION
Fixes early termination when running SBT commands in sequence. See #216 for more information.