### PR TITLE
PactStubber: use the `Resource.allocated` method to handle the creation and shutdown of the server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ credentials.sbt
 .bloop/
 .bloop
 .metals/
+metals.sbt
 
 # Misc
 .DS_Store
@@ -24,6 +25,9 @@ credentials.sbt
 .idea
 .idea_modules
 *.iml
+.history
+.vscode
+
 
 # Ruby
 *.gem

--- a/scalapact-http4s-0-23/src/main/scala/com/itv/scalapact/http4s23/impl/PactStubber.scala
+++ b/scalapact-http4s-0-23/src/main/scala/com/itv/scalapact/http4s23/impl/PactStubber.scala
@@ -7,9 +7,9 @@ import com.itv.scalapact.shared.{IInteractionManager, IPactStubber, ScalaPactSet
 import com.itv.scalapact.shared.json.{IPactReader, IPactWriter}
 import org.http4s.blaze.server.BlazeServerBuilder
 
-class PactStubber extends IPactStubber {
+private final case class PortAndShutdownTask(port: Int, shutdown: IO[Unit])
 
-  private final case class PortAndShutdownTask(port: Int, shutdown: IO[Unit])
+class PactStubber extends IPactStubber {
 
   private var instance: Option[PortAndShutdownTask] = None
 


### PR DESCRIPTION
We're getting some issues trying to start the http4s-0.23 stubber. It looks like it can't get a port. Just seeing if this implementation makes more sense by using the `allocated` method.

Backported it to the 0.21 version too.