### PR TITLE
feat: 🚀 Ability to choose the host and port on which mock server runs

### DIFF
--- a/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactMock.scala
+++ b/scalapact-scalatest/src/main/scala/com/itv/scalapact/ScalaPactMock.scala
@@ -33,12 +33,13 @@ private[scalapact] object ScalaPactMock {
     val interactionManager: InteractionManager = new InteractionManager
 
     val protocol   = pactDescription.serverSslContextName.fold("http")(_ => "https")
-    val host       = "localhost"
+    val host       = pactDescription.options.host
+    val serverPort = pactDescription.options.port
     val outputPath = pactDescription.options.outputPath
     val scalaPactSettings = ScalaPactSettings(
       protocol = Option(protocol),
       host = Option(host),
-      port = Option(0), // `0` means "use any available port".
+      port = Option(serverPort),
       localPactFilePath = None,
       strictMode = Option(strict),
       clientTimeout = None,

--- a/scalapact-scalatest/src/main/scala/com/itv/scalapact/model/ScalaPactOptions.scala
+++ b/scalapact-scalatest/src/main/scala/com/itv/scalapact/model/ScalaPactOptions.scala
@@ -2,9 +2,19 @@ package com.itv.scalapact.model
 
 import scala.util.Properties
 
-final case class ScalaPactOptions(writePactFiles: Boolean, outputPath: String)
+final case class ScalaPactOptions(writePactFiles: Boolean, outputPath: String, host: String, port: Int)
 
 object ScalaPactOptions {
+
   val DefaultOptions: ScalaPactOptions =
-    ScalaPactOptions(writePactFiles = true, outputPath = Properties.envOrElse("pact.rootDir", "target/pacts"))
+    ScalaPactOptions(
+      writePactFiles = true,
+      outputPath = Properties.envOrElse("pact.rootDir", "target/pacts"),
+      host = "localhost",
+      port = 0 // `0` means "use any available port".
+    )
+
+  def apply(writePactFiles: Boolean, outputPath: String): ScalaPactOptions =
+    ScalaPactOptions(writePactFiles, outputPath, DefaultOptions.host, DefaultOptions.port)
+
 }


### PR DESCRIPTION
Aims to solve #232 

I didn't use default values inside the case class definition as I saw a separate `val DefaultOptions` in the companion object. Though I'm not sure why it was done like this in the first place.