### PR TITLE
Add support for http4s 0.22

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -111,6 +111,22 @@ lazy val http4s021 =
     )
     .dependsOn(shared)
 
+lazy val http4s022 =
+  (project in file("scalapact-http4s-0-22"))
+    .settings(commonSettings: _*)
+    .settings(publishSettings: _*)
+    .settings(
+      name := "scalapact-http4s-0-22",
+      libraryDependencies ++= Seq(
+        "org.http4s"            %% "http4s-blaze-server" % "0.22.4" exclude ("org.scala-lang.modules", "scala-xml"),
+        "org.http4s"            %% "http4s-blaze-client" % "0.22.4" exclude ("org.scala-lang.modules", "scala-xml"),
+        "org.http4s"            %% "http4s-dsl"          % "0.22.4",
+        "com.github.tomakehurst" % "wiremock"            % "2.27.2" % "test"
+      )
+    )
+    .dependsOn(shared)
+
+
 lazy val http4s023 =
   (project in file("scalapact-http4s-0-23"))
     .settings(commonSettings: _*)
@@ -314,7 +330,7 @@ lazy val scalaPactProject =
       crossScalaVersions := Nil
     )
     .aggregate(shared, core, pluginShared, plugin, pluginNoDeps, framework, testShared)
-    .aggregate(http4s021, http4s023)
+    .aggregate(http4s021, http4s022, http4s023)
     .aggregate(argonaut62, circe13, circe14)
     .aggregate(standalone, frameworkWithDeps)
     .aggregate(docs)

--- a/scalapact-http4s-0-22/src/main/scala/com/itv/scalapact/http/package.scala
+++ b/scalapact-http4s-0-22/src/main/scala/com/itv/scalapact/http/package.scala
@@ -1,0 +1,5 @@
+package com.itv.scalapact
+
+import com.itv.scalapact.http4s22.impl._
+
+package object http extends HttpInstances

--- a/scalapact-http4s-0-22/src/main/scala/com/itv/scalapact/http4s22/impl/Http4sClientHelper.scala
+++ b/scalapact-http4s-0-22/src/main/scala/com/itv/scalapact/http4s22/impl/Http4sClientHelper.scala
@@ -1,0 +1,59 @@
+package com.itv.scalapact.http4s22.impl
+
+import cats.effect.{ContextShift, IO, Resource, Timer}
+import com.itv.scalapact.shared.http.{SimpleRequest, SimpleResponse, SslContextMap}
+import com.itv.scalapact.shared.utils.PactLogger
+import org.http4s._
+import org.http4s.blaze.client.BlazeClientBuilder
+import org.http4s.client.Client
+import org.http4s.client.middleware.{Retry, RetryPolicy}
+import org.http4s.headers.`User-Agent`
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+
+object Http4sClientHelper {
+
+  def defaultClient: Resource[IO, Client[IO]] =
+    buildPooledBlazeHttpClient(1, 5.seconds, None)
+
+  def buildPooledBlazeHttpClient(maxTotalConnections: Int, clientTimeout: Duration, sslContextName: Option[String])(
+      implicit sslContextMap: SslContextMap
+  ): Resource[IO, Client[IO]] = {
+    implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
+    implicit val timer: Timer[IO]     = IO.timer(ExecutionContext.global)
+    val sslContext                    = sslContextMap(sslContextName)
+    val builder = BlazeClientBuilder[IO](ExecutionContext.Implicits.global)
+      .withMaxTotalConnections(maxTotalConnections)
+      .withRequestTimeout(clientTimeout)
+      .withUserAgentOption(Option(`User-Agent`(ProductId("scala-pact", Option(BuildInfo.version)))))
+
+    PactLogger.debug(
+      s"Creating http4s client: connections $maxTotalConnections, timeout $clientTimeout, sslContextName: $sslContextName, sslContextMap: $sslContextMap"
+    )
+
+    sslContext.fold(builder)(s => builder.withSslContext(s)).resource.map {
+      Retry[IO](
+        RetryPolicy(
+          RetryPolicy.exponentialBackoff(30.seconds, 5),
+          RetryPolicy.defaultRetriable
+        )
+      )
+    }
+  }
+
+  def doRequest(request: SimpleRequest, httpClient: Resource[IO, Client[IO]]): IO[SimpleResponse] =
+    for {
+      request <- Http4sRequestResponseFactory.buildRequest(request)
+      _       <- IO(PactLogger.message(s"cURL for request: ${request.asCurl()}"))
+      response <- httpClient.use { c =>
+        c.run(request).use { r: Response[IO] =>
+          r.bodyText.compile.toVector
+            .map(_.mkString)
+            .map { b =>
+              SimpleResponse(r.status.code, r.headers.toMap, Some(b))
+            }
+        }
+      }
+    } yield response
+}

