### PR TITLE
Fix pact decoding by removing erroneous field.

### DIFF
--- a/scalapact-circe-0-13/src/main/scala/com/itv/scalapact/circe13/PactImplicits.scala
+++ b/scalapact-circe-0-13/src/main/scala/com/itv/scalapact/circe13/PactImplicits.scala
@@ -2,7 +2,7 @@ package com.itv.scalapact.circe13
 
 import com.itv.scalapact.shared.Notice._
 import com.itv.scalapact.shared._
-import io.circe.{Codec, Decoder, DecodingFailure, Encoder, Json, parser}
+import io.circe.{ACursor, Codec, Decoder, DecodingFailure, Encoder, HCursor, Json, parser}
 import io.circe.generic.semiauto.{deriveCodec, deriveDecoder, deriveEncoder}
 import io.circe.syntax._
 
@@ -81,19 +81,19 @@ object PactImplicits {
 
   implicit val pactMetaDataDecoder: Codec[PactMetaData] = deriveCodec
 
+  private def sanitizeLinks(cursor: HCursor): ACursor = {
+    val links: ACursor = cursor.downField("_links").downField("curies").delete
+    if (links.keys.exists(_.toList.contains("pb:consumer-versions"))) links.downField("pb:consumer-versions").delete
+    else links
+  }
+
   implicit val scalaPactDecoder: Decoder[Pact] = Decoder.instance { cur =>
     for {
       provider     <- cur.get[PactActor]("provider")
       consumer     <- cur.get[PactActor]("consumer")
       interactions <- cur.get[List[Interaction]]("interactions")
-      _links <- cur
-        .downField("_links")
-        .downField("curies")
-        .delete
-        .downField("pb:consumer-versions")
-        .delete
-        .as[Option[Links]]
-      metadata <- cur.get[Option[PactMetaData]]("metadata")
+      _links       <- sanitizeLinks(cur).as[Option[Links]]
+      metadata     <- cur.get[Option[PactMetaData]]("metadata")
     } yield Pact(provider, consumer, interactions, _links, metadata)
   }
 
@@ -115,7 +115,7 @@ object PactImplicits {
   }
 
   implicit val halIndexDecoder: Decoder[HALIndex] = Decoder.instance { cur =>
-    cur.downField("_links").downField("curies").delete.downField("pb:consumer-versions").delete.as[Links].map(HALIndex)
+    sanitizeLinks(cur).as[Links].map(HALIndex)
   }
 
   implicit val embeddedPactsForVerificationDecoder: Decoder[EmbeddedPactsForVerification] = deriveDecoder

--- a/scalapact-circe-0-13/src/test/scala/com/itv/scalapact/circe13/ScalaPactReaderWriterSpec.scala
+++ b/scalapact-circe-0-13/src/test/scala/com/itv/scalapact/circe13/ScalaPactReaderWriterSpec.scala
@@ -115,6 +115,137 @@ class ScalaPactReaderWriterSpec extends AnyFunSpec with Matchers with OptionValu
       pactEither.toOption.value shouldEqual PactFileExamples.simpleWithLinksAndMetaData
     }
 
