### PR TITLE
ScalaPactInteraction: add `uponReceiving(ScalaPactRequest)` and `willRespondWith(ScalaPactResponse)` methods

### DIFF
--- a/scalapact-scalatest/src/main/scala/com/itv/scalapact/model/ScalaPactInteraction.scala
+++ b/scalapact-scalatest/src/main/scala/com/itv/scalapact/model/ScalaPactInteraction.scala
@@ -49,11 +49,14 @@ class ScalaPactInteraction(
       body: Option[String],
       matchingRules: ScalaPactMatchingRules
   ): ScalaPactInteraction =
+    uponReceiving(ScalaPactRequest(method, path, query, headers, body, matchingRules.toOption))
+
+  def uponReceiving(request: ScalaPactRequest): ScalaPactInteraction =
     new ScalaPactInteraction(
       description,
       providerState,
       sslContextName,
-      ScalaPactRequest(method, path, query, headers, body, matchingRules.toOption),
+      request,
       response
     )
 
@@ -72,12 +75,15 @@ class ScalaPactInteraction(
       body: Option[String],
       matchingRules: ScalaPactMatchingRules
   ): ScalaPactInteraction =
+    willRespondWith(ScalaPactResponse(status, headers, body, matchingRules.toOption))
+
+  def willRespondWith(response: ScalaPactResponse): ScalaPactInteraction =
     new ScalaPactInteraction(
       description,
       providerState,
       sslContextName,
       request,
-      ScalaPactResponse(status, headers, body, matchingRules.toOption)
+      response
     )
 
   private[scalapact] def finalise: ScalaPactInteractionFinal =


### PR DESCRIPTION
Seemed to make sense to add `uponReceiving(ScalaPactRequest)` and `willRespondWith(ScalaPactResponse)` methods so that users could re-use existing requests or responses that they already have in scope.