--- a/scalapact-http4s-0-22/src/main/scala/com/itv/scalapact/http4s22/impl/Http4sRequestResponseFactory.scala
+++ b/scalapact-http4s-0-22/src/main/scala/com/itv/scalapact/http4s22/impl/Http4sRequestResponseFactory.scala
@@ -1,0 +1,96 @@
+package com.itv.scalapact.http4s22.impl
+
+import java.nio.charset.StandardCharsets
+
+import cats.effect.IO
+import com.itv.scalapact.shared.http.HttpMethod._
+import com.itv.scalapact.shared.http.{HttpMethod, SimpleRequest}
+import fs2.Chunk
+import org.http4s.Method
+import org.http4s._
+import scodec.bits.ByteVector
+
+object Http4sRequestResponseFactory {
+
+  implicit val enc: EntityEncoder[IO, String] =
+    EntityEncoder.simple[IO, String]() { str =>
+      Chunk.bytes(ByteVector(str.getBytes(StandardCharsets.UTF_8)).toArray)
+    }
+
+  def buildUri(baseUrl: String, endpoint: String): IO[Uri] =
+    IO.fromEither(Uri.fromString(baseUrl + endpoint))
+
+  def intToStatus(status: IntAndReason): ParseResult[Status] =
+    status match {
+      case IntAndReason(code, Some(reason)) =>
+        Status.fromIntAndReason(code, reason)
+
+      case IntAndReason(code, None) =>
+        Status.fromInt(code)
+    }
+
+  def httpMethodToMethod(httpMethod: HttpMethod): Method =
+    httpMethod match {
+      case GET =>
+        Method.GET
+
+      case POST =>
+        Method.POST
+
+      case PUT =>
+        Method.PUT
+
+      case DELETE =>
+        Method.DELETE
+
+      case OPTIONS =>
+        Method.OPTIONS
+
+      case PATCH =>
+        Method.PATCH
+
+      case CONNECT =>
+        Method.CONNECT
+
+      case TRACE =>
+        Method.TRACE
+
+      case HEAD =>
+        Method.HEAD
+    }
+
+  def buildRequest(request: SimpleRequest): IO[Request[IO]] =
+    buildUri(request.baseUrl, request.endPoint).flatMap { uri =>
+      val r = Request[IO](
+        method = httpMethodToMethod(request.method),
+        uri = uri
+      ).withHeaders(
+        request.headers.toHttp4sHeaders
+      )
+
+      request.body
+        .map { b =>
+          IO(r.withEntity(b))
+        }
+        .getOrElse(IO(r))
+    }
+
+  def buildResponse(status: IntAndReason, headers: Map[String, String], body: Option[String]): Response[IO] =
+    intToStatus(status) match {
+      case Left(l) =>
+        l.toHttpResponse[IO](HttpVersion.`HTTP/1.1`)
+      case Right(code) =>
+        val response = Response[IO](
+          status = code
+        ).withHeaders(headers.toHttp4sHeaders)
+
+        body
+          .map { b =>
+            response.withEntity(b)
+          }
+          .getOrElse(response)
+    }
+
+}
+
+case class IntAndReason(code: Int, reason: Option[String])