+    it("should remove curies and pb:consumer-versions from parsed _links") {
+      val simpleWithCuriesAndPbConsumerVersionsAsString: String =
+        """{
+          |  "provider" : {
+          |    "name" : "provider"
+          |  },
+          |  "consumer" : {
+          |    "name" : "consumer"
+          |  },
+          |  "interactions" : [
+          |    {
+          |      "request" : {
+          |        "method" : "GET",
+          |        "body" : "fish",
+          |        "path" : "/fetch-json",
+          |        "matchingRules" : {
+          |          "$.headers.Accept" : {
+          |            "match" : "regex",
+          |            "regex" : "\\w+"
+          |          },
+          |          "$.headers.Content-Length" : {
+          |            "match" : "type"
+          |          }
+          |        },
+          |        "query" : "fish=chips",
+          |        "headers" : {
+          |          "Content-Type" : "text/plain"
+          |        }
+          |      },
+          |      "description" : "a simple request",
+          |      "response" : {
+          |        "status" : 200,
+          |        "headers" : {
+          |          "Content-Type" : "application/json"
+          |        },
+          |        "body" : {
+          |          "fish" : [
+          |            "cod",
+          |            "haddock",
+          |            "flying"
+          |          ]
+          |        },
+          |        "matchingRules" : {
+          |          "$.headers.Accept" : {
+          |            "match" : "regex",
+          |            "regex" : "\\w+"
+          |          },
+          |          "$.headers.Content-Length" : {
+          |            "match" : "type"
+          |          }
+          |        }
+          |      },
+          |      "providerState" : "a simple state"
+          |    },
+          |    {
+          |      "request" : {
+          |        "method" : "GET",
+          |        "body" : "fish",
+          |        "path" : "/fetch-json2",
+          |        "headers" : {
+          |          "Content-Type" : "text/plain"
+          |        }
+          |      },
+          |      "description" : "a simple request 2",
+          |      "response" : {
+          |        "status" : 200,
+          |        "headers" : {
+          |          "Content-Type" : "application/json"
+          |        },
+          |        "body" : {
+          |          "chips" : true,
+          |          "fish" : [
+          |            "cod",
+          |            "haddock"
+          |          ]
+          |        }
+          |      },
+          |      "providerState" : "a simple state 2"
+          |    }
+          |  ],
+          |  "_links": {
+          |    "self": {
+          |      "title": "Pact",
+          |      "name": "Pact between consumer (v1.0.0) and provider",
+          |      "href": "http://localhost/pacts/provider/provider/consumer/consumer/version/1.0.0"
+          |    },
+          |    "pb:consumer": {
+          |      "title": "Consumer",
+          |      "name": "consumer",
+          |      "href": "http://localhost/pacticipants/consumer"
+          |    },
+          |    "pb:provider": {
+          |      "title": "Provider",
+          |      "name": "provider",
+          |      "href": "http://localhost/pacticipants/provider"
+          |    },
+          |    "pb:latest-tagged-pact-version": {
+          |      "title": "Latest tagged version of this pact",
+          |      "href": "http://localhost/pacts/provider/provider-service/consumer/consumer-service/latest/{tag}",
+          |      "templated": true
+          |    },
+          |    "pb:consumer-versions": [
+          |      {
+          |        "title": "Consumer version",
+          |        "name": "1.2.3",
+          |        "href": "http://localhost/pacticipants/consumer/versions/1.2.3"
+          |      }
+          |    ],
+          |    "curies": [
+          |      {
+          |        "name": "pb",
+          |        "href": "http://localhost/doc/{rel}",
+          |        "templated": true
+          |      }
+          |    ]
+          |  },
+          |  "metadata": {
+          |    "pactSpecification": {
+          |      "version": "2.0.0"
+          |    },
+          |    "scala-pact": {
+          |      "version": "1.0.0"
+          |    }
+          |  }
+          |}""".stripMargin
+
+      val pactEither = pactReader.jsonStringToScalaPact(simpleWithCuriesAndPbConsumerVersionsAsString)
+
+      pactEither.toOption.value shouldEqual PactFileExamples.simpleWithLinksAndMetaData
+    }
+
     it("should be able to write Pact files and add metadata when missing") {
 
       val written = pactWriter.pactToJsonString(PactFileExamples.simple, scalaPactVersion)

--- a/scalapact-circe-0-14/src/test/scala/com/itv/scalapact/circe14/ScalaPactReaderWriterSpec.scala
+++ b/scalapact-circe-0-14/src/test/scala/com/itv/scalapact/circe14/ScalaPactReaderWriterSpec.scala
@@ -115,6 +115,137 @@ class ScalaPactReaderWriterSpec extends AnyFunSpec with Matchers with OptionValu
       pactEither.toOption.value shouldEqual PactFileExamples.simpleWithLinksAndMetaData
     }
 