--- a/scalapact-http4s-0-22/src/main/scala/com/itv/scalapact/http4s22/impl/HttpInstances.scala
+++ b/scalapact-http4s-0-22/src/main/scala/com/itv/scalapact/http4s22/impl/HttpInstances.scala
@@ -1,0 +1,39 @@
+package com.itv.scalapact.http4s22.impl
+
+import java.util.concurrent.ConcurrentHashMap
+
+import com.itv.scalapact.http4s22.impl.HttpInstances.ClientConfig
+import com.itv.scalapact.shared.IPactStubber
+import com.itv.scalapact.shared.http.{IScalaPactHttpClient, IScalaPactHttpClientBuilder, SslContextMap}
+import com.itv.scalapact.shared.utils.PactLogger
+
+import scala.concurrent.duration.Duration
+
+trait HttpInstances {
+
+  // Note that we create a new stubber anytime this implicit is needed (i.e. this is a `def`).
+  // We need this because implementations of `IPactStubber` might want to have their own state about the server running.
+  implicit def serverInstance: IPactStubber =
+    new PactStubber
+
+  private val clients: ConcurrentHashMap[ClientConfig, IScalaPactHttpClient] = new ConcurrentHashMap
+
+  implicit def httpClientBuilder(implicit sslContextMap: SslContextMap): IScalaPactHttpClientBuilder = {
+    (clientTimeout: Duration, sslContextName: Option[String], maxTotalConnections: Int) =>
+      val clientConfig = ClientConfig(clientTimeout, sslContextName, maxTotalConnections, sslContextMap)
+      PactLogger.debug(s"Checking client cache for config $clientConfig, cache size is ${clients.size}")
+      clients.computeIfAbsent(
+        clientConfig,
+        _ => ScalaPactHttpClient(clientTimeout, sslContextName, maxTotalConnections)
+      )
+  }
+}
+
+object HttpInstances {
+  private final case class ClientConfig(
+      timeout: Duration,
+      sslContextName: Option[String],
+      maxTotalConnections: Int,
+      sslContextMap: SslContextMap
+  )
+}

--- a/scalapact-http4s-0-22/src/main/scala/com/itv/scalapact/http4s22/impl/JsonString.scala
+++ b/scalapact-http4s-0-22/src/main/scala/com/itv/scalapact/http4s22/impl/JsonString.scala
@@ -1,0 +1,15 @@
+package com.itv.scalapact.http4s22.impl
+
+import cats.effect.IO
+import org.http4s.{EntityEncoder, MediaType}
+import org.http4s.headers.`Content-Type`
+
+final case class JsonString(value: String)
+
+object JsonString {
+  implicit val entityEncoder: EntityEncoder[IO, JsonString] =
+    EntityEncoder
+      .stringEncoder[IO]
+      .contramap[JsonString](_.value)
+      .withContentType(`Content-Type`(MediaType.application.json))
+}

--- a/scalapact-http4s-0-22/src/main/scala/com/itv/scalapact/http4s22/impl/PactStubService.scala
+++ b/scalapact-http4s-0-22/src/main/scala/com/itv/scalapact/http4s22/impl/PactStubService.scala
@@ -1,0 +1,159 @@
+package com.itv.scalapact.http4s22.impl
+
+import java.util.concurrent.Executors
+import cats.data.OptionT
+import cats.effect._
+import cats.implicits._
+import com.itv.scalapact.shared.http.SslContextMap
+import com.itv.scalapact.shared.json.{IPactReader, IPactWriter}
+import com.itv.scalapact.shared.{ScalaPactSettings, _}
+import org.http4s.blaze.BuildInfo
+import org.http4s.blaze.server.BlazeServerBuilder
+
+import javax.net.ssl.SSLContext
+import org.http4s.dsl.io._
+import org.http4s.implicits._
+import org.http4s.{BuildInfo => _, _}
+import org.typelevel.ci.CIStringSyntax
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+
+object PactStubService {
+
+  implicit class BlazeBuilderOps(val blazeBuilder: BlazeServerBuilder[IO]) extends AnyVal {
+    def withOptionalSsl(sslContext: Option[SSLContext]): BlazeServerBuilder[IO] =
+      sslContext.fold(blazeBuilder)(ssl => blazeBuilder.withSslContext(ssl))
+  }
+
+  def createServer(
+      interactionManager: IInteractionManager,
+      connectionPoolSize: Int,
+      sslContextName: Option[String],
+      port: Option[Int],
+      config: ScalaPactSettings
+  )(implicit pactReader: IPactReader, pactWriter: IPactWriter, sslContextMap: SslContextMap): BlazeServerBuilder[IO] = {
+
+    val executionContext: ExecutionContext =
+      ExecutionContext.fromExecutor(Executors.newFixedThreadPool(2))
+    implicit val cs: ContextShift[IO] = IO.contextShift(executionContext)
+    implicit val timer: Timer[IO]     = IO.timer(executionContext)
+
+    BlazeServerBuilder[IO](executionContext)
+      .bindHttp(port.getOrElse(config.givePort), config.giveHost)
+      .withIdleTimeout(60.seconds)
+      .withOptionalSsl(sslContextMap(sslContextName))
+      .withConnectorPoolSize(connectionPoolSize)
+      .withHttpApp(PactStubService.service(interactionManager, config.giveStrictMode))
+  }
+
+  def service(
+      interactionManager: IInteractionManager,
+      strictMatching: Boolean
+  )(implicit pactReader: IPactReader, pactWriter: IPactWriter): HttpApp[IO] = {
+
+    val isAdminCall: Request[IO] => Boolean = request =>
+      request.headers.get(ci"X-Pact-Admin").map(_.head.value).contains("true")
+
+    def admin(routes: HttpRoutes[IO]): HttpRoutes[IO] = HttpRoutes { req =>
+      if (isAdminCall(req)) routes(req)
+      else OptionT.none
+    }
+
+    def statusRoutes: HttpRoutes[IO] = HttpRoutes.of[IO] { case GET -> Root / "stub" / "status" =>
+      Ok()
+    }
+
+    def interactionsRoutes: HttpRoutes[IO] = HttpRoutes.of[IO] {
+      case req @ (PUT | POST) -> Root / "interactions" => putOrPostAdminInteraction(req)
+      case GET -> Root / "interactions" =>
+        val output =
+          pactWriter.pactToJsonString(
+            Pact(PactActor(""), PactActor(""), interactionManager.getInteractions, None, None),
+            BuildInfo.version
+          )
+        Ok(JsonString(output))
+      case DELETE -> Root / "interactions" =>
+        IO(interactionManager.clearInteractions()).flatMap { _ =>
+          val output =
+            pactWriter.pactToJsonString(
+              Pact(PactActor(""), PactActor(""), interactionManager.getInteractions, None, None),
+              BuildInfo.version
+            )
+          Ok(JsonString(output))
+        }
+    }
+
+    def putOrPostAdminInteraction(req: Request[IO]): IO[Response[IO]] =
+      req
+        .attemptAs[String]
+        .fold(_ => None, Option.apply)
+        .map { x =>
+          pactReader.jsonStringToScalaPact(x.getOrElse(""))
+        }
+        .flatMap {
+          case Right(r) =>
+            interactionManager.addInteractions(r.interactions)
+
+            val output =
+              pactWriter.pactToJsonString(
+                Pact(PactActor(""), PactActor(""), interactionManager.getInteractions, None, None),
+                BuildInfo.version
+              )
+            Ok(JsonString(output))
+
+          case Left(l) =>
+            InternalServerError(l)
+        }
+
+    def pactRoutes: HttpRoutes[IO] = HttpRoutes.of[IO] { case req =>
+      req.attemptAs[String].toOption.value.flatMap { maybeBody =>
+        interactionManager.findMatchingInteraction(
+          InteractionRequest(
+            method = Option(req.method.name.toUpperCase),
+            headers = Option(req.headers.toMap),
+            query =
+              if (req.params.isEmpty) None
+              else
+                Option(
+                  req.multiParams.toList
+                    .flatMap { case (key, values) => values.map((key, _)) }
+                    .map(p => p._1 + "=" + p._2)
+                    .mkString("&")
+                ),
+            path = Option(req.pathInfo.renderString),
+            body = maybeBody,
+            matchingRules = None
+          ),
+          strictMatching = strictMatching
+        ) match {
+          case Right(ir) =>
+            Status.fromInt(ir.response.status.getOrElse(200)) match {
+              case Right(_) =>
+                IO(
+                  Http4sRequestResponseFactory.buildResponse(
+                    status = IntAndReason(ir.response.status.getOrElse(200), None),
+                    headers = ir.response.headers.getOrElse(Map.empty),
+                    body = ir.response.body
+                  )
+                )
+
+              case Left(l) =>
+                InternalServerError(l.sanitized)
+            }
+
+          case Left(message) =>
+            IO(
+              Http4sRequestResponseFactory.buildResponse(
+                status = IntAndReason(598, Some("Pact Match Failure")),
+                headers = Map("X-Pact-Admin" -> "Pact Match Failure"),
+                body = Option(message)
+              )
+            )
+        }
+      }
+    }
+
+    (admin(statusRoutes) <+> admin(interactionsRoutes) <+> pactRoutes).orNotFound
+  }
+}