+    it("should remove curies and pb:consumer-versions from parsed _links") {
+      val simpleWithCuriesAndPbConsumerVersionsAsString: String =
+        """{
+          |  "provider" : {
+          |    "name" : "provider"
+          |  },
+          |  "consumer" : {
+          |    "name" : "consumer"
+          |  },
+          |  "interactions" : [
+          |    {
+          |      "request" : {
+          |        "method" : "GET",
+          |        "body" : "fish",
+          |        "path" : "/fetch-json",
+          |        "matchingRules" : {
+          |          "$.headers.Accept" : {
+          |            "match" : "regex",
+          |            "regex" : "\\w+"
+          |          },
+          |          "$.headers.Content-Length" : {
+          |            "match" : "type"
+          |          }
+          |        },
+          |        "query" : "fish=chips",
+          |        "headers" : {
+          |          "Content-Type" : "text/plain"
+          |        }
+          |      },
+          |      "description" : "a simple request",
+          |      "response" : {
+          |        "status" : 200,
+          |        "headers" : {
+          |          "Content-Type" : "application/json"
+          |        },
+          |        "body" : {
+          |          "fish" : [
+          |            "cod",
+          |            "haddock",
+          |            "flying"
+          |          ]
+          |        },
+          |        "matchingRules" : {
+          |          "$.headers.Accept" : {
+          |            "match" : "regex",
+          |            "regex" : "\\w+"
+          |          },
+          |          "$.headers.Content-Length" : {
+          |            "match" : "type"
+          |          }
+          |        }
+          |      },
+          |      "providerState" : "a simple state"
+          |    },
+          |    {
+          |      "request" : {
+          |        "method" : "GET",
+          |        "body" : "fish",
+          |        "path" : "/fetch-json2",
+          |        "headers" : {
+          |          "Content-Type" : "text/plain"
+          |        }
+          |      },
+          |      "description" : "a simple request 2",
+          |      "response" : {
+          |        "status" : 200,
+          |        "headers" : {
+          |          "Content-Type" : "application/json"
+          |        },
+          |        "body" : {
+          |          "chips" : true,
+          |          "fish" : [
+          |            "cod",
+          |            "haddock"
+          |          ]
+          |        }
+          |      },
+          |      "providerState" : "a simple state 2"
+          |    }
+          |  ],
+          |  "_links": {
+          |    "self": {
+          |      "title": "Pact",
+          |      "name": "Pact between consumer (v1.0.0) and provider",
+          |      "href": "http://localhost/pacts/provider/provider/consumer/consumer/version/1.0.0"
+          |    },
+          |    "pb:consumer": {
+          |      "title": "Consumer",
+          |      "name": "consumer",
+          |      "href": "http://localhost/pacticipants/consumer"
+          |    },
+          |    "pb:provider": {
+          |      "title": "Provider",
+          |      "name": "provider",
+          |      "href": "http://localhost/pacticipants/provider"
+          |    },
+          |    "pb:latest-tagged-pact-version": {
+          |      "title": "Latest tagged version of this pact",
+          |      "href": "http://localhost/pacts/provider/provider-service/consumer/consumer-service/latest/{tag}",
+          |      "templated": true
+          |    },
+          |    "pb:consumer-versions": [
+          |      {
+          |        "title": "Consumer version",
+          |        "name": "1.2.3",
+          |        "href": "http://localhost/pacticipants/consumer/versions/1.2.3"
+          |      }
+          |    ],
+          |    "curies": [
+          |      {
+          |        "name": "pb",
+          |        "href": "http://localhost/doc/{rel}",
+          |        "templated": true
+          |      }
+          |    ]
+          |  },
+          |  "metadata": {
+          |    "pactSpecification": {
+          |      "version": "2.0.0"
+          |    },
+          |    "scala-pact": {
+          |      "version": "1.0.0"
+          |    }
+          |  }
+          |}""".stripMargin
+
+      val pactEither = pactReader.jsonStringToScalaPact(simpleWithCuriesAndPbConsumerVersionsAsString)
+
+      pactEither.toOption.value shouldEqual PactFileExamples.simpleWithLinksAndMetaData
+    }
+
     it("should be able to write Pact files and add metadata when missing") {
 
       val written = pactWriter.pactToJsonString(PactFileExamples.simple, scalaPactVersion)


### PR DESCRIPTION
- Updated `scalaPactDecoder` and `halIndexDecoder` to delete the `pb:consumer-versions` field from the `_links` object when decoding a pact JSON.
- This array-type field has only recently been added to the broker and causes decoding errors due to it being an array and thus not an expected value in the `Links` type.
- A better solution would be to update the `Links` type to properly support array-type links, but i unfortunately do not have the time to fix this at present. This is however a critical blocker for ours (and others') pact verification pipelines so is critical to resolve quickly even if a better solution follows later.
- This is a rough and ready solution for #231 
- More info can be found in this thread on the Pact foundation Slack channel: https://pact-foundation.slack.com/archives/CLS16AVEE/p1635324284042200