--- a/scalapact-http4s-0-22/src/main/scala/com/itv/scalapact/http4s22/impl/PactStubber.scala
+++ b/scalapact-http4s-0-22/src/main/scala/com/itv/scalapact/http4s22/impl/PactStubber.scala
@@ -1,0 +1,70 @@
+package com.itv.scalapact.http4s22.impl
+
+import cats.effect._
+import com.itv.scalapact.shared.http.SslContextMap
+import com.itv.scalapact.shared.{IInteractionManager, IPactStubber, ScalaPactSettings}
+import com.itv.scalapact.shared.json.{IPactReader, IPactWriter}
+import org.http4s.blaze.server.BlazeServerBuilder
+
+import scala.concurrent.ExecutionContext
+
+private final case class PortAndShutdownTask(port: Int, shutdown: IO[Unit])
+
+class PactStubber extends IPactStubber {
+
+  private var instance: Option[PortAndShutdownTask] = None
+
+  private def blazeServerBuilder(
+      scalaPactSettings: ScalaPactSettings,
+      interactionManager: IInteractionManager,
+      connectionPoolSize: Int,
+      sslContextName: Option[String],
+      port: Option[Int]
+  )(implicit pactReader: IPactReader, pactWriter: IPactWriter, sslContextMap: SslContextMap): BlazeServerBuilder[IO] =
+    PactStubService.createServer(
+      interactionManager,
+      connectionPoolSize,
+      sslContextName,
+      port,
+      scalaPactSettings
+    )
+
+  def start(
+      interactionManager: IInteractionManager,
+      connectionPoolSize: Int,
+      sslContextName: Option[String],
+      port: Option[Int]
+  )(implicit
+      pactReader: IPactReader,
+      pactWriter: IPactWriter,
+      sslContextMap: SslContextMap
+  ): ScalaPactSettings => IPactStubber =
+    scalaPactSettings => {
+      instance match {
+        case Some(_) =>
+          this
+
+        case None =>
+          implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
+          instance = Some(
+            PortAndShutdownTask.tupled(
+              blazeServerBuilder(
+                scalaPactSettings,
+                interactionManager,
+                connectionPoolSize,
+                sslContextName,
+                instance.map(_.port)
+              ).resource.map(_.address.getPort).allocated.unsafeRunSync()
+            )
+          )
+          this
+      }
+    }
+
+  def shutdown(): Unit = {
+    instance.foreach(_.shutdown.unsafeRunSync())
+    instance = None
+  }
+
+  def port: Option[Int] = instance.map(_.port)
+}

--- a/scalapact-http4s-0-22/src/main/scala/com/itv/scalapact/http4s22/impl/ScalaPactHttpClient.scala
+++ b/scalapact-http4s-0-22/src/main/scala/com/itv/scalapact/http4s22/impl/ScalaPactHttpClient.scala
@@ -1,0 +1,56 @@
+package com.itv.scalapact.http4s22.impl
+
+import cats.effect._
+import com.itv.scalapact.shared._
+import com.itv.scalapact.shared.http.{HttpMethod, IScalaPactHttpClient, SimpleRequest, SimpleResponse, SslContextMap}
+import org.http4s.client.Client
+
+import scala.concurrent.duration._
+
+class ScalaPactHttpClient(client: Resource[IO, Client[IO]])(
+    fetcher: (SimpleRequest, Resource[IO, Client[IO]]) => IO[SimpleResponse]
+) extends IScalaPactHttpClient {
+
+  def doRequest(simpleRequest: SimpleRequest): Either[Throwable, SimpleResponse] =
+    doRequestIO(simpleRequest).attempt.unsafeRunSync()
+
+  def doInteractionRequest(
+      url: String,
+      ir: InteractionRequest
+  ): Either[Throwable, InteractionResponse] =
+    doInteractionRequestIO(url, ir).attempt.unsafeRunSync()
+
+  def doRequestIO(simpleRequest: SimpleRequest): IO[SimpleResponse] = fetcher(simpleRequest, client)
+
+  def doInteractionRequestIO(url: String, ir: InteractionRequest): IO[InteractionResponse] = {
+    val request =
+      SimpleRequest(
+        url,
+        ir.path.getOrElse("") + ir.query.map(q => s"?$q").getOrElse(""),
+        HttpMethod.maybeMethodToMethod(ir.method),
+        ir.headers.getOrElse(Map.empty[String, String]),
+        ir.body,
+        None
+      )
+    fetcher(request, client).map { r =>
+      InteractionResponse(
+        status = Option(r.statusCode),
+        headers =
+          if (r.headers.isEmpty) None
+          else Option(r.headers.map(p => p._1 -> p._2)),
+        body = r.body,
+        matchingRules = None
+      )
+    }
+  }
+
+}
+
+object ScalaPactHttpClient {
+  def apply(clientTimeout: Duration, sslContextName: Option[String], maxTotalConnections: Int)(implicit
+      sslContextMap: SslContextMap
+  ): IScalaPactHttpClient = {
+    val client = Http4sClientHelper.buildPooledBlazeHttpClient(maxTotalConnections, clientTimeout, sslContextName)
+    new ScalaPactHttpClient(client)(Http4sClientHelper.doRequest)
+  }
+}

--- a/scalapact-http4s-0-22/src/main/scala/com/itv/scalapact/http4s22/impl/package.scala
+++ b/scalapact-http4s-0-22/src/main/scala/com/itv/scalapact/http4s22/impl/package.scala
@@ -1,0 +1,16 @@
+package com.itv.scalapact.http4s22
+
+import org.http4s.{Header, Headers}
+import org.typelevel.ci.CIString
+
+package object impl {
+  implicit class HeaderOps(headers: Headers) {
+    def toMap: Map[String, String] =
+      headers.headers.map(h => h.name.toString -> h.value).toMap
+  }
+
+  implicit class MapOps(val values: Map[String, String]) extends AnyVal {
+    def toHttp4sHeaders: Headers = Headers(values.map { case (k, v) => Header.Raw(CIString(k),v) }.toList)
+  }
+
+}

--- a/scalapact-http4s-0-22/src/main/scala/com/itv/scalapact/http4s22/package.scala
+++ b/scalapact-http4s-0-22/src/main/scala/com/itv/scalapact/http4s22/package.scala
@@ -1,0 +1,5 @@
+package com.itv.scalapact
+
+import com.itv.scalapact.http4s22.impl._
+
+package object http4s22 extends HttpInstances

--- a/scalapact-http4s-0-22/src/test/scala/com/itv/scalapact/http4s/http4s21/impl/Http4sClientHelperSpec.scala
+++ b/scalapact-http4s-0-22/src/test/scala/com/itv/scalapact/http4s/http4s21/impl/Http4sClientHelperSpec.scala
@@ -1,0 +1,49 @@
+package com.itv.scalapact.http4s.http4s21.impl
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration._
+import com.itv.scalapact.http4s22.impl.Http4sClientHelper
+import com.itv.scalapact.shared.http.{HttpMethod, SimpleRequest}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class Http4sClientHelperSpec extends AnyFunSpec with Matchers with BeforeAndAfterAll {
+
+  private val wireMockServer = new WireMockServer(wireMockConfig().port(0))
+
+  private def port(): Int = wireMockServer.port
+
+  override def beforeAll(): Unit = {
+
+    wireMockServer.start()
+
+    WireMock.configureFor("localhost", port())
+
+    val response = aResponse().withStatus(200).withBody("Success").withHeader("foo", "bar")
+
+    wireMockServer.addStubMapping(
+      get(urlEqualTo("/test")).willReturn(response).build()
+    )
+
+  }
+
+  override def afterAll(): Unit =
+    wireMockServer.stop()
+
+  describe("Making an HTTP request") {
+
+    it("should be able to make a simple request") {
+      val request  = SimpleRequest(s"http://localhost:${port()}", "/test", HttpMethod.GET, None)
+      val response = Http4sClientHelper.doRequest(request, Http4sClientHelper.defaultClient).unsafeRunSync()
+
+      response.statusCode shouldEqual 200
+      response.body.get shouldEqual "Success"
+      response.headers.exists(_ == ("foo" -> "bar")) shouldEqual true
+    }
+
+  }
+
+}

--- a/scalapact-http4s-0-22/src/test/scala/com/itv/scalapact/http4s/http4s21/impl/Http4sRequestResponseFactorySpec.scala
+++ b/scalapact-http4s-0-22/src/test/scala/com/itv/scalapact/http4s/http4s21/impl/Http4sRequestResponseFactorySpec.scala
@@ -1,0 +1,52 @@
+package com.itv.scalapact.http4s.http4s21.impl
+
+import com.itv.scalapact.http4s22.impl.{Http4sRequestResponseFactory, IntAndReason}
+import com.itv.scalapact.shared.http.{HttpMethod, SimpleRequest}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class Http4sRequestResponseFactorySpec extends AnyFunSpec with Matchers {
+
+  describe("Creating Http4s requests and responses") {
+
+    it("should be able to manufacture a good request") {
+
+      val simpleRequest = SimpleRequest(
+        "http://localhost:8080",
+        "/foo",
+        HttpMethod.POST,
+        Map(
+          "Accept"       -> "application/json",
+          "Content-Type" -> "test/plain"
+        ),
+        Some("Greetings!"),
+        None
+      )
+
+      val request = Http4sRequestResponseFactory.buildRequest(simpleRequest).unsafeRunSync()
+
+      request.method.name shouldEqual "POST"
+      request.pathInfo.renderString.contains("foo") shouldEqual true
+      request.bodyText.compile.toVector.unsafeRunSync().mkString shouldEqual "Greetings!"
+
+    }
+
+    it("should be able to manufacture a good response") {
+
+      val response = Http4sRequestResponseFactory
+        .buildResponse(
+          IntAndReason(404, Some("Not Found")),
+          Map(
+            "Content-Type" -> "test/plain"
+          ),
+          Some("Missing")
+        )
+
+      response.status.code shouldEqual 404
+      response.bodyText.compile.toVector.unsafeRunSync().mkString shouldEqual "Missing"
+
+    }
+
+  }
+
+}

--- a/scalapact-http4s-0-22/src/test/scala/com/itv/scalapact/http4s/http4s21/impl/ScalaPactHttpClientSpec.scala
+++ b/scalapact-http4s-0-22/src/test/scala/com/itv/scalapact/http4s/http4s21/impl/ScalaPactHttpClientSpec.scala
@@ -1,0 +1,44 @@
+package com.itv.scalapact.http4s.http4s21.impl
+
+import cats.effect.{IO, Resource}
+import com.itv.scalapact.http4s22.impl.ScalaPactHttpClient
+import com.itv.scalapact.shared._
+import com.itv.scalapact.shared.http.{SimpleRequest, SimpleResponse}
+import org.http4s.client.Client
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class ScalaPactHttpClientSpec extends AnyFunSpec with Matchers {
+
+  describe("Making an interaction request") {
+
+    it("should be able to make and interaction request and get an interaction response") {
+
+      val requestDetails = InteractionRequest(
+        method = Some("GET"),
+        headers = None,
+        query = None,
+        path = Some("/foo"),
+        body = None,
+        matchingRules = None
+      )
+
+      val responseDetails = InteractionResponse(
+        status = Some(200),
+        headers = None,
+        body = None,
+        matchingRules = None
+      )
+
+      val fakeCaller: (SimpleRequest, Resource[IO, Client[IO]]) => IO[SimpleResponse] =
+        (_, _) => IO.pure(SimpleResponse(200))
+
+      val result =
+        new ScalaPactHttpClient(null)(fakeCaller)
+          .doInteractionRequestIO("", requestDetails)
+          .unsafeRunSync()
+
+      result shouldEqual responseDetails
+    }
+  }
+}


### PR DESCRIPTION
http4s 0.21 and 0.22 are binary-incompatible and some of us use http4s-0.22 (i.e. because we want newest features but still CE 2).
PR is quite simple cause it just copies everything from http4s-0.21 module and fixes imports/deprecations.